### PR TITLE
fix(deploy): failed to start manager_api

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -46,4 +46,4 @@ COPY --from=build-env /root/manager-api/* /root/manager-api/
 COPY --from=build-env /usr/share/zoneinfo/Hongkong /etc/localtime
 EXPOSE 8080
 RUN chmod +x ./build.sh
-CMD ["/root/manager-api/build.sh"]
+CMD ["/bin/ash", "-c", "/root/manager-api/build.sh"]


### PR DESCRIPTION
Fixes #361 .

This PR is going to use ash, which is the default shell environment in alpine v3.11, to execute the `build.sh`.

Signed-off-by: imjoey <majunjiev@gmail.com>