### PR TITLE
fix(ci): fix read configuration file path in docker

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -24,7 +24,7 @@ RUN mkdir /root/manager-api \
     && export GOPROXY=https://goproxy.io \
     && go build -o /root/manager-api/manager-api \
     && mv /go/src/github.com/apisix/manager-api/build.sh /root/manager-api/ \
-    && mv /go/src/github.com/apisix/manager-api/conf/conf_preview.json /root/manager-api/ \
+    && mv /go/src/github.com/apisix/manager-api/conf/conf_preview.json /root/manager-api/conf.json \
     && rm -rf /go/src/github.com/apisix/manager-api \
     && rm -rf /etc/localtime \
     && ln -s  /usr/share/zoneinfo/Hongkong /etc/localtime \

--- a/api/build.sh
+++ b/api/build.sh
@@ -1,21 +1,22 @@
 #!/bin/sh
 #	
 # Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with	
-# this work for additional information regarding copyright ownership.	
-# The ASF licenses this file to You under the Apache License, Version 2.0	
-# (the "License"); you may not use this file except in compliance with	
-# the License.  You may obtain a copy of the License at	
-#	
-#     http://www.apache.org/licenses/LICENSE-2.0	
-#	
-# Unless required by applicable law or agreed to in writing, software	
-# distributed under the License is distributed on an "AS IS" BASIS,	
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.	
-# See the License for the specific language governing permissions and	
-# limitations under the License.	
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
+export ENV=prod
 pwd=`pwd`
 
 sed -i -e "s%#mysqlAddress#%`echo $MYSQL_SERVER_ADDRESS`%g" ${pwd}/conf.json


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bugfix
- Description
Because of the wrong environment variable, the Manager API cannot set the correct configuration file path when running in docker.
- How to fix?
Add an export in `build.sh` script.
Change moved file name in Dockerfile.
___
### New feature or improvement
- Describe the details and related test reports.
