### PR TITLE
fix: dashboard /user/login get error code 405

### DIFF
--- a/compose/dashboard_conf/nginx.conf
+++ b/compose/dashboard_conf/nginx.conf
@@ -16,7 +16,8 @@ server {
     }
 
     location /apisix/admin {
-        proxy_pass http://manager:8080/apisix/admin;
+        proxy_pass http://192.17.5.15:8080/apisix/admin;
     }
+    error_page  405  =200 $uri;
 }
 

--- a/compose/dashboard_conf/nginx.conf
+++ b/compose/dashboard_conf/nginx.conf
@@ -15,9 +15,15 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
-    location /apisix/admin {
-        proxy_pass http://192.17.5.15:8080/apisix/admin;
+    location /user/login {
+        if ( $request_method = 'POST' ) { #HERE
+            proxy_pass http://manager:8080;
+        }
+        try_files $uri $uri/ /index.html;
     }
-    error_page  405  =200 $uri;
+    
+    location /apisix/admin {
+        proxy_pass http://manager:8080/apisix/admin;
+    }
 }
 


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues
#396 
___
### Bugfix
- Description

- How to fix?

1. according to https://gist.github.com/zxhfighter/7560812  add `error_page  405  =200 $uri;`

1. in dashboard docker container, there is no hosts config about 'manage', so change

```
location /apisix/admin {
        proxy_pass http://manage:8080/apisix/admin;
    }
```
to
```
location /apisix/admin {
        proxy_pass http://192.17.5.15:8080/apisix/admin;
    }
```

___
### New feature or improvement
- Describe the details and related test reports.
