### PR TITLE
fix: APISIX using default admin key in docker compose

### DIFF
--- a/compose/apisix_conf/config.yaml
+++ b/compose/apisix_conf/config.yaml
@@ -24,7 +24,7 @@ apisix:
   admin_key:
     -
       name: "admin"
-      key: edd1c9f034335f136f87ad84b625c8f2
+      key: edd1c9f034335f136f87ad84b625c8f1
       role: admin                 # admin: manage all configuration data
                                   # viewer: only can view configuration data
     -


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bugfix
- Description

- How to fix?
fix typo

___
### New feature or improvement
- Describe the details and related test reports.
