### PR TITLE
fix: create route [websocket] param consistent with user behavior.

### DIFF
--- a/api/service/route.go
+++ b/api/service/route.go
@@ -35,7 +35,6 @@ const (
 	HTTP             = "http"
 	HTTPS            = "https"
 	SCHEME           = "scheme"
-	WEBSOCKET        = "websocket"
 	REDIRECT         = "redirect"
 	PROXY_REWRIETE   = "proxy-rewrite"
 	UPATHTYPE_STATIC = "static"
@@ -187,12 +186,6 @@ func (r *ApisixRouteResponse) Parse() (*RouteRequest, error) {
 
 	//Protocols from vars and upstream
 	protocols := make([]string, 0)
-	if o.Upstream != nil && o.Upstream.EnableWebsocket {
-		protocols = append(protocols, WEBSOCKET)
-	}
-	if o.UpstreamId != "" {
-		protocols = append(protocols, WEBSOCKET)
-	}
 	flag := true
 	for _, t := range o.Vars {
 		if t[0] == SCHEME {
@@ -479,10 +472,6 @@ func ToApisixRequest(routeRequest *RouteRequest) *ApisixRouteRequest {
 	arr := &ApisixRouteRequest{}
 	arr.Parse(routeRequest)
 
-	// protocols[websokect] -> upstream
-	if pMap[WEBSOCKET] == 1 && arr.Upstream != nil {
-		arr.Upstream.EnableWebsocket = true
-	}
 	vars := utils.CopyStrings(routeRequest.Vars)
 	if pMap[HTTP] != 1 || pMap[HTTPS] != 1 {
 		if pMap[HTTP] == 1 {

--- a/api/service/route_test.go
+++ b/api/service/route_test.go
@@ -51,7 +51,7 @@ func TestToApisixRequest_RediretPlugins(t *testing.T) {
 		Methods:   []string{"GET"},
 		Uris:      []string{},
 		Hosts:     []string{"www.baidu.com"},
-		Protocols: []string{"http", "https", "websocket"},
+		Protocols: []string{"http", "https"},
 		Redirect:  &Redirect{HttpToHttps: true, Code: 200, Uri: "/hello"},
 		Vars:      [][]string{},
 	}
@@ -79,7 +79,7 @@ func TestToApisixRequest_proxyRewrite(t *testing.T) {
 		Methods:      []string{"GET"},
 		Uris:         []string{},
 		Hosts:        []string{"www.baidu.com"},
-		Protocols:    []string{"http", "https", "websocket"},
+		Protocols:    []string{"http", "https"},
 		Redirect:     &Redirect{HttpToHttps: true, Code: 200, Uri: "/hello"},
 		Vars:         [][]string{},
 		Upstream:     upstream,
@@ -105,7 +105,7 @@ func TestToApisixRequest_Vars(t *testing.T) {
 		Methods:   []string{"GET"},
 		Uris:      []string{},
 		Hosts:     []string{"www.baidu.com"},
-		Protocols: []string{"http", "https", "websocket"},
+		Protocols: []string{"http", "https"},
 		Redirect:  &Redirect{HttpToHttps: true, Code: 200, Uri: "/hello"},
 		Vars:      [][]string{},
 	}
@@ -125,9 +125,10 @@ func TestToApisixRequest_Upstream(t *testing.T) {
 	nodes := make(map[string]int64)
 	nodes["127.0.0.1:8080"] = 100
 	upstream := &Upstream{
-		UType:   "roundrobin",
-		Nodes:   nodes,
-		Timeout: UpstreamTimeout{15, 15, 15},
+		UType:           "roundrobin",
+		Nodes:           nodes,
+		Timeout:         UpstreamTimeout{15, 15, 15},
+		EnableWebsocket: true,
 	}
 	rr := &RouteRequest{
 		ID:        "u guess a uuid",
@@ -137,7 +138,7 @@ func TestToApisixRequest_Upstream(t *testing.T) {
 		Methods:   []string{"GET"},
 		Uris:      []string{},
 		Hosts:     []string{"www.baidu.com"},
-		Protocols: []string{"http", "https", "websocket"},
+		Protocols: []string{"http", "https"},
 		Redirect:  &Redirect{HttpToHttps: true, Code: 200, Uri: "/hello"},
 		Vars:      [][]string{},
 		Upstream:  upstream,

--- a/src/pages/Route/components/Step1/RequestConfigView.tsx
+++ b/src/pages/Route/components/Step1/RequestConfigView.tsx
@@ -16,7 +16,7 @@
  */
 import React from 'react';
 import Form from 'antd/es/form';
-import { Checkbox, Button, Input, Switch, Select, Row, Col } from 'antd';
+import { Checkbox, Button, Input, Select, Row, Col } from 'antd';
 import { PlusOutlined, MinusCircleOutlined } from '@ant-design/icons';
 import { CheckboxValueType } from 'antd/lib/checkbox/Group';
 import { useIntl } from 'umi';
@@ -195,9 +195,6 @@ const RequestConfigView: React.FC<Props> = ({ data, disabled, onChange }) => {
           value={protocols}
           onChange={onProtocolChange}
         />
-      </Form.Item>
-      <Form.Item label="WebSocket" name="websocket" valuePropName="checked">
-        <Switch disabled={disabled} />
       </Form.Item>
       {/* <Form.Item
         label="优先级"

--- a/src/pages/Route/components/Step2/RequestRewriteView.tsx
+++ b/src/pages/Route/components/Step2/RequestRewriteView.tsx
@@ -17,7 +17,7 @@
 import React, { useEffect, useState } from 'react';
 import Form, { FormInstance } from 'antd/es/form';
 import Radio from 'antd/lib/radio';
-import { Input, Row, Col, InputNumber, Button, Select } from 'antd';
+import { Input, Row, Col, InputNumber, Button, Select, Switch } from 'antd';
 import { PlusOutlined, MinusCircleOutlined } from '@ant-design/icons';
 import { useIntl } from 'umi';
 
@@ -304,6 +304,9 @@ const RequestRewriteView: React.FC<Props> = ({ data, form, disabled, onChange })
           </Select>
         </Form.Item>
         {renderUpstreamMeta()}
+        <Form.Item label="WebSocket" name="enable_websocket" valuePropName="checked">
+          <Switch disabled={upstreamDisabled} />
+        </Form.Item>
         <Form.Item
           label={formatMessage({ id: 'route.request.override.connection.timeout' })}
           required

--- a/src/pages/Route/service.ts
+++ b/src/pages/Route/service.ts
@@ -65,11 +65,12 @@ export const checkUniqueName = (name = '', exclude = '') =>
 export const fetchUpstreamList = () => request(`/names/upstreams`);
 
 export const fetchUpstreamItem = (sid: string) => {
-  return request(`/upstreams/${sid}`).then(({ nodes, timeout, id }) => {
+  return request(`/upstreams/${sid}`).then(({ nodes, timeout, id, enable_websocket }) => {
     return {
       upstreamHostList: transformUpstreamNodes(nodes),
       timeout,
       upstream_id: id,
+      enable_websocket,
     };
   });
 };

--- a/src/pages/Route/transform.ts
+++ b/src/pages/Route/transform.ts
@@ -48,10 +48,7 @@ export const transformStepData = ({
     };
   }
 
-  let { protocols } = step1Data;
-  if (step1Data.websocket) {
-    protocols = protocols.concat('websocket');
-  }
+  const { protocols } = step1Data;
 
   const data: Partial<RouteModule.Body> = {
     ...step1Data,
@@ -80,6 +77,7 @@ export const transformStepData = ({
       ...chashData,
       nodes,
       timeout: step2Data.timeout,
+      enable_websocket: step2Data.enable_websocket,
     },
     upstream_header,
   };
@@ -118,6 +116,7 @@ export const transformStepData = ({
       'redirectCode',
       'forceHttps',
       'redirectOption',
+      'enable_websocket',
       step1Data.redirectOption === 'disabled' ? 'redirect' : '',
       step2Data.upstream_id ? 'upstream' : 'upstream_id',
     ]);
@@ -161,7 +160,6 @@ export const transformRouteData = (data: RouteModule.Body) => {
     name,
     desc,
     protocols: protocols.filter((item) => item !== 'websocket'),
-    websocket: protocols.includes('websocket'),
     hosts,
     paths: uris,
     methods,
@@ -219,6 +217,7 @@ export const transformRouteData = (data: RouteModule.Body) => {
       send: 6000,
       read: 6000,
     },
+    enable_websocket: upstream?.enable_websocket || false,
   };
 
   const { plugins, script } = data;

--- a/src/pages/Route/typing.d.ts
+++ b/src/pages/Route/typing.d.ts
@@ -100,6 +100,7 @@ declare namespace RouteModule {
       send: number;
       read: number;
     };
+    enable_websocket: boolean;
   };
 
   type ModalType = 'CREATE' | 'EDIT';
@@ -134,6 +135,7 @@ declare namespace RouteModule {
         send: number;
         read: number;
       };
+      enable_websocket: boolean;
     };
     upstream_path?: {
       type?: string;

--- a/src/pages/Upstream/components/Step1.tsx
+++ b/src/pages/Upstream/components/Step1.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 import React from 'react';
-import { Form, Input, Row, Col, InputNumber, Select } from 'antd';
+import { Form, Input, Row, Col, InputNumber, Select, Switch } from 'antd';
 import { FormInstance } from 'antd/lib/form';
 import { useIntl } from 'umi';
 
@@ -38,6 +38,7 @@ const initialValues = {
   description: '',
   type: 'roundrobin',
   upstreamHostList: [{} as UpstreamModule.UpstreamHost],
+  enable_websocket: false,
   timeout: {
     connect: 6000,
     send: 6000,
@@ -228,6 +229,9 @@ const Step1: React.FC<Props> = ({ form, disabled }) => {
           }
           return null;
         }}
+      </Form.Item>
+      <Form.Item label="WebSocket" name="enable_websocket" valuePropName="checked">
+        <Switch disabled={disabled} />
       </Form.Item>
       {renderUpstreamMeta()}
       <Form.Item label={formatMessage({ id: 'upstream.step.connect.timeout' })} required>

--- a/src/pages/Upstream/typing.d.ts
+++ b/src/pages/Upstream/typing.d.ts
@@ -30,6 +30,7 @@ declare namespace UpstreamModule {
     };
     type: 'roundrobin' | 'chash';
     description: string;
+    enable_websocket: boolean;
   };
 
   type Entity = Base & {


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues
fix issue: #417 
___
### Bugfix
- Description

- How to fix?

The modification of the front end consists of two aspects：
1. add enable_websocket to upstream module，so that user can control with manage upstream.

1. in route module, websocket also changes with its upstream, if use a upstream already exited, websocket is disabled, the value is the same with its upstream enable_websocket value; if use a manually upstream, websocket can be edit, and it will pass in upstream object.


* UI changed like this
  *  create/edit upstream
![2020-08-29 16-22-25屏幕截图](https://user-images.githubusercontent.com/2561857/91632530-fee63780-ea13-11ea-8cfc-88d52bc7cd82.png)
![2020-08-29 16-24-08屏幕截图](https://user-images.githubusercontent.com/2561857/91632554-19b8ac00-ea14-11ea-9eb0-89121fc2f2a1.png)
  * create/edit route with upstream already exited
![2020-08-29 16-25-55屏幕截图](https://user-images.githubusercontent.com/2561857/91632589-61d7ce80-ea14-11ea-8472-0c5ecf326235.png)
  * create/edit route with manually upstream
![2020-08-29 16-40-47屏幕截图](https://user-images.githubusercontent.com/2561857/91632865-6ef5bd00-ea16-11ea-8d73-bf7f29913836.png)



### New feature or improvement
- Describe the details and related test reports.

the modify idea come from :

1. https://github.com/apache/apisix/blob/master/doc/admin-api.md#upstream
enable_websocket come from upstream, so UI should enable to modify this key;

1. the manage-api now has some logic that could not be understood, like
https://github.com/apache/apisix-dashboard/blob/master/api/service/route.go#L480
https://github.com/apache/apisix-dashboard/blob/master/api/service/route.go#L193

1. this update is only modifiy the logic in frontend, even if not change the manage-api, It can still work fine
