### PR TITLE
feat: add publish status to route in manager api

### DIFF
--- a/api/errno/error.go
+++ b/api/errno/error.go
@@ -58,6 +58,7 @@ var (
 	DBRouteDeleteError      = Message{"010207", "Route deletion failed: %s", 500}
 	DBRouteReduplicateError = Message{"010208", "Route name is reduplicate : %s", 400}
 	SetRouteUngroupError    = Message{"010209", "Set route ungroup err", 500}
+	RoutePublishError       = Message{"010209", "Route publish error", 400}
 
 	// 03 plugins
 	ApisixPluginListError   = Message{"010301", "find APISIX plugin list failed: %s", 500}

--- a/api/route/route.go
+++ b/api/route/route.go
@@ -34,9 +34,98 @@ func AppendRoute(r *gin.Engine) *gin.Engine {
 	r.GET("/apisix/admin/routes/:rid", findRoute)
 	r.GET("/apisix/admin/routes", listRoute)
 	r.PUT("/apisix/admin/routes/:rid", updateRoute)
+	r.PUT("/apisix/admin/publishroutes/:rid", publishRoute)
 	r.DELETE("/apisix/admin/routes/:rid", deleteRoute)
 	r.GET("/apisix/admin/notexist/routes", isRouteExist)
+	r.PUT("/apisix/admin/offlineroutes/:rid", offlineRoute)
 	return r
+}
+
+func publishRoute(c *gin.Context) {
+	rid := c.Param("rid")
+	r := &service.Route{}
+	tx := conf.DB().Begin()
+	if err := tx.Model(&service.Route{}).Where("id = ?", rid).Update("status", true).Find(&r).Error; err != nil {
+		tx.Rollback()
+		e := errno.FromMessage(errno.RoutePublishError, err.Error())
+		logger.Error(e.Msg)
+		c.AbortWithStatusJSON(http.StatusInternalServerError, e.Response())
+		return
+	} else {
+		routeRequest := &service.RouteRequest{}
+		if err := json.Unmarshal([]byte(r.Content), routeRequest); err != nil {
+			tx.Rollback()
+			e := errno.FromMessage(errno.RoutePublishError, err.Error())
+			logger.Error(e.Msg)
+			c.AbortWithStatusJSON(http.StatusInternalServerError, e.Response())
+			return
+		}
+		arr := service.ToApisixRequest(routeRequest)
+		var resp *service.ApisixRouteResponse
+		if resp, err = arr.Create(rid); err != nil {
+			tx.Rollback()
+			if httpError, ok := err.(*errno.HttpError); ok {
+				c.AbortWithStatusJSON(httpError.Code, httpError.Msg)
+				return
+			} else {
+				e := errno.FromMessage(errno.ApisixRouteCreateError, err.Error())
+				logger.Error(e.Msg)
+				c.AbortWithStatusJSON(http.StatusInternalServerError, e.Response())
+				return
+			}
+		} else {
+			resp.Node.Value.Name = r.Name
+			resp.Node.Value.Status = r.Status
+			if respStr, err := json.Marshal(resp); err != nil {
+				e := errno.FromMessage(errno.RoutePublishError, err.Error())
+				logger.Error(e.Msg)
+				c.AbortWithStatusJSON(http.StatusInternalServerError, e.Response())
+				return
+			} else {
+				r.ContentAdminApi = string(respStr)
+			}
+		}
+		if err := tx.Commit().Error; err == nil {
+			// update content_admin_api
+			if err := conf.DB().Model(&service.Route{}).Update(r).Error; err != nil {
+				e := errno.FromMessage(errno.DBRouteUpdateError, err.Error())
+				logger.Error(e.Msg)
+			}
+		}
+	}
+	c.Data(http.StatusOK, service.ContentType, errno.Success())
+}
+
+func offlineRoute(c *gin.Context) {
+	rid := c.Param("rid")
+	db := conf.DB()
+	tx := db.Begin()
+	if err := tx.Model(&service.Route{}).Where("id = ?", rid).Update(map[string]interface{}{"status": 0, "content_admin_api": ""}).Error; err != nil {
+		tx.Rollback()
+		e := errno.FromMessage(errno.RoutePublishError, err.Error())
+		logger.Error(e.Msg)
+		c.AbortWithStatusJSON(http.StatusInternalServerError, e.Response())
+		return
+	} else {
+		request := &service.ApisixRouteRequest{}
+		if _, err := request.Delete(rid); err != nil {
+			tx.Rollback()
+			if httpError, ok := err.(*errno.HttpError); ok {
+				c.AbortWithStatusJSON(httpError.Code, httpError.Msg)
+				return
+			} else {
+				e := errno.FromMessage(errno.ApisixRouteDeleteError, err.Error())
+				logger.Error(e.Msg)
+				c.AbortWithStatusJSON(http.StatusInternalServerError, e.Response())
+				return
+			}
+		}
+	}
+	if err := tx.Commit().Error; err != nil {
+		e := errno.FromMessage(errno.ApisixRouteDeleteError, err.Error())
+		logger.Error(e.Msg)
+	}
+	c.Data(http.StatusOK, service.ContentType, errno.Success())
 }
 
 func isRouteExist(c *gin.Context) {
@@ -156,13 +245,19 @@ func deleteRoute(c *gin.Context) {
 	// delete from mysql
 	rd := &service.Route{}
 	rd.ID = uuid.FromStringOrNil(rid)
+	if err := db.Table("routes").Where("id=?", rid).First(&rd).Error; err != nil {
+		e := errno.FromMessage(errno.RouteRequestError, err.Error()+" route ID: "+rid)
+		logger.Error(e.Msg)
+		c.AbortWithStatusJSON(http.StatusInternalServerError, e.Response())
+		return
+	}
 	if err := conf.DB().Delete(rd).Error; err != nil {
 		tx.Rollback()
 		e := errno.FromMessage(errno.DBRouteDeleteError, err.Error())
 		logger.Error(e.Msg)
 		c.AbortWithStatusJSON(http.StatusInternalServerError, e.Response())
 		return
-	} else {
+	} else if rd.Status {
 		request := &service.ApisixRouteRequest{}
 		if _, err := request.Delete(rid); err != nil {
 			tx.Rollback()
@@ -217,10 +312,12 @@ func updateRoute(c *gin.Context) {
 	db := conf.DB()
 	arr := service.ToApisixRequest(routeRequest)
 	var resp *service.ApisixRouteResponse
+	var r *service.Route
 	if rd, err := service.ToRoute(routeRequest, arr, uuid.FromStringOrNil(rid), nil); err != nil {
 		c.AbortWithStatusJSON(http.StatusInternalServerError, err.Response())
 		return
 	} else {
+		r = rd
 		tx := db.Begin()
 		defer func() {
 			if r := recover(); r != nil {
@@ -244,7 +341,7 @@ func updateRoute(c *gin.Context) {
 			logger.Error(e.Msg)
 			c.AbortWithStatusJSON(http.StatusInternalServerError, e.Response())
 			return
-		} else {
+		} else if rd.Status {
 			if resp, err = arr.Update(rid); err != nil {
 				tx.Rollback()
 				if httpError, ok := err.(*errno.HttpError); ok {
@@ -267,7 +364,7 @@ func updateRoute(c *gin.Context) {
 				return
 			}
 		}
-		if err := tx.Commit().Error; err == nil {
+		if err := tx.Commit().Error; err == nil && r.Status {
 			// update content_admin_api
 			if rd, err := service.ToRoute(routeRequest, arr, uuid.FromStringOrNil(rid), resp); err != nil {
 				e := errno.FromMessage(errno.DBRouteUpdateError, err.Error())
@@ -285,8 +382,9 @@ func updateRoute(c *gin.Context) {
 
 func findRoute(c *gin.Context) {
 	rid := c.Param("rid")
+	route := &service.Route{}
 	var count int
-	if err := conf.DB().Table("routes").Where("id=?", rid).Count(&count).Error; err != nil {
+	if err := conf.DB().Table("routes").Where("id=?", rid).Count(&count).First(&route).Error; err != nil {
 		e := errno.FromMessage(errno.RouteRequestError, err.Error()+" route ID: "+rid)
 		logger.Error(e.Msg)
 		c.AbortWithStatusJSON(http.StatusInternalServerError, e.Response())
@@ -299,40 +397,48 @@ func findRoute(c *gin.Context) {
 			return
 		}
 	}
-	// find from apisix
-	request := &service.ApisixRouteRequest{}
-	if response, err := request.FindById(rid); err != nil {
-		e := errno.FromMessage(errno.RouteRequestError, err.Error()+" route ID: "+rid)
-		logger.Error(e.Msg)
-		c.AbortWithStatusJSON(http.StatusBadRequest, e.Response())
-		return
+	if !route.Status {
+		routeRequest := &service.RouteRequest{}
+		if err := json.Unmarshal([]byte(route.Content), &routeRequest); err != nil {
+			e := errno.FromMessage(errno.RouteRequestError, " route ID: "+rid+" not exist")
+			logger.Error(e.Msg)
+			c.AbortWithStatusJSON(e.Status, e.Response())
+			return
+		} else {
+			routeRequest.Name = route.Name
+			resp, _ := json.Marshal(routeRequest)
+			c.Data(http.StatusOK, service.ContentType, resp)
+		}
 	} else {
-		// transfer response to dashboard struct
-		if result, err := response.Parse(); err != nil {
+		// find from apisix
+		request := &service.ApisixRouteRequest{}
+		if response, err := request.FindById(rid); err != nil {
 			e := errno.FromMessage(errno.RouteRequestError, err.Error()+" route ID: "+rid)
 			logger.Error(e.Msg)
 			c.AbortWithStatusJSON(http.StatusBadRequest, e.Response())
 			return
 		} else {
-			// need to find name from mysql temporary
-			route := &service.Route{}
-			if err := conf.DB().Table("routes").Where("id=?", rid).First(&route).Error; err != nil {
+			// transfer response to dashboard struct
+			if result, err := response.Parse(); err != nil {
 				e := errno.FromMessage(errno.RouteRequestError, err.Error()+" route ID: "+rid)
 				logger.Error(e.Msg)
 				c.AbortWithStatusJSON(http.StatusBadRequest, e.Response())
 				return
-			}
-			result.Name = route.Name
-			var script map[string]interface{}
-			if err = json.Unmarshal([]byte(route.Script), &script); err != nil {
-				script = map[string]interface{}{}
-			}
-			result.Script = script
+			} else {
+				// need to find name from mysql temporary
+				result.Name = route.Name
+				var script map[string]interface{}
+				if err = json.Unmarshal([]byte(route.Script), &script); err != nil {
+					script = map[string]interface{}{}
+				}
+				result.Script = script
 
-			result.RouteGroupId = route.RouteGroupId
-			result.RouteGroupName = route.RouteGroupName
-			resp, _ := json.Marshal(result)
-			c.Data(http.StatusOK, service.ContentType, resp)
+				result.RouteGroupId = route.RouteGroupId
+				result.RouteGroupName = route.RouteGroupName
+				result.Status = true
+				resp, _ := json.Marshal(result)
+				c.Data(http.StatusOK, service.ContentType, resp)
+			}
 		}
 	}
 }
@@ -369,10 +475,12 @@ func createRoute(c *gin.Context) {
 	db := conf.DB()
 	arr := service.ToApisixRequest(routeRequest)
 	var resp *service.ApisixRouteResponse
+	var r *service.Route
 	if rd, err := service.ToRoute(routeRequest, arr, u4, nil); err != nil {
 		c.AbortWithStatusJSON(http.StatusInternalServerError, err.Response())
 		return
 	} else {
+		r = rd
 		tx := db.Begin()
 		defer func() {
 			if r := recover(); r != nil {
@@ -396,7 +504,7 @@ func createRoute(c *gin.Context) {
 			logger.Error(e.Msg)
 			c.AbortWithStatusJSON(http.StatusInternalServerError, e.Response())
 			return
-		} else {
+		} else if rd.Status {
 			if resp, err = arr.Create(rid); err != nil {
 				tx.Rollback()
 				if httpError, ok := err.(*errno.HttpError); ok {
@@ -410,7 +518,7 @@ func createRoute(c *gin.Context) {
 				}
 			}
 		}
-		if err := tx.Commit().Error; err == nil {
+		if err := tx.Commit().Error; err == nil && r.Status {
 			// update content_admin_api
 			if rd, err := service.ToRoute(routeRequest, arr, u4, resp); err != nil {
 				e := errno.FromMessage(errno.DBRouteUpdateError, err.Error())

--- a/api/route/route.go
+++ b/api/route/route.go
@@ -34,10 +34,10 @@ func AppendRoute(r *gin.Engine) *gin.Engine {
 	r.GET("/apisix/admin/routes/:rid", findRoute)
 	r.GET("/apisix/admin/routes", listRoute)
 	r.PUT("/apisix/admin/routes/:rid", updateRoute)
-	r.PUT("/apisix/admin/publishroutes/:rid", publishRoute)
+	r.PUT("/apisix/admin/routes/:rid/publish", publishRoute)
 	r.DELETE("/apisix/admin/routes/:rid", deleteRoute)
 	r.GET("/apisix/admin/notexist/routes", isRouteExist)
-	r.PUT("/apisix/admin/offlineroutes/:rid", offlineRoute)
+	r.PUT("/apisix/admin/routes/:rid/offline", offlineRoute)
 	return r
 }
 

--- a/api/route/route_test.go
+++ b/api/route/route_test.go
@@ -19,37 +19,38 @@ package route
 import (
 	"net/http"
 	"testing"
+
 	"github.com/apisix/manager-api/conf"
 	"github.com/apisix/manager-api/service"
 )
-
+ 
 func TestCreateRouteForUngroup(t *testing.T) {
 	// create route with no route group -- test ungroup
 	handler.Post(uriPrefix+"/routes").
 		Header("Authorization", token).
 		JSON(`{
-      "name":"api-test-no-group",
-      "desc":"api-test-no-group",
-      "priority":0,
-      "protocols":["http"],
-      "hosts":["test.com"],
-      "paths":["/*"],
-      "methods":["GET","HEAD","POST","PUT","DELETE","OPTIONS","PATCH"],
-      "status":false,
-      "upstream_protocol":"keep",
-      "plugins":{},
-      "uris":["/*"],
-      "vars":[],
-      "upstream":{"type":"roundrobin","nodes":{"127.0.0.1:443":1},
-      "timeout":{"connect":6000,"send":6000,"read":6000}},
-      "upstream_header":{},
-      "route_group_id":"",
-      "route_group_name":""
+			"name":"api-test-no-group",
+			"desc":"api-test-no-group",
+			"priority":0,
+			"protocols":["http"],
+			"hosts":["test.com"],
+			"paths":["/*"],
+			"methods":["GET","HEAD","POST","PUT","DELETE","OPTIONS","PATCH"],
+			"status":false,
+			"upstream_protocol":"keep",
+			"plugins":{},
+			"uris":["/*"],
+			"vars":[],
+			"upstream":{"type":"roundrobin","nodes":{"127.0.0.1:443":1},
+			"timeout":{"connect":6000,"send":6000,"read":6000}},
+			"upstream_header":{},
+			"route_group_id":"",
+			"route_group_name":""
 }`).Expect(t).
-		Status(http.StatusOK).
-		End()
+	Status(http.StatusOK).
+	End()
 }
-
+ 
 func TestUpdateRouteWithCreateRouteGroup(t *testing.T) {
 	route, _ := getRouteByName("api-test-no-group")
 
@@ -57,65 +58,92 @@ func TestUpdateRouteWithCreateRouteGroup(t *testing.T) {
 	handler.Put(uriPrefix+"/routes/"+route.ID.String()).
 		Header("Authorization", token).
 		JSON(`{
-      "name":"api-test-no-group",
-      "desc":"api-test-no-group",
-      "priority":0,
-      "protocols":["http"],
-      "hosts":["test.com"],
-      "paths":["/*"],
-      "methods":["GET","HEAD","POST","PUT","DELETE","OPTIONS","PATCH"],
-      "status":false,
-      "upstream_protocol":"keep",
-      "plugins":{},
-      "uris":["/*"],
-      "vars":[],
-      "upstream":{"type":"roundrobin","nodes":{"127.0.0.1:443":1},
-      "timeout":{"connect":6000,"send":6000,"read":6000}},
-      "upstream_header":{},
-      "route_group_id":"",
-      "route_group_name":"route-update-test-create-group"
+			"name":"api-test-no-group",
+			"desc":"api-test-no-group",
+			"priority":0,
+			"protocols":["http"],
+			"hosts":["test.com"],
+			"paths":["/*"],
+			"methods":["GET","HEAD","POST","PUT","DELETE","OPTIONS","PATCH"],
+			"status":false,
+			"upstream_protocol":"keep",
+			"plugins":{},
+			"uris":["/*"],
+			"vars":[],
+			"upstream":{"type":"roundrobin","nodes":{"127.0.0.1:443":1},
+			"timeout":{"connect":6000,"send":6000,"read":6000}},
+			"upstream_header":{},
+			"route_group_id":"",
+			"route_group_name":"route-update-test-create-group"
 }`).Expect(t).
-		Status(http.StatusOK).
-		End()
+	Status(http.StatusOK).
+	End()
 }
-
+ 
 func TestCreateRouteWithCreateNewGroup(t *testing.T) {
 	// create route with new route group
 	handler.Post(uriPrefix+"/routes").
 		Header("Authorization", token).
 		JSON(`{
-      "name":"api-test-new-group",
-      "desc":"api-test-new-group",
-      "priority":0,
-      "protocols":["http"],
-      "hosts":["test.com"],
-      "paths":["/*"],
-      "methods":["GET","HEAD","POST","PUT","DELETE","OPTIONS","PATCH"],
-      "status":false,
-      "upstream_protocol":"keep",
-      "plugins":{},
-      "uris":["/*"],
-      "vars":[],
-      "upstream":{"type":"roundrobin","nodes":{"127.0.0.1:443":1},
-      "timeout":{"connect":6000,"send":6000,"read":6000}},
-      "upstream_header":{},
-      "route_group_id":"",
-      "route_group_name":"route-create-test-create-group"
+			"name":"api-test-new-group",
+			"desc":"api-test-new-group",
+			"priority":0,
+			"protocols":["http"],
+			"hosts":["test.com"],
+			"paths":["/*"],
+			"methods":["GET","HEAD","POST","PUT","DELETE","OPTIONS","PATCH"],
+			"status":false,
+			"upstream_protocol":"keep",
+			"plugins":{},
+			"uris":["/*"],
+			"vars":[],
+			"upstream":{"type":"roundrobin","nodes":{"127.0.0.1:443":1},
+			"timeout":{"connect":6000,"send":6000,"read":6000}},
+			"upstream_header":{},
+			"route_group_id":"",
+			"route_group_name":"route-create-test-create-group"
 }`).Expect(t).
-		Status(http.StatusOK).
-		End()
+	Status(http.StatusOK).
+	End()
 }
-
+ 
 func TestCreateRouteWithDuplicateGroupName(t *testing.T) {
 	// create route with duplicate route group name
 	handler.Post(uriPrefix+"/routes").
 		Header("Authorization", token).
 		JSON(`{
+			"name":"api-test",
+			"desc":"api-test",
+			"priority":0,
+			"protocols":["http"],
+			"hosts":["test.com"],
+			"paths":["/*"],
+			"methods":["GET","HEAD","POST","PUT","DELETE","OPTIONS","PATCH"],
+			"status":false,
+			"upstream_protocol":"keep",
+			"plugins":{},
+			"uris":["/*"],
+			"vars":[],
+			"upstream":{"type":"roundrobin","nodes":{"127.0.0.1:443":1},
+			"timeout":{"connect":6000,"send":6000,"read":6000}},
+			"upstream_header":{},
+			"route_group_id":"",
+			"route_group_name":"route-create-test-create-group"
+}`).Expect(t).
+	Status(http.StatusInternalServerError).
+	End()
+}
+
+ func TestPublishRoute(t *testing.T) {
+	// create route
+	handler.Post(uriPrefix+"/routes").
+		Header("Authorization", token).
+		JSON(`{
       "name":"api-test",
-      "desc":"api-test",
+      "desc":"",
       "priority":0,
       "protocols":["http"],
-      "hosts":["test.com"],
+      "hosts":["test1.com"],
       "paths":["/*"],
       "methods":["GET","HEAD","POST","PUT","DELETE","OPTIONS","PATCH"],
       "status":false,
@@ -125,12 +153,41 @@ func TestCreateRouteWithDuplicateGroupName(t *testing.T) {
       "vars":[],
       "upstream":{"type":"roundrobin","nodes":{"127.0.0.1:443":1},
       "timeout":{"connect":6000,"send":6000,"read":6000}},
-      "upstream_header":{},
-      "route_group_id":"",
-      "route_group_name":"route-create-test-create-group"
+      "upstream_header":{}
 }`).Expect(t).
-		Status(http.StatusInternalServerError).
-		End()
+	Status(http.StatusOK).
+	End()
+	route, _ := getRouteByName("api-test")
+	// publish route
+	handler.Put(uriPrefix + "/routes/" + route.ID.String() + "/publish").Expect(t).Status(http.StatusOK).End()
+}
+
+func TestOfflineRoute(t *testing.T) {
+	// create route
+	handler.Post(uriPrefix+"/routes").
+		Header("Authorization", token).
+		JSON(`{
+      "name":"api-test-published",
+      "desc":"",
+      "priority":0,
+      "protocols":["http"],
+      "hosts":["test1.com"],
+      "paths":["/*"],
+      "methods":["GET","HEAD","POST","PUT","DELETE","OPTIONS","PATCH"],
+      "status":true,
+      "upstream_protocol":"keep",
+      "plugins":{},
+      "uris":["/*"],
+      "vars":[],
+      "upstream":{"type":"roundrobin","nodes":{"127.0.0.1:443":1},
+      "timeout":{"connect":6000,"send":6000,"read":6000}},
+      "upstream_header":{}
+}`).Expect(t).
+	Status(http.StatusOK).
+	End()
+	routePublished, _ := getRouteByName("api-test-published")
+	// offline route
+	handler.Put(uriPrefix + "/routes/" + routePublished.ID.String() + "/offline").Expect(t).Status(http.StatusOK).End()
 }
 
 func getRouteByName(name string) (*service.Route, error) {

--- a/api/script/db/schema.sql
+++ b/api/script/db/schema.sql
@@ -18,7 +18,7 @@ CREATE TABLE `routes` (
   `update_time` bigint(20),
   `route_group_id` varchar(64) NOT NULL,
   `route_group_name` varchar(64) NOT NULL,
-
+  `status` tinyint(1),
   PRIMARY KEY (`id`)
 ) DEFAULT CHARSET=utf8;
 

--- a/api/service/route.go
+++ b/api/service/route.go
@@ -82,6 +82,7 @@ func (rd *Route) Parse(r *RouteRequest, arr *ApisixRouteRequest) error {
 	rd.UpstreamId = r.UpstreamId
 	rd.RouteGroupId = r.RouteGroupId
 	rd.RouteGroupName = r.RouteGroupName
+	rd.Status = r.Status
 	if content, err := json.Marshal(r); err != nil {
 		return err
 	} else {
@@ -192,6 +193,7 @@ type RouteRequest struct {
 	Script           map[string]interface{} `json:"script"`
 	RouteGroupId     string                 `json:"route_group_id"`
 	RouteGroupName   string                 `json:"route_group_name"`
+	Status           bool                   `json:"status"`
 }
 
 func (r *ApisixRouteResponse) Parse() (*RouteRequest, error) {
@@ -414,6 +416,7 @@ type Value struct {
 	Plugins        map[string]interface{} `json:"plugins"`
 	RouteGroupId   string                 `json:"route_group_id"`
 	RouteGroupName string                 `json:"route_group_name"`
+	Status         bool                   `json:"status"`
 }
 
 type Route struct {
@@ -430,6 +433,7 @@ type Route struct {
 	ContentAdminApi string `json:"content_admin_api"`
 	RouteGroupId    string `json:"route_group_id"`
 	RouteGroupName  string `json:"route_group_name"`
+	Status          bool   `json:"status"`
 }
 
 type RouteResponse struct {
@@ -443,6 +447,7 @@ type RouteResponse struct {
 	Priority       int64     `json:"priority"`
 	RouteGroupId   string    `json:"route_group_id"`
 	RouteGroupName string    `json:"route_group_name"`
+	Status         bool      `json:"status"`
 }
 
 type ListResponse struct {
@@ -458,6 +463,7 @@ func (rr *RouteResponse) Parse(r *Route) {
 	rr.Priority = r.Priority
 	rr.RouteGroupId = r.RouteGroupId
 	rr.RouteGroupName = r.RouteGroupName
+	rr.Status = r.Status
 	// hosts
 	if len(r.Hosts) > 0 {
 		var hosts []string
@@ -597,6 +603,7 @@ func ToRoute(routeRequest *RouteRequest,
 	// content_admin_api
 	if resp != nil {
 		resp.Node.Value.RouteGroupId = rd.RouteGroupId
+		resp.Node.Value.Status = rd.Status
 		if respStr, err := json.Marshal(resp); err != nil {
 			e := errno.FromMessage(errno.DBRouteCreateError, err.Error())
 			return nil, e


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [ ] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues
issue #437 manage api
___
### Bugfix
- Description

- How to fix?

___
### New feature or improvement
- Describe the details and related test reports.

1. add a Column to route, called `status`

1. `status = true`, means create a new route in both mysql and apisix;  `status=false`: means create a route only in mysql

1. modified the logic of editing and deleting route at the same time, 

1. add manager apis to support change route `status`