### PR TITLE
feat: support ungroup in manager api

### DIFF
--- a/api/errno/error.go
+++ b/api/errno/error.go
@@ -57,6 +57,7 @@ var (
 	DBRouteUpdateError      = Message{"010206", "Route update failed: %s", 500}
 	DBRouteDeleteError      = Message{"010207", "Route deletion failed: %s", 500}
 	DBRouteReduplicateError = Message{"010208", "Route name is reduplicate : %s", 400}
+	SetRouteUngroupError    = Message{"010209", "Set route ungroup err", 500}
 
 	// 03 plugins
 	ApisixPluginListError   = Message{"010301", "find APISIX plugin list failed: %s", 500}

--- a/api/route/route_test.go
+++ b/api/route/route_test.go
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package route
+
+import (
+	"net/http"
+	"testing"
+	"github.com/apisix/manager-api/conf"
+	"github.com/apisix/manager-api/service"
+)
+
+func TestCreateRouteForUngroup(t *testing.T) {
+	// create route with no route group -- test ungroup
+	handler.Post(uriPrefix+"/routes").
+		Header("Authorization", token).
+		JSON(`{
+      "name":"api-test-no-group",
+      "desc":"api-test-no-group",
+      "priority":0,
+      "protocols":["http"],
+      "hosts":["test.com"],
+      "paths":["/*"],
+      "methods":["GET","HEAD","POST","PUT","DELETE","OPTIONS","PATCH"],
+      "status":false,
+      "upstream_protocol":"keep",
+      "plugins":{},
+      "uris":["/*"],
+      "vars":[],
+      "upstream":{"type":"roundrobin","nodes":{"127.0.0.1:443":1},
+      "timeout":{"connect":6000,"send":6000,"read":6000}},
+      "upstream_header":{},
+      "route_group_id":"",
+      "route_group_name":""
+}`).Expect(t).
+		Status(http.StatusOK).
+		End()
+}
+
+func TestUpdateRouteWithCreateRouteGroup(t *testing.T) {
+	route, _ := getRouteByName("api-test-no-group")
+
+	// update route for create route group
+	handler.Put(uriPrefix+"/routes/"+route.ID.String()).
+		Header("Authorization", token).
+		JSON(`{
+      "name":"api-test-no-group",
+      "desc":"api-test-no-group",
+      "priority":0,
+      "protocols":["http"],
+      "hosts":["test.com"],
+      "paths":["/*"],
+      "methods":["GET","HEAD","POST","PUT","DELETE","OPTIONS","PATCH"],
+      "status":false,
+      "upstream_protocol":"keep",
+      "plugins":{},
+      "uris":["/*"],
+      "vars":[],
+      "upstream":{"type":"roundrobin","nodes":{"127.0.0.1:443":1},
+      "timeout":{"connect":6000,"send":6000,"read":6000}},
+      "upstream_header":{},
+      "route_group_id":"",
+      "route_group_name":"route-update-test-create-group"
+}`).Expect(t).
+		Status(http.StatusOK).
+		End()
+}
+
+func TestCreateRouteWithCreateNewGroup(t *testing.T) {
+	// create route with new route group
+	handler.Post(uriPrefix+"/routes").
+		Header("Authorization", token).
+		JSON(`{
+      "name":"api-test-new-group",
+      "desc":"api-test-new-group",
+      "priority":0,
+      "protocols":["http"],
+      "hosts":["test.com"],
+      "paths":["/*"],
+      "methods":["GET","HEAD","POST","PUT","DELETE","OPTIONS","PATCH"],
+      "status":false,
+      "upstream_protocol":"keep",
+      "plugins":{},
+      "uris":["/*"],
+      "vars":[],
+      "upstream":{"type":"roundrobin","nodes":{"127.0.0.1:443":1},
+      "timeout":{"connect":6000,"send":6000,"read":6000}},
+      "upstream_header":{},
+      "route_group_id":"",
+      "route_group_name":"route-create-test-create-group"
+}`).Expect(t).
+		Status(http.StatusOK).
+		End()
+}
+
+func TestCreateRouteWithDuplicateGroupName(t *testing.T) {
+	// create route with duplicate route group name
+	handler.Post(uriPrefix+"/routes").
+		Header("Authorization", token).
+		JSON(`{
+      "name":"api-test",
+      "desc":"api-test",
+      "priority":0,
+      "protocols":["http"],
+      "hosts":["test.com"],
+      "paths":["/*"],
+      "methods":["GET","HEAD","POST","PUT","DELETE","OPTIONS","PATCH"],
+      "status":false,
+      "upstream_protocol":"keep",
+      "plugins":{},
+      "uris":["/*"],
+      "vars":[],
+      "upstream":{"type":"roundrobin","nodes":{"127.0.0.1:443":1},
+      "timeout":{"connect":6000,"send":6000,"read":6000}},
+      "upstream_header":{},
+      "route_group_id":"",
+      "route_group_name":"route-create-test-create-group"
+}`).Expect(t).
+		Status(http.StatusInternalServerError).
+		End()
+}
+
+func getRouteByName(name string) (*service.Route, error) {
+	db := conf.DB()
+	route := &service.Route{}
+	if err := db.Table("routes").Where("name = ?", name).First(&route).Error; err != nil {
+		return nil, err
+	}
+	return route, nil
+}

--- a/api/service/route_group_test.go
+++ b/api/service/route_group_test.go
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package service
+
+import (
+	"testing"
+
+	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+var gid = uuid.NewV4()
+var gid2 = uuid.NewV4()
+
+func TestCreateRouteGroup(t *testing.T) {
+	routeGroup := &RouteGroupDao{
+		Base:        Base{},
+		Name:        "route_group_test",
+		Description: "route_group_test",
+	}
+	routeGroup.ID = gid
+	// create ok
+	err := routeGroup.CreateRouteGroup()
+	as := assert.New(t)
+	as.Nil(err)
+}
+
+func TestGetRouteGroup(t *testing.T) {
+	// get group ok
+	as := assert.New(t)
+	getGroup := &RouteGroupDao{}
+	err, i := getGroup.FindRouteGroup(gid.String())
+	as.Nil(err)
+	as.Equal("route_group_test", getGroup.Name)
+	as.Equal(1, i)
+}
+
+func TestRouteGroupNameDuplicate(t *testing.T) {
+	// name duplicate
+	as := assert.New(t)
+	routeGroup2 := &RouteGroupDao{
+		Base:        Base{},
+		Name:        "route_group_test",
+		Description: "route_group_test",
+	}
+	routeGroup2.ID = gid2
+	err := routeGroup2.CreateRouteGroup()
+	as.NotNil(err)
+	// ok
+	routeGroup2.Name = "route_group_test2"
+	err = routeGroup2.CreateRouteGroup()
+	as.Nil(err)
+}
+
+func TestGetRouteGupList(t *testing.T) {
+	as := assert.New(t)
+	// list ok
+	routeGroups := []RouteGroupDao{}
+	routeGroup := &RouteGroupDao{}
+	err, i3 := routeGroup.GetRouteGroupList(&routeGroups, "", 1, 2)
+	as.Nil(err)
+	as.Equal(true, i3 >= 2)
+	as.Equal(2, len(routeGroups))
+}
+
+func TestUpdateRouteGroup(t *testing.T) {
+	as := assert.New(t)
+	// update ok
+	routeGroup := &RouteGroupDao{
+		Base:        Base{},
+		Name:        "route_group_test_update",
+		Description: "route_group_test_update",
+	}
+	routeGroup.ID = gid
+	err := routeGroup.UpdateRouteGroup()
+	as.Nil(err)
+}
+
+func TestDeleteRouteGroup(t *testing.T) {
+	as := assert.New(t)
+	routeGroup := &RouteGroupDao{
+		Base:        Base{},
+		Name:        "route_group_test_update",
+		Description: "route_group_test_update",
+	}
+	routeGroup.ID = gid
+	// delete ok
+	err := routeGroup.DeleteRouteGroup()
+	as.Nil(err)
+
+	deleteGroup := &RouteGroupDao{}
+	err, i2 := deleteGroup.FindRouteGroup(gid.String())
+	as.Nil(err)
+	as.Equal("", deleteGroup.Name)
+	as.Equal(0, i2)
+
+	routeGroup2 := &RouteGroupDao{
+		Base:        Base{},
+		Name:        "route_group_test",
+		Description: "route_group_test",
+	}
+	routeGroup2.ID = gid2
+	err = routeGroup2.DeleteRouteGroup()
+	as.Nil(err)
+}


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bug fix
- [x] New feature provided
- [ ] Improve performance

- Related issues

1. this pr could Independently resolve issue #452 

1. this pr could also resolve the ci error in pr #450 

 
___
### Bugfix
- Description

- How to fix?

___
### New feature or improvement
- Describe the details and related test reports.

1. refer to the https://github.com/apache/apisix-dashboard/issues/431#issuecomment-684158042, user could ungroup a  route which is already in a routeGroup.

1.  routeGroup is not a required item when create/edit the route

1.  decouple api and front-end 