### PR TITLE
fix: update valify rules about whether enabled auth plugin in create/…

### DIFF
--- a/src/pages/Consumer/Create.tsx
+++ b/src/pages/Consumer/Create.tsx
@@ -18,7 +18,7 @@ import React, { useState, useEffect } from 'react';
 import { PageContainer } from '@ant-design/pro-layout';
 import { Card, Steps, notification, Form } from 'antd';
 import { history, useIntl } from 'umi';
-import { PluginPage, PluginPageType } from '@api7-dashboard/plugin';
+import { PluginPage, PluginPageType, PLUGIN_MAPPER_SOURCE } from '@api7-dashboard/plugin';
 
 import ActionBar from '@/components/ActionBar';
 
@@ -68,13 +68,9 @@ const Page: React.FC = (props) => {
         setStep(nextStep);
       });
     } else if (nextStep === 3) {
-      const authPluginNames = [
-        'openid-connect',
-        'basic-auth',
-        'jwt-auth',
-        'key-auth',
-        'authz-keycloak',
-      ];
+      const authPluginNames = Object.keys(PLUGIN_MAPPER_SOURCE).filter(
+        (pluginName) => PLUGIN_MAPPER_SOURCE[pluginName].category === 'Authentication',
+      );
       const currentAuthPlugin = Object.keys(plugins).filter((plugin) =>
         authPluginNames.includes(plugin),
       );

--- a/src/pages/Consumer/Create.tsx
+++ b/src/pages/Consumer/Create.tsx
@@ -68,8 +68,18 @@ const Page: React.FC = (props) => {
         setStep(nextStep);
       });
     } else if (nextStep === 3) {
-      const isValid = Object.keys(plugins).some((name) => name.includes('auth'));
-      if (!isValid) {
+      const authPluginNames = [
+        'openid-connect',
+        'basic-auth',
+        'jwt-auth',
+        'key-auth',
+        'authz-keycloak',
+      ];
+      const currentAuthPlugin = Object.keys(plugins).filter((plugin) =>
+        authPluginNames.includes(plugin),
+      );
+      const currentAuthPluginLen = currentAuthPlugin.length;
+      if (currentAuthPluginLen > 1 || currentAuthPluginLen === 0) {
         notification.warning({
           message: formatMessage({ id: 'consumer.create.enable.authentication.plugin' }),
         });

--- a/src/pages/Consumer/locales/en-US.ts
+++ b/src/pages/Consumer/locales/en-US.ts
@@ -16,7 +16,8 @@
  */
 export default {
   'consumer.step.username': 'Username',
-  'consumer.step.username.rule': 'Maximum length is 100, only letters, numbers and _ are supported, and can only begin with letters',
+  'consumer.step.username.rule':
+    'Maximum length is 100, only letters, numbers and _ are supported, and can only begin with letters',
   'consumer.step.username.unique': 'Username should be unique',
   'consumer.step.input.username': 'Please input username',
   'consumer.step.description': 'Description',
@@ -25,7 +26,7 @@ export default {
   'consumer.create.edit': 'Edit',
   'consumer.create.create': 'Create',
   'consumer.create.success': 'Success',
-  'consumer.create.enable.authentication.plugin': 'Please enable at least one authentication plugin',
+  'consumer.create.enable.authentication.plugin': 'Please enable one authentication plugin',
   'consumer.create.basic.information': 'Basic Information',
   'consumer.create.plugin.config': 'Plugin Config',
   'consumer.create.preview': 'Preview',

--- a/src/pages/Consumer/locales/zh-CN.ts
+++ b/src/pages/Consumer/locales/zh-CN.ts
@@ -25,7 +25,7 @@ export default {
   'consumer.create.edit': '编辑',
   'consumer.create.create': '创建',
   'consumer.create.success': '成功',
-  'consumer.create.enable.authentication.plugin': '请启用至少一种身份认证类插件',
+  'consumer.create.enable.authentication.plugin': '请启用一种身份认证类插件',
   'consumer.create.basic.information': '基础信息',
   'consumer.create.plugin.config': '插件配置',
   'consumer.create.preview': '预览',


### PR DESCRIPTION
…update a consumer

Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues
fix: #509 
___
### Bugfix
- Description

- How to fix?
update valify rules to create/update a consumer must enable one of the five auth plugins.
(when enables two or above auth plugins , it will return a error from Apisix: `only one auth plugin is allowed`
![2020-09-24 18-27-50屏幕截图](https://user-images.githubusercontent.com/2561857/94133825-c2332200-fe93-11ea-9553-72717626c018.png)
![2020-09-24 18-27-11屏幕截图](https://user-images.githubusercontent.com/2561857/94133844-c65f3f80-fe93-11ea-917e-c91deee4fe2b.png)

) 

___
### New feature or improvement
- Describe the details and related test reports.

