### PR TITLE
style: Drop `npm run` in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,19 +6,19 @@
   "scripts": {
     "analyze": "cross-env ANALYZE=1 umi build",
     "build": "umi build",
-    "dev": "npm run start:dev",
-    "fetch:blocks": "pro fetch-blocks --branch antd@4 && npm run prettier",
+    "dev": "yarn run start:dev",
+    "fetch:blocks": "pro fetch-blocks --branch antd@4 && yarn run prettier",
     "i18n-remove": "pro i18n-remove --locale=zh-CN --write",
     "postinstall": "umi g tmp",
-    "lint": "umi g tmp && npm run lint:js && npm run lint:style && npm run lint:prettier",
+    "lint": "umi g tmp && yarn run lint:js && yarn run lint:style && yarn run lint:prettier",
     "lint-staged": "lint-staged",
     "lint-staged:js": "eslint --ext .js,.jsx,.ts,.tsx ",
-    "lint:fix": "eslint --fix --cache --ext .js,.jsx,.ts,.tsx --format=pretty ./src && npm run lint:style",
+    "lint:fix": "eslint --fix --cache --ext .js,.jsx,.ts,.tsx --format=pretty ./src && yarn run lint:style",
     "lint:js": "eslint --cache --ext .js,.jsx,.ts,.tsx --format=pretty ./src",
     "lint:prettier": "prettier --check \"**/*\" --end-of-line auto",
     "lint:style": "stylelint --fix \"src/**/*.less\" --syntax less",
     "prettier": "prettier -c --write \"**/*\"",
-    "site": "npm run fetch:blocks && npm run build",
+    "site": "yarn run fetch:blocks && yarn run build",
     "start": "umi dev",
     "start:dev": "cross-env REACT_APP_ENV=dev MOCK=none umi dev",
     "start:no-mock": "cross-env MOCK=none umi dev",
@@ -35,12 +35,12 @@
   "husky": {
     "hooks": {
       "commit-msg": "node scripts/verifyCommit.js",
-      "pre-commit": "npm run lint-staged"
+      "pre-commit": "yarn run lint-staged"
     }
   },
   "lint-staged": {
     "**/*.less": "stylelint --syntax less",
-    "**/*.{js,jsx,ts,tsx}": "npm run lint-staged:js",
+    "**/*.{js,jsx,ts,tsx}": "yarn run lint-staged:js",
     "**/*.{js,jsx,tsx,ts,less,md,json}": [
       "prettier --write"
     ]


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bugfix
- Description
In [README/Build the dashboard](https://github.com/apache/apisix-dashboard#build-the-dashboard), only `yarn` is mentioned but `npm` is used instead of `yarn` in `package.json` multiple times. It will throw errors and cause confusion to users who have installed yarn according to README but without `npm` on their machines.

- How to fix?
`npm` is not actually used in the project. In `package.json`, it acts as a command caller. So simply dropping `npm` works.
All `npm` has been replaced to `yarn`.
