### PR TITLE
fix: double scroll bar in plugin page

### DIFF
--- a/web/src/global.less
+++ b/web/src/global.less
@@ -83,3 +83,8 @@ ol {
 .ant-select-disabled.ant-select-single:not(.ant-select-customize-input) .ant-select-selector {
   background-color: #fff !important;
 }
+
+.ant-layout.ant-layout-has-sider > .ant-layout,
+.ant-layout.ant-layout-has-sider > .ant-layout-content {
+  overflow-x: unset;
+}


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [ ] Bugfix
- [ ] New feature provided
- [x] Improve performance

___
### Bugfix
- Description

When step to the third step of create/edit route: plugin Config, double scroll bars will appear on the page, which is not convenient for user .

![image](https://user-images.githubusercontent.com/2561857/99034608-8b86a780-25b8-11eb-9413-b2da928fefc0.png)




- How to fix?

