### PR TITLE
feat: skip puppeteer chromium download when build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ help:
 ### build:		Build Apache APISIX Dashboard, it contains web and manager-api
 .PHONY: build
 build: web-default api-default
-	api/build.sh && cd ./web && yarn install && yarn build  && mkdir -p ../output/logs
+	api/build.sh && cd ./web && export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true && yarn install && yarn build  && mkdir -p ../output/logs
 
 
 .PHONY: web-default


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [ ] Bugfix
- [ ] New feature provided
- [x] Improve performance

- Related issues

___
### Bugfix
- Description

- How to fix?

___
### New feature or improvement
- Describe the details and related test reports.

https://stackoverflow.com/questions/53283809/yarn-install-error-failed-to-download-chromium