### PR TITLE
feat: add a hanlder unit test for upstream and remove init

### DIFF
--- a/api/conf/conf.go
+++ b/api/conf/conf.go
@@ -93,7 +93,7 @@ type Config struct {
 	Authentication Authentication
 }
 
-func init() {
+func InitConf() {
 	//go test
 	if workDir := os.Getenv("APISIX_API_WORKDIR"); workDir != "" {
 		WorkDir = workDir

--- a/api/internal/core/store/store_mock.go
+++ b/api/internal/core/store/store_mock.go
@@ -1,0 +1,35 @@
+package store
+
+import (
+	"context"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockInterface struct {
+	mock.Mock
+}
+
+func (m *MockInterface) Get(key string) (interface{}, error) {
+	ret := m.Mock.Called(key)
+	return ret.Get(0), ret.Error(1)
+}
+
+func (m *MockInterface) List(input ListInput) (*ListOutput, error) {
+	ret := m.Mock.Called(input)
+	return ret.Get(0).(*ListOutput), ret.Error(1)
+}
+
+func (m *MockInterface) Create(ctx context.Context, obj interface{}) error {
+	ret := m.Mock.Called(ctx, obj)
+	return ret.Error(0)
+}
+
+func (m *MockInterface) Update(ctx context.Context, obj interface{}, createOnFail bool) error {
+	ret := m.Mock.Called(ctx, obj, createOnFail)
+	return ret.Error(0)
+}
+
+func (m *MockInterface) BatchDelete(ctx context.Context, keys []string) error {
+	ret := m.Mock.Called(ctx, keys)
+	return ret.Error(0)
+}

--- a/api/log/zap.go
+++ b/api/log/zap.go
@@ -27,7 +27,7 @@ import (
 
 var logger *zap.SugaredLogger
 
-func init() {
+func InitLog() {
 	writeSyncer := fileWriter()
 	encoder := getEncoder()
 	logLevel := getLogLevel()

--- a/api/main.go
+++ b/api/main.go
@@ -34,7 +34,8 @@ import (
 )
 
 func main() {
-
+	conf.InitConf()
+	log.InitLog()
 	if err := storage.InitETCDClient(conf.ETCDEndpoints); err != nil {
 		log.Error("init etcd client fail: %w", err)
 		panic(err)


### PR DESCRIPTION
This pr is a demo about how to do a real `unit test` in handler.
I also remove the `init` in `conf` and `log`, go is recommended to use explicit initial function instead of implicit `init`