### PR TITLE
chore: add middleware to transform error and rename placeholder.txt

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/lestrrat-go/strftime v1.0.3 // indirect
 	github.com/natefinch/lumberjack v2.0.0+incompatible
 	github.com/satori/go.uuid v1.2.0
-	github.com/shiningrush/droplet v0.2.2
+	github.com/shiningrush/droplet v0.2.3
 	github.com/shiningrush/droplet/wrapper/gin v0.2.0
 	github.com/sirupsen/logrus v1.7.0
 	github.com/sony/sonyflake v1.0.0

--- a/api/go.mod
+++ b/api/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/lestrrat-go/strftime v1.0.3 // indirect
 	github.com/natefinch/lumberjack v2.0.0+incompatible
 	github.com/satori/go.uuid v1.2.0
-	github.com/shiningrush/droplet v0.2.1
+	github.com/shiningrush/droplet v0.2.2
 	github.com/shiningrush/droplet/wrapper/gin v0.2.0
 	github.com/sirupsen/logrus v1.7.0
 	github.com/sony/sonyflake v1.0.0

--- a/api/go.sum
+++ b/api/go.sum
@@ -116,6 +116,8 @@ github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdh
 github.com/shiningrush/droplet v0.0.0-20191118073048-00b06fe19ce4/go.mod h1:E/th13n/wtPi+Cj2f0hAAEFeT3gb5xsS6Ob4WRrdxdM=
 github.com/shiningrush/droplet v0.2.1 h1:p2utttTbCfgiL+x0Zrb2jFeWspB7/o+v3e+R94G6nm4=
 github.com/shiningrush/droplet v0.2.1/go.mod h1:akW2vIeamvMD6zj6wIBfzYn6StGXBxwlW3gA+hcHu5M=
+github.com/shiningrush/droplet v0.2.2 h1:jEqSGoJXlybt1yQdauu+waE+l7KYlguNs8VayMfQ96Q=
+github.com/shiningrush/droplet v0.2.2/go.mod h1:akW2vIeamvMD6zj6wIBfzYn6StGXBxwlW3gA+hcHu5M=
 github.com/shiningrush/droplet/wrapper/gin v0.2.0 h1:LHkU+TbSkpePgXrTg3hJoSZlCMS03GeWMl0t+oLkd44=
 github.com/shiningrush/droplet/wrapper/gin v0.2.0/go.mod h1:ZJu+sCRrVXn5Pg618c1KK3Ob2UiXGuPM1ROx5uMM9YQ=
 github.com/sirupsen/logrus v1.7.0 h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM=

--- a/api/internal/handler/handler.go
+++ b/api/internal/handler/handler.go
@@ -59,10 +59,10 @@ func (mw *ErrorTransformMiddleware) Handle(ctx droplet.Context) error {
 		if !ok {
 			return err
 		}
-		switch {
-		case bErr.Code == data.ErrCodeValidate:
+		switch bErr.Code {
+		case data.ErrCodeValidate, data.ErrCodeFormat:
 			ctx.SetOutput(&data.SpecCodeResponse{StatusCode: http.StatusBadRequest})
-		case bErr.Code == data.ErrCodeInternal:
+		case data.ErrCodeInternal:
 			ctx.SetOutput(&data.SpecCodeResponse{StatusCode: http.StatusInternalServerError})
 		}
 		return err

--- a/api/internal/handler/handler.go
+++ b/api/internal/handler/handler.go
@@ -17,6 +17,8 @@
 package handler
 
 import (
+	"github.com/shiningrush/droplet"
+	"github.com/shiningrush/droplet/middleware"
 	"net/http"
 	"strings"
 
@@ -45,4 +47,25 @@ func SpecCodeResponse(err error) *data.SpecCodeResponse {
 	}
 
 	return &data.SpecCodeResponse{StatusCode: http.StatusInternalServerError}
+}
+
+type ErrorTransformMiddleware struct {
+	middleware.BaseMiddleware
+}
+
+func (mw *ErrorTransformMiddleware) Handle(ctx droplet.Context) error {
+	if err := mw.BaseMiddleware.Handle(ctx); err != nil {
+		bErr, ok := err.(*data.BaseError)
+		if !ok {
+			return err
+		}
+		switch {
+		case bErr.Code == data.ErrCodeValidate:
+			ctx.SetOutput(&data.SpecCodeResponse{StatusCode: http.StatusBadRequest})
+		case bErr.Code == data.ErrCodeInternal:
+			ctx.SetOutput(&data.SpecCodeResponse{StatusCode: http.StatusInternalServerError})
+		}
+		return err
+	}
+	return nil
 }

--- a/api/test/e2e/route_test.go
+++ b/api/test/e2e/route_test.go
@@ -133,6 +133,17 @@ func TestRoute_Create_With_Hosts(t *testing.T) {
 			ExpectStatus: http.StatusOK,
 		},
 		{
+			caseDesc: "create route with int uri",
+			Object:   MangerApiExpect(t),
+			Method:   http.MethodPut,
+			Path:     "/apisix/admin/routes/r1",
+			Body: `{
+				"uri": 123456
+			}`,
+			Headers:      map[string]string{"Authorization": token},
+			ExpectStatus: http.StatusInternalServerError,
+		},
+		{
 			caseDesc:     "hit the route just created - wildcard domain name",
 			Object:       APISIXExpect(t),
 			Method:       http.MethodGet,

--- a/api/test/e2e/route_test.go
+++ b/api/test/e2e/route_test.go
@@ -141,7 +141,7 @@ func TestRoute_Create_With_Hosts(t *testing.T) {
 				"uri": 123456
 			}`,
 			Headers:      map[string]string{"Authorization": token},
-			ExpectStatus: http.StatusInternalServerError,
+			ExpectStatus: http.StatusBadRequest,
 		},
 		{
 			caseDesc:     "hit the route just created - wildcard domain name",


### PR DESCRIPTION
- Add middleware to transform error, resolve #568 
- Rename `placeholder.txt` to `.gitkeep`, It is more suitable