### PR TITLE
fix: typo `scheme validate fail` should be `schema validate failed`

### DIFF
--- a/api/internal/core/store/validate.go
+++ b/api/internal/core/store/validate.go
@@ -77,8 +77,8 @@ type APISIXJsonSchemaValidator struct {
 func NewAPISIXJsonSchemaValidator(jsonPath string) (Validator, error) {
 	schemaDef := conf.Schema.Get(jsonPath).String()
 	if schemaDef == "" {
-		log.Warnf("scheme validate failed: schema not found, path: %s", jsonPath)
-		return nil, fmt.Errorf("scheme validate failed: schema not found, path: %s", jsonPath)
+		log.Warnf("schema validate faileded: schema not found, path: %s", jsonPath)
+		return nil, fmt.Errorf("schema validate faileded: schema not found, path: %s", jsonPath)
 	}
 
 	s, err := gojsonschema.NewSchema(gojsonschema.NewStringLoader(schemaDef))
@@ -123,25 +123,25 @@ func cHashKeySchemaCheck(upstream *entity.UpstreamDef) error {
 	if upstream.HashOn == "vars" {
 		schemaDef = conf.Schema.Get("main.upstream_hash_vars_schema").String()
 		if schemaDef == "" {
-			return fmt.Errorf("scheme validate failed: schema not found, patch: main.upstream_hash_vars_schema")
+			return fmt.Errorf("schema validate faileded: schema not found, patch: main.upstream_hash_vars_schema")
 		}
 	}
 
 	if upstream.HashOn == "header" || upstream.HashOn == "cookie" {
 		schemaDef = conf.Schema.Get("main.upstream_hash_header_schema").String()
 		if schemaDef == "" {
-			return fmt.Errorf("scheme validate failed: schema not found, path: main.upstream_hash_header_schema")
+			return fmt.Errorf("schema validate faileded: schema not found, path: main.upstream_hash_header_schema")
 		}
 	}
 
 	s, err := gojsonschema.NewSchema(gojsonschema.NewStringLoader(schemaDef))
 	if err != nil {
-		return fmt.Errorf("scheme validate failed: %w", err)
+		return fmt.Errorf("schema validate faileded: %w", err)
 	}
 
 	ret, err := s.Validate(gojsonschema.NewGoLoader(upstream.Key))
 	if err != nil {
-		return fmt.Errorf("scheme validate failed: %w", err)
+		return fmt.Errorf("schema validate faileded: %w", err)
 	}
 
 	if !ret.Valid() {
@@ -152,7 +152,7 @@ func cHashKeySchemaCheck(upstream *entity.UpstreamDef) error {
 			}
 			errString.AppendString(vErr.String())
 		}
-		return fmt.Errorf("scheme validate failed: %s", errString.String())
+		return fmt.Errorf("schema validate faileded: %s", errString.String())
 	}
 
 	return nil
@@ -218,8 +218,8 @@ func checkConf(reqBody interface{}) error {
 func (v *APISIXJsonSchemaValidator) Validate(obj interface{}) error {
 	ret, err := v.schema.Validate(gojsonschema.NewGoLoader(obj))
 	if err != nil {
-		log.Warnf("scheme validate failed: %w", err)
-		return fmt.Errorf("scheme validate failed: %w", err)
+		log.Warnf("schema validate faileded: %w", err)
+		return fmt.Errorf("schema validate faileded: %w", err)
 	}
 
 	if !ret.Valid() {
@@ -230,7 +230,7 @@ func (v *APISIXJsonSchemaValidator) Validate(obj interface{}) error {
 			}
 			errString.AppendString(vErr.String())
 		}
-		return fmt.Errorf("scheme validate fail: %s", errString.String())
+		return fmt.Errorf("schema validate failed: %s", errString.String())
 	}
 
 	//custom check
@@ -248,20 +248,20 @@ func (v *APISIXJsonSchemaValidator) Validate(obj interface{}) error {
 			schemaDef = conf.Schema.Get("plugins." + pluginName + ".schema").String()
 		}
 		if schemaDef == "" {
-			log.Warnf("scheme validate failed: schema not found, path: %s", "plugins."+pluginName)
-			return fmt.Errorf("scheme validate failed: schema not found, path: %s", "plugins."+pluginName)
+			log.Warnf("schema validate faileded: schema not found, path: %s", "plugins."+pluginName)
+			return fmt.Errorf("schema validate faileded: schema not found, path: %s", "plugins."+pluginName)
 		}
 
 		schemaDef = reg.ReplaceAllString(schemaDef, `"properties":{}`)
 		s, err := gojsonschema.NewSchema(gojsonschema.NewStringLoader(schemaDef))
 		if err != nil {
-			log.Warnf("init scheme validate failed: %w", err)
-			return fmt.Errorf("scheme validate failed: %w", err)
+			log.Warnf("init schema validate faileded: %w", err)
+			return fmt.Errorf("schema validate faileded: %w", err)
 		}
 
 		ret, err := s.Validate(gojsonschema.NewGoLoader(pluginConf))
 		if err != nil {
-			return fmt.Errorf("scheme validate failed: %w", err)
+			return fmt.Errorf("schema validate faileded: %w", err)
 		}
 
 		if !ret.Valid() {
@@ -272,7 +272,7 @@ func (v *APISIXJsonSchemaValidator) Validate(obj interface{}) error {
 				}
 				errString.AppendString(vErr.String())
 			}
-			return fmt.Errorf("scheme validate failed: %s", errString.String())
+			return fmt.Errorf("schema validate faileded: %s", errString.String())
 		}
 	}
 

--- a/api/internal/core/store/validate.go
+++ b/api/internal/core/store/validate.go
@@ -77,8 +77,8 @@ type APISIXJsonSchemaValidator struct {
 func NewAPISIXJsonSchemaValidator(jsonPath string) (Validator, error) {
 	schemaDef := conf.Schema.Get(jsonPath).String()
 	if schemaDef == "" {
-		log.Warnf("schema validate faileded: schema not found, path: %s", jsonPath)
-		return nil, fmt.Errorf("schema validate faileded: schema not found, path: %s", jsonPath)
+		log.Warnf("schema validate failed: schema not found, path: %s", jsonPath)
+		return nil, fmt.Errorf("schema validate failed: schema not found, path: %s", jsonPath)
 	}
 
 	s, err := gojsonschema.NewSchema(gojsonschema.NewStringLoader(schemaDef))
@@ -123,25 +123,25 @@ func cHashKeySchemaCheck(upstream *entity.UpstreamDef) error {
 	if upstream.HashOn == "vars" {
 		schemaDef = conf.Schema.Get("main.upstream_hash_vars_schema").String()
 		if schemaDef == "" {
-			return fmt.Errorf("schema validate faileded: schema not found, patch: main.upstream_hash_vars_schema")
+			return fmt.Errorf("schema validate failed: schema not found, patch: main.upstream_hash_vars_schema")
 		}
 	}
 
 	if upstream.HashOn == "header" || upstream.HashOn == "cookie" {
 		schemaDef = conf.Schema.Get("main.upstream_hash_header_schema").String()
 		if schemaDef == "" {
-			return fmt.Errorf("schema validate faileded: schema not found, path: main.upstream_hash_header_schema")
+			return fmt.Errorf("schema validate failed: schema not found, path: main.upstream_hash_header_schema")
 		}
 	}
 
 	s, err := gojsonschema.NewSchema(gojsonschema.NewStringLoader(schemaDef))
 	if err != nil {
-		return fmt.Errorf("schema validate faileded: %w", err)
+		return fmt.Errorf("schema validate failed: %w", err)
 	}
 
 	ret, err := s.Validate(gojsonschema.NewGoLoader(upstream.Key))
 	if err != nil {
-		return fmt.Errorf("schema validate faileded: %w", err)
+		return fmt.Errorf("schema validate failed: %w", err)
 	}
 
 	if !ret.Valid() {
@@ -152,7 +152,7 @@ func cHashKeySchemaCheck(upstream *entity.UpstreamDef) error {
 			}
 			errString.AppendString(vErr.String())
 		}
-		return fmt.Errorf("schema validate faileded: %s", errString.String())
+		return fmt.Errorf("schema validate failed: %s", errString.String())
 	}
 
 	return nil
@@ -218,8 +218,8 @@ func checkConf(reqBody interface{}) error {
 func (v *APISIXJsonSchemaValidator) Validate(obj interface{}) error {
 	ret, err := v.schema.Validate(gojsonschema.NewGoLoader(obj))
 	if err != nil {
-		log.Warnf("schema validate faileded: %w", err)
-		return fmt.Errorf("schema validate faileded: %w", err)
+		log.Warnf("schema validate failed: %w", err)
+		return fmt.Errorf("schema validate failed: %w", err)
 	}
 
 	if !ret.Valid() {
@@ -248,20 +248,20 @@ func (v *APISIXJsonSchemaValidator) Validate(obj interface{}) error {
 			schemaDef = conf.Schema.Get("plugins." + pluginName + ".schema").String()
 		}
 		if schemaDef == "" {
-			log.Warnf("schema validate faileded: schema not found, path: %s", "plugins."+pluginName)
-			return fmt.Errorf("schema validate faileded: schema not found, path: %s", "plugins."+pluginName)
+			log.Warnf("schema validate failed: schema not found, path: %s", "plugins."+pluginName)
+			return fmt.Errorf("schema validate failed: schema not found, path: %s", "plugins."+pluginName)
 		}
 
 		schemaDef = reg.ReplaceAllString(schemaDef, `"properties":{}`)
 		s, err := gojsonschema.NewSchema(gojsonschema.NewStringLoader(schemaDef))
 		if err != nil {
-			log.Warnf("init schema validate faileded: %w", err)
-			return fmt.Errorf("schema validate faileded: %w", err)
+			log.Warnf("init schema validate failed: %w", err)
+			return fmt.Errorf("schema validate failed: %w", err)
 		}
 
 		ret, err := s.Validate(gojsonschema.NewGoLoader(pluginConf))
 		if err != nil {
-			return fmt.Errorf("schema validate faileded: %w", err)
+			return fmt.Errorf("schema validate failed: %w", err)
 		}
 
 		if !ret.Valid() {
@@ -272,7 +272,7 @@ func (v *APISIXJsonSchemaValidator) Validate(obj interface{}) error {
 				}
 				errString.AppendString(vErr.String())
 			}
-			return fmt.Errorf("schema validate faileded: %s", errString.String())
+			return fmt.Errorf("schema validate failed: %s", errString.String())
 		}
 	}
 

--- a/api/internal/core/store/validate_test.go
+++ b/api/internal/core/store/validate_test.go
@@ -111,7 +111,7 @@ func TestAPISIXJsonSchemaValidator_Validate(t *testing.T) {
 
 	err = validator.Validate(consumer2)
 	assert.NotNil(t, err)
-	assert.EqualError(t, err, "schema validate failed: id: Must validate at least one schema (anyOf)\nid: String length must be greater than or equal to 1\nid: Does not match pattern '^[a-zA-Z0-9-_.]+$'")
+	assert.EqualError(t, err, "schema validate failed: id: Must validate at least one schema (anyOf)\nid: Invalid type. Expected: string, given: null")
 
 	//check nil obj
 	err = validator.Validate(nil)

--- a/api/internal/core/store/validate_test.go
+++ b/api/internal/core/store/validate_test.go
@@ -111,12 +111,12 @@ func TestAPISIXJsonSchemaValidator_Validate(t *testing.T) {
 
 	err = validator.Validate(consumer2)
 	assert.NotNil(t, err)
-	assert.EqualError(t, err, "scheme validate fail: id: Must validate at least one schema (anyOf)\nid: String length must be greater than or equal to 1\nid: Does not match pattern '^[a-zA-Z0-9-_.]+$'")
+	assert.EqualError(t, err, "schema validate failed: id: Must validate at least one schema (anyOf)\nid: String length must be greater than or equal to 1\nid: Does not match pattern '^[a-zA-Z0-9-_.]+$'")
 
 	//check nil obj
 	err = validator.Validate(nil)
 	assert.NotNil(t, err)
-	assert.EqualError(t, err, "scheme validate fail: (root): Invalid type. Expected: object, given: null")
+	assert.EqualError(t, err, "schema validate failed: (root): Invalid type. Expected: object, given: null")
 
 	//plugin schema fail
 	consumer3 := &entity.Consumer{}
@@ -136,7 +136,7 @@ func TestAPISIXJsonSchemaValidator_Validate(t *testing.T) {
 	assert.Nil(t, err)
 	err = validator.Validate(consumer3)
 	assert.NotNil(t, err)
-	assert.EqualError(t, err, "scheme validate failed: (root): count is required")
+	assert.EqualError(t, err, "schema validate faileded: (root): count is required")
 
 }
 
@@ -246,6 +246,6 @@ func TestAPISIXJsonSchemaValidator_checkUpstream(t *testing.T) {
 	assert.Nil(t, err)
 	err = validator.Validate(route5)
 	assert.NotNil(t, err)
-	assert.EqualError(t, err, "scheme validate failed: (root): Does not match pattern '^((uri|server_name|server_addr|request_uri|remote_port|remote_addr|query_string|host|hostname)|arg_[0-9a-zA-z_-]+)$'")
+	assert.EqualError(t, err, "schema validate faileded: (root): Does not match pattern '^((uri|server_name|server_addr|request_uri|remote_port|remote_addr|query_string|host|hostname)|arg_[0-9a-zA-z_-]+)$'")
 
 }

--- a/api/internal/core/store/validate_test.go
+++ b/api/internal/core/store/validate_test.go
@@ -136,7 +136,7 @@ func TestAPISIXJsonSchemaValidator_Validate(t *testing.T) {
 	assert.Nil(t, err)
 	err = validator.Validate(consumer3)
 	assert.NotNil(t, err)
-	assert.EqualError(t, err, "schema validate faileded: (root): count is required")
+	assert.EqualError(t, err, "schema validate failed: (root): count is required")
 
 }
 
@@ -246,6 +246,6 @@ func TestAPISIXJsonSchemaValidator_checkUpstream(t *testing.T) {
 	assert.Nil(t, err)
 	err = validator.Validate(route5)
 	assert.NotNil(t, err)
-	assert.EqualError(t, err, "schema validate faileded: (root): Does not match pattern '^((uri|server_name|server_addr|request_uri|remote_port|remote_addr|query_string|host|hostname)|arg_[0-9a-zA-z_-]+)$'")
+	assert.EqualError(t, err, "schema validate failed: (root): Does not match pattern '^((uri|server_name|server_addr|request_uri|remote_port|remote_addr|query_string|host|hostname)|arg_[0-9a-zA-z_-]+)$'")
 
 }

--- a/api/internal/handler/handler.go
+++ b/api/internal/handler/handler.go
@@ -38,7 +38,7 @@ func SpecCodeResponse(err error) *data.SpecCodeResponse {
 		strings.Contains(errMsg, "conflicted") ||
 		strings.Contains(errMsg, "invalid") ||
 		strings.Contains(errMsg, "missing") ||
-		strings.Contains(errMsg, "scheme validate fail") {
+		strings.Contains(errMsg, "schema validate failed") {
 		return &data.SpecCodeResponse{StatusCode: http.StatusBadRequest}
 	}
 


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance

- Related issues
fix  #914
typo:  `scheme validate fail` -> `schema validate failed`


