### PR TITLE
chore: fix typo, `MangerApiExpect` should be `ManagerApiExpect`

### DIFF
--- a/api/test/e2e/base.go
+++ b/api/test/e2e/base.go
@@ -83,7 +83,7 @@ func httpGet(url string) ([]byte, int, error) {
 	return body, resp.StatusCode, nil
 }
 
-func MangerApiExpect(t *testing.T) *httpexpect.Expect {
+func ManagerApiExpect(t *testing.T) *httpexpect.Expect {
 	return httpexpect.New(t, "http://127.0.0.1:8080")
 }
 

--- a/api/test/e2e/consumer_test.go
+++ b/api/test/e2e/consumer_test.go
@@ -25,7 +25,7 @@ func TestConsumer_with_key_auth(t *testing.T) {
 	tests := []HttpTestCase{
 		{
 			caseDesc: "create route",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/r1",
 			Body: `{
@@ -56,7 +56,7 @@ func TestConsumer_with_key_auth(t *testing.T) {
 		},
 		{
 			caseDesc: "create consumer",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Path:     "/apisix/admin/consumers",
 			Method:   http.MethodPut,
 			Body: `{
@@ -93,7 +93,7 @@ func TestConsumer_with_key_auth(t *testing.T) {
 		},
 		{
 			caseDesc:     "delete consumer",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodDelete,
 			Path:         "/apisix/admin/consumers/jack",
 			Headers:      map[string]string{"Authorization": token},
@@ -101,7 +101,7 @@ func TestConsumer_with_key_auth(t *testing.T) {
 		},
 		{
 			caseDesc:     "delete consumer (as delete not exist consumer)",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodDelete,
 			Path:         "/apisix/admin/consumers/jack",
 			Headers:      map[string]string{"Authorization": token},
@@ -119,7 +119,7 @@ func TestConsumer_with_key_auth(t *testing.T) {
 		},
 		{
 			caseDesc:     "delete route",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodDelete,
 			Path:         "/apisix/admin/routes/r1",
 			Headers:      map[string]string{"Authorization": token},

--- a/api/test/e2e/id_compatible_test.go
+++ b/api/test/e2e/id_compatible_test.go
@@ -25,7 +25,7 @@ func TestID_Using_Int(t *testing.T) {
 	tests := []HttpTestCase{
 		{
 			caseDesc: "create upstream",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/upstreams",
 			Body: `{
@@ -42,7 +42,7 @@ func TestID_Using_Int(t *testing.T) {
 		},
 		{
 			caseDesc: "create route using the upstream just created",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/1",
 			Body: `{
@@ -64,7 +64,7 @@ func TestID_Using_Int(t *testing.T) {
 		},
 		{
 			caseDesc: "create service",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/services",
 			Body: `{
@@ -76,7 +76,7 @@ func TestID_Using_Int(t *testing.T) {
 		},
 		{
 			caseDesc: "update route to use the service just created",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/1",
 			Body: `{
@@ -98,7 +98,7 @@ func TestID_Using_Int(t *testing.T) {
 		},
 		{
 			caseDesc:     "delete the route",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodDelete,
 			Path:         "/apisix/admin/routes/1",
 			Headers:      map[string]string{"Authorization": token},
@@ -106,7 +106,7 @@ func TestID_Using_Int(t *testing.T) {
 		},
 		{
 			caseDesc:     "delete the service",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodDelete,
 			Path:         "/apisix/admin/services/1",
 			Headers:      map[string]string{"Authorization": token},
@@ -115,7 +115,7 @@ func TestID_Using_Int(t *testing.T) {
 		},
 		{
 			caseDesc:     "make sure the service has been deleted",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodGet,
 			Path:         "/apisix/admin/services/1",
 			Headers:      map[string]string{"Authorization": token},
@@ -124,7 +124,7 @@ func TestID_Using_Int(t *testing.T) {
 		},
 		{
 			caseDesc:     "delete the upstream",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodDelete,
 			Path:         "/apisix/admin/upstreams/1",
 			Headers:      map[string]string{"Authorization": token},
@@ -132,7 +132,7 @@ func TestID_Using_Int(t *testing.T) {
 		},
 		{
 			caseDesc:     "make sure the upstream has been deleted",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodGet,
 			Path:         "/apisix/admin/upstreams/1",
 			Headers:      map[string]string{"Authorization": token},
@@ -158,7 +158,7 @@ func TestID_Using_String(t *testing.T) {
 	tests := []HttpTestCase{
 		{
 			caseDesc: "create upstream",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/upstreams",
 			Body: `{
@@ -175,7 +175,7 @@ func TestID_Using_String(t *testing.T) {
 		},
 		{
 			caseDesc: "create route using the upstream just created",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/2",
 			Body: `{
@@ -197,7 +197,7 @@ func TestID_Using_String(t *testing.T) {
 		},
 		{
 			caseDesc:     "delete the route",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodDelete,
 			Path:         "/apisix/admin/routes/2",
 			Headers:      map[string]string{"Authorization": token},
@@ -205,7 +205,7 @@ func TestID_Using_String(t *testing.T) {
 		},
 		{
 			caseDesc:     "delete the upstream",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodDelete,
 			Path:         "/apisix/admin/upstreams/2",
 			Headers:      map[string]string{"Authorization": token},
@@ -213,7 +213,7 @@ func TestID_Using_String(t *testing.T) {
 		},
 		{
 			caseDesc:     "make sure the upstream has been deleted",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodGet,
 			Path:         "/apisix/admin/upstreams/2",
 			Headers:      map[string]string{"Authorization": token},
@@ -269,7 +269,7 @@ func TestID_Crossing(t *testing.T) {
 		},
 		{
 			caseDesc:     "verify that the upstream is available for manager api",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodGet,
 			Path:         "/apisix/admin/upstreams/3",
 			Headers:      map[string]string{"Authorization": token},
@@ -279,7 +279,7 @@ func TestID_Crossing(t *testing.T) {
 		},
 		{
 			caseDesc:     "verify that the route is available for manager api",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodGet,
 			Path:         "/apisix/admin/routes/3",
 			Headers:      map[string]string{"Authorization": token},
@@ -298,7 +298,7 @@ func TestID_Crossing(t *testing.T) {
 		},
 		{
 			caseDesc:     "delete the route",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodDelete,
 			Path:         "/apisix/admin/routes/3",
 			Headers:      map[string]string{"Authorization": token},
@@ -306,7 +306,7 @@ func TestID_Crossing(t *testing.T) {
 		},
 		{
 			caseDesc:     "delete the upstream",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodDelete,
 			Path:         "/apisix/admin/upstreams/3",
 			Headers:      map[string]string{"Authorization": token},
@@ -314,7 +314,7 @@ func TestID_Crossing(t *testing.T) {
 		},
 		{
 			caseDesc:     "make sure the upstream has been deleted",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodGet,
 			Path:         "/apisix/admin/upstreams/3",
 			Headers:      map[string]string{"Authorization": token},

--- a/api/test/e2e/route_service_upstream_test.go
+++ b/api/test/e2e/route_service_upstream_test.go
@@ -61,7 +61,7 @@ func TestRoute_Invalid_Service_And_Service(t *testing.T) {
 	tests := []HttpTestCase{
 		{
 			caseDesc: "use service that not exist - dashboard",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/r1",
 			Body: `{
@@ -80,7 +80,7 @@ func TestRoute_Invalid_Service_And_Service(t *testing.T) {
 		},
 		{
 			caseDesc: "use upstream that not exist",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/r1",
 			Body: `{
@@ -99,7 +99,7 @@ func TestRoute_Invalid_Service_And_Service(t *testing.T) {
 		},
 		{
 			caseDesc: "create service and upstream together at the same time",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/r1",
 			Body: `{
@@ -127,7 +127,7 @@ func TestRoute_Create_Service(t *testing.T) {
 	tests := []HttpTestCase{
 		{
 			caseDesc: "create service",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/services/200",
 			Body: `{
@@ -157,7 +157,7 @@ func TestRoute_Create_Service(t *testing.T) {
 		},
 		{
 			caseDesc: "create route using the service just created",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/r2",
 			Body: `{
@@ -188,7 +188,7 @@ func TestRoute_Delete_Service(t *testing.T) {
 	tests := []HttpTestCase{
 		{
 			caseDesc:     "delete route",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodDelete,
 			Path:         "/apisix/admin/routes/r2",
 			Headers:      map[string]string{"Authorization": token},
@@ -196,7 +196,7 @@ func TestRoute_Delete_Service(t *testing.T) {
 		},
 		{
 			caseDesc:     "remove service",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodDelete,
 			Path:         "/apisix/admin/services/200",
 			Headers:      map[string]string{"Authorization": token},
@@ -219,7 +219,7 @@ func TestRoute_Create_Upstream(t *testing.T) {
 	tests := []HttpTestCase{
 		{
 			caseDesc: "create upstream",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/upstreams/1",
 			Body: `{
@@ -247,7 +247,7 @@ func TestRoute_Create_Upstream(t *testing.T) {
 		},
 		{
 			caseDesc: "create route using the upstream just created",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/r1",
 			Body: `{
@@ -278,7 +278,7 @@ func TestRoute_Delete_Upstream(t *testing.T) {
 	tests := []HttpTestCase{
 		{
 			caseDesc:     "delete route",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodDelete,
 			Path:         "/apisix/admin/routes/r1",
 			Headers:      map[string]string{"Authorization": token},
@@ -286,7 +286,7 @@ func TestRoute_Delete_Upstream(t *testing.T) {
 		},
 		{
 			caseDesc:     "remove upstream",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodDelete,
 			Path:         "/apisix/admin/upstreams/1",
 			Headers:      map[string]string{"Authorization": token},

--- a/api/test/e2e/route_test.go
+++ b/api/test/e2e/route_test.go
@@ -25,7 +25,7 @@ func TestRoute_Invalid_Host(t *testing.T) {
 	tests := []HttpTestCase{
 		{
 			caseDesc: "invalid host",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Path:     "/apisix/admin/routes/r1",
 			Method:   http.MethodPut,
 			Body: `{
@@ -43,7 +43,7 @@ func TestRoute_Invalid_Host(t *testing.T) {
 		},
 		{
 			caseDesc: "invalid hosts",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/r1",
 			Body: `{
@@ -61,7 +61,7 @@ func TestRoute_Invalid_Host(t *testing.T) {
 		},
 		{
 			caseDesc: "create route with host and hosts together at the same time",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/r1",
 			Body: `{
@@ -116,7 +116,7 @@ func TestRoute_Create_With_Hosts(t *testing.T) {
 		},
 		{
 			caseDesc: "create route",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/r1",
 			Body: `{
@@ -134,7 +134,7 @@ func TestRoute_Create_With_Hosts(t *testing.T) {
 		},
 		{
 			caseDesc: "create route with int uri",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/r1",
 			Body: `{
@@ -182,7 +182,7 @@ func TestRoute_Update_Routes_With_Hosts(t *testing.T) {
 	tests := []HttpTestCase{
 		{
 			caseDesc: "update route",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/r1",
 			Body: `{
@@ -228,7 +228,7 @@ func TestRoute_Delete_Routes_With_Hosts(t *testing.T) {
 	tests := []HttpTestCase{
 		{
 			caseDesc:     "delete route",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodDelete,
 			Path:         "/apisix/admin/routes/r1",
 			Headers:      map[string]string{"Authorization": token},
@@ -236,7 +236,7 @@ func TestRoute_Delete_Routes_With_Hosts(t *testing.T) {
 		},
 		{
 			caseDesc:     "delete not exist route",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodDelete,
 			Path:         "/apisix/admin/routes/not-exist",
 			Headers:      map[string]string{"Authorization": token},

--- a/api/test/e2e/route_with_auth_plugin_test.go
+++ b/api/test/e2e/route_with_auth_plugin_test.go
@@ -36,7 +36,7 @@ func TestRoute_With_Auth_Plugin(t *testing.T) {
 		},
 		{
 			caseDesc: "create route",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/r1",
 			Body: `{
@@ -59,7 +59,7 @@ func TestRoute_With_Auth_Plugin(t *testing.T) {
 		},
 		{
 			caseDesc:     "make sure the consumer is not created",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodGet,
 			Path:         "/apisix/admin/consumers/jack",
 			Headers:      map[string]string{"Authorization": token},
@@ -67,7 +67,7 @@ func TestRoute_With_Auth_Plugin(t *testing.T) {
 		},
 		{
 			caseDesc: "create consumer",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Path:     "/apisix/admin/consumers",
 			Method:   http.MethodPut,
 			Body: `{
@@ -134,7 +134,7 @@ func TestRoute_With_Auth_Plugin(t *testing.T) {
 		},
 		{
 			caseDesc:     "delete consumer",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodDelete,
 			Path:         "/apisix/admin/consumers/jack",
 			Headers:      map[string]string{"Authorization": token},
@@ -152,7 +152,7 @@ func TestRoute_With_Auth_Plugin(t *testing.T) {
 		},
 		{
 			caseDesc:     "delete route",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodDelete,
 			Path:         "/apisix/admin/routes/r1",
 			Headers:      map[string]string{"Authorization": token},

--- a/api/test/e2e/route_with_limit_plugin_test.go
+++ b/api/test/e2e/route_with_limit_plugin_test.go
@@ -34,7 +34,7 @@ func TestRoute_With_Limit_Plugin(t *testing.T) {
 		},
 		{
 			caseDesc: "create route",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/r1",
 			Body: `{
@@ -96,7 +96,7 @@ func TestRoute_With_Limit_Plugin(t *testing.T) {
 		},
 		{
 			caseDesc:     "delete route",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodDelete,
 			Path:         "/apisix/admin/routes/r1",
 			Headers:      map[string]string{"Authorization": token},
@@ -130,7 +130,7 @@ func TestRoute_With_Limit_Plugin_By_Consumer(t *testing.T) {
 		},
 		{
 			caseDesc: "create route",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/r1",
 			Body: `{
@@ -159,7 +159,7 @@ func TestRoute_With_Limit_Plugin_By_Consumer(t *testing.T) {
 		},
 		{
 			caseDesc:     "make sure the consumer is not created",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodGet,
 			Path:         "/apisix/admin/consumers/jack",
 			Headers:      map[string]string{"Authorization": token},
@@ -167,7 +167,7 @@ func TestRoute_With_Limit_Plugin_By_Consumer(t *testing.T) {
 		},
 		{
 			caseDesc: "create consumer",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Path:     "/apisix/admin/consumers",
 			Method:   http.MethodPut,
 			Body: `{
@@ -183,7 +183,7 @@ func TestRoute_With_Limit_Plugin_By_Consumer(t *testing.T) {
 		},
 		{
 			caseDesc: "create consumer 2",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Path:     "/apisix/admin/consumers",
 			Method:   http.MethodPut,
 			Body: `{
@@ -246,7 +246,7 @@ func TestRoute_With_Limit_Plugin_By_Consumer(t *testing.T) {
 		},
 		{
 			caseDesc:     "delete consumer pony",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodDelete,
 			Path:         "/apisix/admin/consumers/pony",
 			Headers:      map[string]string{"Authorization": token},
@@ -254,7 +254,7 @@ func TestRoute_With_Limit_Plugin_By_Consumer(t *testing.T) {
 		},
 		{
 			caseDesc:     "delete consumer jack",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodDelete,
 			Path:         "/apisix/admin/consumers/jack",
 			Headers:      map[string]string{"Authorization": token},
@@ -281,7 +281,7 @@ func TestRoute_With_Limit_Plugin_By_Consumer(t *testing.T) {
 		},
 		{
 			caseDesc:     "delete route",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodDelete,
 			Path:         "/apisix/admin/routes/r1",
 			Headers:      map[string]string{"Authorization": token},

--- a/api/test/e2e/route_with_log_plugin_test.go
+++ b/api/test/e2e/route_with_log_plugin_test.go
@@ -66,7 +66,7 @@ func TestRoute_With_Log_Plugin(t *testing.T) {
 		},
 		{
 			caseDesc: "create route",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/r1",
 			Body: `{
@@ -125,7 +125,7 @@ func TestRoute_With_Log_Plugin(t *testing.T) {
 	tests = []HttpTestCase{
 		{
 			caseDesc: "create route with wrong https endpoint",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/r2",
 			Body: `{
@@ -186,7 +186,7 @@ func TestRoute_With_Log_Plugin(t *testing.T) {
 	tests = []HttpTestCase{
 		{
 			caseDesc:     "delete route",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodDelete,
 			Path:         "/apisix/admin/routes/r1",
 			Headers:      map[string]string{"Authorization": token},
@@ -203,7 +203,7 @@ func TestRoute_With_Log_Plugin(t *testing.T) {
 		},
 		{
 			caseDesc:     "delete route 2",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodDelete,
 			Path:         "/apisix/admin/routes/r2",
 			Headers:      map[string]string{"Authorization": token},

--- a/api/test/e2e/route_with_methods_test.go
+++ b/api/test/e2e/route_with_methods_test.go
@@ -25,7 +25,7 @@ func TestRoute_with_methods(t *testing.T) {
 	tests := []HttpTestCase{
 		{
 			caseDesc: "add route with invalid method",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/r1",
 			Body: `{
@@ -54,7 +54,7 @@ func TestRoute_with_methods(t *testing.T) {
 		},
 		{
 			caseDesc: "add route with valid method",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/r1",
 			Body: `{
@@ -84,7 +84,7 @@ func TestRoute_with_methods(t *testing.T) {
 		},
 		{
 			caseDesc:     "delete route",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodDelete,
 			Path:         "/apisix/admin/routes/r1",
 			Headers:      map[string]string{"Authorization": token},
@@ -92,7 +92,7 @@ func TestRoute_with_methods(t *testing.T) {
 		},
 		{
 			caseDesc: "add route with valid methods",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/r1",
 			Body: `{
@@ -165,7 +165,7 @@ func TestRoute_with_methods(t *testing.T) {
 		},
 		{
 			caseDesc:     "delete route",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodDelete,
 			Path:         "/apisix/admin/routes/r1",
 			Headers:      map[string]string{"Authorization": token},
@@ -173,7 +173,7 @@ func TestRoute_with_methods(t *testing.T) {
 		},
 		{
 			caseDesc: "add route with lower case methods",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/r1",
 			Body: `{
@@ -202,7 +202,7 @@ func TestRoute_with_methods(t *testing.T) {
 		},
 		{
 			caseDesc: "add route with methods GET",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/r1",
 			Body: `{
@@ -242,7 +242,7 @@ func TestRoute_with_methods(t *testing.T) {
 		},
 		{
 			caseDesc: "update route methods to POST",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/r1",
 			Body: `{
@@ -282,7 +282,7 @@ func TestRoute_with_methods(t *testing.T) {
 		},
 		{
 			caseDesc:     "delete route",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodDelete,
 			Path:         "/apisix/admin/routes/r1",
 			Headers:      map[string]string{"Authorization": token},

--- a/api/test/e2e/route_with_metric_plugin_test.go
+++ b/api/test/e2e/route_with_metric_plugin_test.go
@@ -33,7 +33,7 @@ func TestRoute_With_Plugin_Prometheus(t *testing.T) {
 		},
 		{
 			caseDesc: "create route",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/r1",
 			Body: `{
@@ -72,7 +72,7 @@ func TestRoute_With_Plugin_Prometheus(t *testing.T) {
 		},
 		{
 			caseDesc: "create route that uri not exists in upstream",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/r1",
 			Body: `{
@@ -120,7 +120,7 @@ func TestRoute_With_Plugin_Prometheus(t *testing.T) {
 		},
 		{
 			caseDesc:     "delete route",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodDelete,
 			Path:         "/apisix/admin/routes/r1",
 			Headers:      map[string]string{"Authorization": token},

--- a/api/test/e2e/route_with_plugin_orchestration_test.go
+++ b/api/test/e2e/route_with_plugin_orchestration_test.go
@@ -45,7 +45,7 @@ func TestRoute_With_Plugin_Orchestration(t *testing.T) {
 		},
 		{
 			caseDesc:     "create route with invalid dag config",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodPut,
 			Path:         "/apisix/admin/routes/r1",
 			Body:         invalidDagConf,
@@ -63,7 +63,7 @@ func TestRoute_With_Plugin_Orchestration(t *testing.T) {
 		},
 		{
 			caseDesc:     "create route with correct dag config",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodPut,
 			Path:         "/apisix/admin/routes/r1",
 			Body:         dagConf,
@@ -90,7 +90,7 @@ func TestRoute_With_Plugin_Orchestration(t *testing.T) {
 		},
 		{
 			caseDesc:     "delete route",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodDelete,
 			Path:         "/apisix/admin/routes/r1",
 			Headers:      map[string]string{"Authorization": token},

--- a/api/test/e2e/route_with_plugin_proxy_rewrite_test.go
+++ b/api/test/e2e/route_with_plugin_proxy_rewrite_test.go
@@ -33,7 +33,7 @@ func TestRoute_With_Plugin_Proxy_Rewrite(t *testing.T) {
 		},
 		{
 			caseDesc: "create route that will rewrite host and uri",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/r1",
 			Body: `{
@@ -67,7 +67,7 @@ func TestRoute_With_Plugin_Proxy_Rewrite(t *testing.T) {
 		},
 		{
 			caseDesc: "update route that will rewrite headers",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/r1",
 			Body: `{
@@ -104,7 +104,7 @@ func TestRoute_With_Plugin_Proxy_Rewrite(t *testing.T) {
 		},
 		{
 			caseDesc: "update route using regex_uri",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/r1",
 			Body: `{
@@ -137,7 +137,7 @@ func TestRoute_With_Plugin_Proxy_Rewrite(t *testing.T) {
 		},
 		{
 			caseDesc: "update route that will rewrite args",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/r1",
 			Body: `{
@@ -171,7 +171,7 @@ func TestRoute_With_Plugin_Proxy_Rewrite(t *testing.T) {
 		},
 		{
 			caseDesc:     "delete route",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodDelete,
 			Path:         "/apisix/admin/routes/r1",
 			Headers:      map[string]string{"Authorization": token},

--- a/api/test/e2e/route_with_trace_plugin_test.go
+++ b/api/test/e2e/route_with_trace_plugin_test.go
@@ -36,7 +36,7 @@ func TestRoute_With_Plugin_Skywalking(t *testing.T) {
 		},
 		{
 			caseDesc: "create route",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/r1",
 			Body: `{
@@ -86,7 +86,7 @@ func TestRoute_With_Plugin_Skywalking(t *testing.T) {
 	tests = []HttpTestCase{
 		{
 			caseDesc: "update route to change sample ratio",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/r1",
 			Body: `{
@@ -136,7 +136,7 @@ func TestRoute_With_Plugin_Skywalking(t *testing.T) {
 	tests = []HttpTestCase{
 		{
 			caseDesc:     "delete route",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodDelete,
 			Path:         "/apisix/admin/routes/r1",
 			Headers:      map[string]string{"Authorization": token},

--- a/api/test/e2e/route_with_uri_uris_test.go
+++ b/api/test/e2e/route_with_uri_uris_test.go
@@ -25,7 +25,7 @@ func TestRoute_with_valid_uri_uris(t *testing.T) {
 	tests := []HttpTestCase{
 		{
 			caseDesc: "add route with valid uri",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/r1",
 			Body: `{
@@ -54,7 +54,7 @@ func TestRoute_with_valid_uri_uris(t *testing.T) {
 		},
 		{
 			caseDesc:     "delete the route (r1)",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodDelete,
 			Path:         "/apisix/admin/routes/r1",
 			Headers:      map[string]string{"Authorization": token},
@@ -63,7 +63,7 @@ func TestRoute_with_valid_uri_uris(t *testing.T) {
 		},
 		{
 			caseDesc: "add route with valid uris",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/r1",
 			Body: `{
@@ -102,7 +102,7 @@ func TestRoute_with_valid_uri_uris(t *testing.T) {
 		},
 		{
 			caseDesc:     "delete the route (r1)",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodDelete,
 			Path:         "/apisix/admin/routes/r1",
 			Headers:      map[string]string{"Authorization": token},

--- a/api/test/e2e/route_with_valid_remote_addr_test.go
+++ b/api/test/e2e/route_with_valid_remote_addr_test.go
@@ -25,7 +25,7 @@ func TestRoute_with_valid_remote_addr(t *testing.T) {
 	tests := []HttpTestCase{
 		{
 			caseDesc: "add route with valid remote_addr",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/r1",
 			Body: `{
@@ -55,7 +55,7 @@ func TestRoute_with_valid_remote_addr(t *testing.T) {
 		},
 		{
 			caseDesc: "update route with valid remote_addr (CIDR)",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/r1",
 			Body: `{
@@ -85,7 +85,7 @@ func TestRoute_with_valid_remote_addr(t *testing.T) {
 		},
 		{
 			caseDesc: "update route with valid remote_addrs",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/r1",
 			Body: `{
@@ -115,7 +115,7 @@ func TestRoute_with_valid_remote_addr(t *testing.T) {
 		},
 		{
 			caseDesc: "update remote_addr to not be hit",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/r1",
 			Body: `{
@@ -144,7 +144,7 @@ func TestRoute_with_valid_remote_addr(t *testing.T) {
 		},
 		{
 			caseDesc: "update remote_addrs to not be hit",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/r1",
 			Body: `{
@@ -173,7 +173,7 @@ func TestRoute_with_valid_remote_addr(t *testing.T) {
 		},
 		{
 			caseDesc:     "delete route",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodDelete,
 			Path:         "/apisix/admin/routes/r1",
 			Headers:      map[string]string{"Authorization": token},

--- a/api/test/e2e/route_with_vars_test.go
+++ b/api/test/e2e/route_with_vars_test.go
@@ -25,7 +25,7 @@ func TestRoute_with_vars(t *testing.T) {
 	tests := []HttpTestCase{
 		{
 			caseDesc: "add route with vars (args)",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/r1",
 			Body: `{
@@ -77,7 +77,7 @@ func TestRoute_with_vars(t *testing.T) {
 
 		{
 			caseDesc: "update route with vars (header)",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/r1",
 			Body: `{
@@ -129,7 +129,7 @@ func TestRoute_with_vars(t *testing.T) {
 
 		{
 			caseDesc: "update route with vars (cookie)",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/r1",
 			Body: `{
@@ -181,7 +181,7 @@ func TestRoute_with_vars(t *testing.T) {
 
 		{
 			caseDesc:     "delete route",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodDelete,
 			Path:         "/apisix/admin/routes/r1",
 			Headers:      map[string]string{"Authorization": token},
@@ -191,7 +191,7 @@ func TestRoute_with_vars(t *testing.T) {
 
 		{
 			caseDesc: "add route with multiple vars (args, cookie and header)",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/r1",
 			Body: `{
@@ -259,7 +259,7 @@ func TestRoute_with_vars(t *testing.T) {
 
 		{
 			caseDesc:     "delete route",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodDelete,
 			Path:         "/apisix/admin/routes/r1",
 			Headers:      map[string]string{"Authorization": token},
@@ -269,7 +269,7 @@ func TestRoute_with_vars(t *testing.T) {
 
 		{
 			caseDesc: "add route with vars (args is digital)",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/r1",
 			Body: `{
@@ -302,7 +302,7 @@ func TestRoute_with_vars(t *testing.T) {
 
 		{
 			caseDesc:     "delete the route with vars (args is digital)",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodDelete,
 			Path:         "/apisix/admin/routes/r1",
 			Headers:      map[string]string{"Authorization": token},

--- a/api/test/e2e/ssl_test.go
+++ b/api/test/e2e/ssl_test.go
@@ -67,7 +67,7 @@ func TestSSL_Basic(t *testing.T) {
 	tests := []HttpTestCase{
 		{
 			caseDesc:     "create ssl fail - key and cert not match",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodPost,
 			Path:         "/apisix/admin/ssl",
 			Body:         string(invalidBody),
@@ -76,7 +76,7 @@ func TestSSL_Basic(t *testing.T) {
 		},
 		{
 			caseDesc:     "create ssl successfully",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodPost,
 			Path:         "/apisix/admin/ssl",
 			Body:         string(body),
@@ -85,7 +85,7 @@ func TestSSL_Basic(t *testing.T) {
 		},
 		{
 			caseDesc: "create route",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/r1",
 			Body: `{
@@ -113,7 +113,7 @@ func TestSSL_Basic(t *testing.T) {
 		},
 		{
 			caseDesc:     "delete ssl",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodDelete,
 			Path:         "/apisix/admin/ssl/1",
 			Headers:      map[string]string{"Authorization": token},
@@ -135,7 +135,7 @@ func TestSSL_Basic(t *testing.T) {
 	// clean test data
 	delRoute := HttpTestCase{
 		caseDesc:     "delete route",
-		Object:       MangerApiExpect(t),
+		Object:       ManagerApiExpect(t),
 		Method:       http.MethodDelete,
 		Path:         "/apisix/admin/routes/r1",
 		Headers:      map[string]string{"Authorization": token},

--- a/api/test/e2e/upstream_test.go
+++ b/api/test/e2e/upstream_test.go
@@ -25,7 +25,7 @@ func TestUpstream_Create(t *testing.T) {
 	tests := []HttpTestCase{
 		{
 			caseDesc: "use upstream that not exist",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/r1",
 			Body: `{
@@ -37,7 +37,7 @@ func TestUpstream_Create(t *testing.T) {
 		},
 		{
 			caseDesc: "create upstream",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/upstreams/1",
 			Body: `{
@@ -53,7 +53,7 @@ func TestUpstream_Create(t *testing.T) {
 		},
 		{
 			caseDesc: "create route using the upstream just created",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/1",
 			Body: `{
@@ -84,7 +84,7 @@ func TestUpstream_Update(t *testing.T) {
 	tests := []HttpTestCase{
 		{
 			caseDesc: "update upstream with domain",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/upstreams/1",
 			Body: `{
@@ -118,7 +118,7 @@ func TestRoute_Node_Host(t *testing.T) {
 	tests := []HttpTestCase{
 		{
 			caseDesc: "update upstream - pass host: node",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/upstreams/1",
 			Body: `{
@@ -135,7 +135,7 @@ func TestRoute_Node_Host(t *testing.T) {
 		},
 		{
 			caseDesc: "update path for route",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/routes/1",
 			Body: `{
@@ -156,7 +156,7 @@ func TestRoute_Node_Host(t *testing.T) {
 		},
 		{
 			caseDesc: "update upstream - pass host: rewrite",
-			Object:   MangerApiExpect(t),
+			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
 			Path:     "/apisix/admin/upstreams/1",
 			Body: `{
@@ -195,7 +195,7 @@ func TestRoute_Delete(t *testing.T) {
 	tests := []HttpTestCase{
 		{
 			caseDesc:     "delete not exist upstream",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodDelete,
 			Path:         "/apisix/admin/upstreams/not-exist",
 			Headers:      map[string]string{"Authorization": token},
@@ -204,7 +204,7 @@ func TestRoute_Delete(t *testing.T) {
 		// TODO it's a bug here, see: https://github.com/apache/apisix-dashboard/issues/728
 		//{
 		//	caseDesc:     "delete upstream - being used by route 1",
-		//	Object:       MangerApiExpect(t),
+		//	Object:       ManagerApiExpect(t),
 		//	Method:       http.MethodDelete,
 		//	Path:         "/apisix/admin/upstreams/1",
 		//	Headers:      map[string]string{"Authorization": token},
@@ -212,7 +212,7 @@ func TestRoute_Delete(t *testing.T) {
 		//},
 		{
 			caseDesc:     "delete route",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodDelete,
 			Path:         "/apisix/admin/routes/1",
 			Headers:      map[string]string{"Authorization": token},
@@ -220,7 +220,7 @@ func TestRoute_Delete(t *testing.T) {
 		},
 		{
 			caseDesc:     "delete upstream",
-			Object:       MangerApiExpect(t),
+			Object:       ManagerApiExpect(t),
 			Method:       http.MethodDelete,
 			Path:         "/apisix/admin/upstreams/1",
 			Headers:      map[string]string{"Authorization": token},


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance

fix typo, `MangerApiExpect` should be `ManagerApiExpect`

