### PR TITLE
fix: omit remote_addrs when users don't input it

### DIFF
--- a/web/src/pages/Route/transform.ts
+++ b/web/src/pages/Route/transform.ts
@@ -82,6 +82,7 @@ export const transformStepData = ({
       !Object.keys(step3DataCloned.script || {}).length ? 'script' : '',
       form1Data.hosts.filter(Boolean).length === 0 ? 'hosts' : '',
       form1Data.redirectOption === 'disabled' ? 'redirect' : '',
+      data.remote_addrs?.filter(Boolean).length === 0 ? 'remote_addrs' : '',
     ]);
   }
 
@@ -97,8 +98,8 @@ export const transformStepData = ({
     'redirect',
     'vars',
     'plugins',
-    'remote_addrs',
     form1Data.hosts.filter(Boolean).length !== 0 ? 'hosts' : '',
+    data.remote_addrs?.filter(Boolean).length !== 0 ? 'remote_addrs' : '',
   ]);
 };
 


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bugfix
- Description

remote_addrs should not be [""]

close #940 

- How to fix?

___
### New feature or improvement
- Describe the details and related test reports.
