### PR TITLE
ci: increase the sleep time to fix e2e test unstable issue

### DIFF
--- a/api/test/e2e/base.go
+++ b/api/test/e2e/base.go
@@ -115,7 +115,7 @@ func APISIXHTTPSExpect(t *testing.T) *httpexpect.Expect {
 	return e
 }
 
-var sleepTime = time.Duration(100) * time.Millisecond
+var sleepTime = time.Duration(300) * time.Millisecond
 
 type HttpTestCase struct {
 	caseDesc      string


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance


### Description

Under normal circumstances, after a short sleep, APISIX can synchronize the data from ETCD and works normally. 

But once there is network jitter, or the CPU who processing ETCD is just busy, or APISIX's watch is just timeout, the time required for synchronization will become longer. 

When the next request arrives, the data may not be synchronized to APISIX. 

So by increasing the sleep time, we could reduce the probability of failure and increase stability.



### Related issues
close #907
close #923
