### PR TITLE
fix: fix router name conflict in route_service_upstream_test.go

### DIFF
--- a/api/test/e2e/route_service_upstream_test.go
+++ b/api/test/e2e/route_service_upstream_test.go
@@ -126,6 +126,14 @@ func TestRoute_Invalid_Service_And_Service(t *testing.T) {
 func TestRoute_Create_Service(t *testing.T) {
 	tests := []HttpTestCase{
 		{
+			caseDesc:     "make sure the route has not created",
+			Object:       APISIXExpect(t),
+			Method:       http.MethodGet,
+			Path:         "/server_port",
+			ExpectStatus: http.StatusNotFound,
+			Sleep:        sleepTime,
+		},
+		{
 			caseDesc: "create service",
 			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
@@ -159,7 +167,7 @@ func TestRoute_Create_Service(t *testing.T) {
 			caseDesc: "create route using the service just created",
 			Object:   ManagerApiExpect(t),
 			Method:   http.MethodPut,
-			Path:     "/apisix/admin/routes/r2",
+			Path:     "/apisix/admin/routes/r1",
 			Body: `{
 				"uri": "/server_port",
 				"service_id": "200"
@@ -190,7 +198,7 @@ func TestRoute_Delete_Service(t *testing.T) {
 			caseDesc:     "delete route",
 			Object:       ManagerApiExpect(t),
 			Method:       http.MethodDelete,
-			Path:         "/apisix/admin/routes/r2",
+			Path:         "/apisix/admin/routes/r1",
 			Headers:      map[string]string{"Authorization": token},
 			ExpectStatus: http.StatusOK,
 		},
@@ -244,6 +252,14 @@ func TestRoute_Create_Upstream(t *testing.T) {
 			}`,
 			Headers:      map[string]string{"Authorization": token},
 			ExpectStatus: http.StatusOK,
+		},
+		{
+			caseDesc:     "make sure the route has not created",
+			Object:       APISIXExpect(t),
+			Method:       http.MethodGet,
+			Path:         "/server_port",
+			ExpectStatus: http.StatusNotFound,
+			Sleep:        sleepTime,
 		},
 		{
 			caseDesc: "create route using the upstream just created",

--- a/api/test/e2e/route_with_limit_plugin_test.go
+++ b/api/test/e2e/route_with_limit_plugin_test.go
@@ -92,7 +92,7 @@ func TestRoute_With_Limit_Plugin(t *testing.T) {
 			Path:         "/hello",
 			ExpectStatus: http.StatusOK,
 			ExpectBody:   "hello world",
-			Sleep:        2 * time.Second,
+			Sleep:        3 * time.Second,
 		},
 		{
 			caseDesc:     "delete route",


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

close #998 

___
### Bugfix
- Description

In `route_service_upstream_test.go`, r2 is used as the route ID. As a result, r1 and r2 may coexist, and the same uri is used, which may produce different results


- How to fix?

Route always use the same ID, and confirm that the uri has not been created before use

