### PR TITLE
fix: login bg displayed imcompletely

### DIFF
--- a/web/src/global.less
+++ b/web/src/global.less
@@ -20,6 +20,7 @@ html,
 body,
 #root {
   height: 100%;
+  background: @layout-body-background;
 }
 
 .colorWeak {

--- a/web/src/pages/User/Login.less
+++ b/web/src/pages/User/Login.less
@@ -20,7 +20,6 @@
   display: flex;
   flex-direction: column;
   overflow: auto;
-  background: @layout-body-background;
 }
 
 .lang {


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [ ] Bugfix
- [ ] New feature provided
- [ ] Improve performance


___
### Bugfix
- Description
current login page’s background(update dashboard to master) displayed imcompletely:

![2020-12-11 21-41-56屏幕截图](https://user-images.githubusercontent.com/2561857/101910580-17144800-3bfa-11eb-8848-7cd1c7f1a0ff.png)


- How to fix?

updated less files.

