### PR TITLE
feat(CI): add a GitHub Action to lint the Markdown

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,16 @@
+name: ❄️ Lint
+
+on: [pull_request]
+
+jobs:
+  markdownlint:
+    name: 🍇 Markdown
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: 🚀 Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - run: npm install -g markdownlint-cli@0.25.0
+      - run: markdownlint '**/*.md' --ignore node_modules

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,59 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+MD001: false
+MD002: false
+MD003: false
+MD004: false
+MD005: false
+MD006: false
+MD007: false
+MD009: false
+MD010: false
+MD011: false
+MD012: false
+MD013: false
+MD014: false
+MD018: false
+MD019: false
+MD020: false
+MD021: false
+MD022: false
+MD023: false
+MD024: false
+MD025: false
+MD026: false
+MD027: false
+MD028: false
+MD029: false
+MD030: false
+MD031: false
+MD032: false
+MD033: false
+MD034: false
+MD035: false
+MD036: false
+MD037: false
+MD040: false
+MD041: false
+MD042: false
+MD043: false
+MD044: false
+MD045: false
+MD046: false
+MD047: false
+MD048: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,7 +163,7 @@ Breaking Change section should start with the phrase "BREAKING CHANGE: " followe
 
 ### Revert commits
 
-If the commit reverts a previous commit, it should begin with `revert: `, followed by the header of the reverted commit.
+If the commit reverts a previous commit, it should begin with `revert:`, followed by the header of the reverted commit.
 
 The content of the commit message body should contain:
 


### PR DESCRIPTION
- Add a Markdownlint config file
- Lint Markdown for MD038/no-space-in-code Spaces inside code span elements

https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md#md038---spaces-inside-code-span-elements

Please answer these questions before submitting a pull request

- Why submit this pull request?
- [ ] Bugfix
- [X] New feature provided
- [ ] Improve performance

- Related issues

___
### Bugfix
- Description

- How to fix?

___
### New feature or improvement
Adding an npm based Markdown linter to standardize the code.
