### PR TITLE
fix: create_and_delete_route used wrong way to locate plugin button

### DIFF
--- a/web/cypress/integration/route/create_and_delete_route.spec.js
+++ b/web/cypress/integration/route/create_and_delete_route.spec.js
@@ -65,7 +65,9 @@ context('Create and Delete Route', () => {
     cy.contains('Next').click();
 
     // config prometheus plugin
-    cy.contains('.ant-card', 'prometheus').get('button').first().click();
+    cy.contains('.ant-card', 'prometheus').within(($form) => {
+      cy.get('button').first().click();
+    })
     cy.contains('button', 'Cancel').click();
 
     // go to step4


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] E2E
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bugfix
create_and_delete_route case used the wrong way to locate prometheus button
