### PR TITLE
fix: not allowed to specify `create_time` and `update_time` when create/edit route, service, upstream and consumer

### DIFF
--- a/api/filter/schema.go
+++ b/api/filter/schema.go
@@ -112,10 +112,10 @@ func handleSpecialField(resource string, reqBody []byte) ([]byte, error) {
 		return reqBody, fmt.Errorf("read request body failed: %s", err)
 	}
 	if _, ok := bodyMap["create_time"]; ok {
-		return reqBody, fmt.Errorf("not support specifying create_time")
+		return reqBody, fmt.Errorf("we don't accept create_time from client")
 	}
 	if _, ok := bodyMap["update_time"]; ok {
-		return reqBody, fmt.Errorf("not support specifying update_time")
+		return reqBody, fmt.Errorf("we don't accept update_time from client")
 	}
 
 	// remove script, because it's a map, and need to be parsed into lua code

--- a/api/filter/schema.go
+++ b/api/filter/schema.go
@@ -112,10 +112,10 @@ func handleSpecialField(resource string, reqBody []byte) ([]byte, error) {
 		return reqBody, fmt.Errorf("read request body failed: %s", err)
 	}
 	if _, ok := bodyMap["create_time"]; ok {
-		return reqBody, fmt.Errorf("we don't accept create_time from client")
+		return reqBody, errors.New("we don't accept create_time from client")
 	}
 	if _, ok := bodyMap["update_time"]; ok {
-		return reqBody, fmt.Errorf("we don't accept update_time from client")
+		return reqBody, errors.New("we don't accept update_time from client")
 	}
 
 	// remove script, because it's a map, and need to be parsed into lua code

--- a/api/filter/schema.go
+++ b/api/filter/schema.go
@@ -106,6 +106,18 @@ func parseCert(crt, key string) ([]string, error) {
 }
 
 func handleSpecialField(resource string, reqBody []byte) ([]byte, error) {
+	var bodyMap map[string]interface{}
+	err := json.Unmarshal(reqBody, &bodyMap)
+	if err != nil {
+		return reqBody, fmt.Errorf("read request body failed: %s", err)
+	}
+	if _, ok := bodyMap["create_time"]; ok {
+		return reqBody, fmt.Errorf("not support specifying create_time")
+	}
+	if _, ok := bodyMap["update_time"]; ok {
+		return reqBody, fmt.Errorf("not support specifying update_time")
+	}
+
 	// remove script, because it's a map, and need to be parsed into lua code
 	if resource == "routes" {
 		var route map[string]interface{}

--- a/api/test/e2e/route_with_management_fileds_test.go
+++ b/api/test/e2e/route_with_management_fileds_test.go
@@ -367,10 +367,10 @@ func TestRoute_search_by_label(t *testing.T) {
 func TestRoute_With_Create_Time(t *testing.T) {
 	tests := []HttpTestCase{
 		{
-			caseDesc: "create route with create_time",
-			Object:   ManagerApiExpect(t),
-			Path:     "/apisix/admin/routes/r1",
-			Method:   http.MethodPut,
+			Desc:   "create route with create_time",
+			Object: ManagerApiExpect(t),
+			Path:   "/apisix/admin/routes/r1",
+			Method: http.MethodPut,
 			Body: `{
 				"uri": "/hello",
 				"create_time": 1608792721,
@@ -385,10 +385,10 @@ func TestRoute_With_Create_Time(t *testing.T) {
 			ExpectStatus: http.StatusBadRequest,
 		},
 		{
-			caseDesc: "create route with update_time",
-			Object:   ManagerApiExpect(t),
-			Path:     "/apisix/admin/routes/r1",
-			Method:   http.MethodPut,
+			Desc:   "create route with update_time",
+			Object: ManagerApiExpect(t),
+			Path:   "/apisix/admin/routes/r1",
+			Method: http.MethodPut,
 			Body: `{
 				"uri": "/hello",
 				"update_time": 1608792721,
@@ -403,10 +403,10 @@ func TestRoute_With_Create_Time(t *testing.T) {
 			ExpectStatus: http.StatusBadRequest,
 		},
 		{
-			caseDesc: "create route with create_time and update_time",
-			Object:   ManagerApiExpect(t),
-			Path:     "/apisix/admin/routes/r1",
-			Method:   http.MethodPut,
+			Desc:   "create route with create_time and update_time",
+			Object: ManagerApiExpect(t),
+			Path:   "/apisix/admin/routes/r1",
+			Method: http.MethodPut,
 			Body: `{
 				"uri": "/hello",
 				"create_time": 1608792721,
@@ -422,7 +422,7 @@ func TestRoute_With_Create_Time(t *testing.T) {
 			ExpectStatus: http.StatusBadRequest,
 		},
 		{
-			caseDesc:     "make sure the route not created",
+			Desc:         "make sure the route not created",
 			Object:       APISIXExpect(t),
 			Method:       http.MethodGet,
 			Path:         "/hello",
@@ -432,6 +432,6 @@ func TestRoute_With_Create_Time(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		testCaseCheck(tc)
+		testCaseCheck(tc, t)
 	}
 }

--- a/api/test/e2e/route_with_management_fileds_test.go
+++ b/api/test/e2e/route_with_management_fileds_test.go
@@ -373,7 +373,7 @@ func TestRoute_With_Create_Time(t *testing.T) {
 			Method:   http.MethodPut,
 			Body: `{
 				"uri": "/hello",
-				"create_time": 1,
+				"create_time": 1608792721,
 				"upstream": {
 					"nodes": {
 						"172.16.238.20:1980": 1
@@ -391,7 +391,7 @@ func TestRoute_With_Create_Time(t *testing.T) {
 			Method:   http.MethodPut,
 			Body: `{
 				"uri": "/hello",
-				"update_time": 1,
+				"update_time": 1608792721,
 				"upstream": {
 					"nodes": {
 						"172.16.238.20:1980": 1
@@ -409,8 +409,8 @@ func TestRoute_With_Create_Time(t *testing.T) {
 			Method:   http.MethodPut,
 			Body: `{
 				"uri": "/hello",
-				"create_time": 1,
-				"update_time": 1,
+				"create_time": 1608792721,
+				"update_time": 1608792721,
 				"upstream": {
 					"nodes": {
 						"172.16.238.20:1980": 1

--- a/api/test/e2e/route_with_management_fileds_test.go
+++ b/api/test/e2e/route_with_management_fileds_test.go
@@ -363,3 +363,75 @@ func TestRoute_search_by_label(t *testing.T) {
 		testCaseCheck(tc)
 	}
 }
+
+func TestRoute_With_Create_Time(t *testing.T) {
+	tests := []HttpTestCase{
+		{
+			caseDesc: "create route with create_time",
+			Object:   ManagerApiExpect(t),
+			Path:     "/apisix/admin/routes/r1",
+			Method:   http.MethodPut,
+			Body: `{
+				"uri": "/hello",
+				"create_time": 1,
+				"upstream": {
+					"nodes": {
+						"172.16.238.20:1980": 1
+					},
+					"type": "roundrobin"
+				}
+			}`,
+			Headers:      map[string]string{"Authorization": token},
+			ExpectStatus: http.StatusBadRequest,
+		},
+		{
+			caseDesc: "create route with update_time",
+			Object:   ManagerApiExpect(t),
+			Path:     "/apisix/admin/routes/r1",
+			Method:   http.MethodPut,
+			Body: `{
+				"uri": "/hello",
+				"update_time": 1,
+				"upstream": {
+					"nodes": {
+						"172.16.238.20:1980": 1
+					},
+					"type": "roundrobin"
+				}
+			}`,
+			Headers:      map[string]string{"Authorization": token},
+			ExpectStatus: http.StatusBadRequest,
+		},
+		{
+			caseDesc: "create route with create_time and update_time",
+			Object:   ManagerApiExpect(t),
+			Path:     "/apisix/admin/routes/r1",
+			Method:   http.MethodPut,
+			Body: `{
+				"uri": "/hello",
+				"create_time": 1,
+				"update_time": 1,
+				"upstream": {
+					"nodes": {
+						"172.16.238.20:1980": 1
+					},
+					"type": "roundrobin"
+				}
+			}`,
+			Headers:      map[string]string{"Authorization": token},
+			ExpectStatus: http.StatusBadRequest,
+		},
+		{
+			caseDesc:     "make sure the route not created",
+			Object:       APISIXExpect(t),
+			Method:       http.MethodGet,
+			Path:         "/hello",
+			ExpectStatus: http.StatusNotFound,
+			ExpectBody:   `{"error_msg":"404 Route Not Found"}`,
+		},
+	}
+
+	for _, tc := range tests {
+		testCaseCheck(tc)
+	}
+}


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance

- Related issues
close #933


