### PR TITLE
fix: fetch code from master branch instead of v2.0 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 #
 FROM alpine:latest as pre-build
 
-ARG APISIX_DASHBOARD_VERSION=v2.0
+ARG APISIX_DASHBOARD_VERSION=master
 
 RUN set -x \
     && wget https://github.com/apache/apisix-dashboard/archive/${APISIX_DASHBOARD_VERSION}.tar.gz -O /tmp/apisix-dashboard.tar.gz \


### PR DESCRIPTION
Signed-off-by: imjoey <majunjiev@gmail.com>

Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

Related to  #1145 .

___
### Bugfix
- Description

For now, the `Dockerfile` in master branch fetches the codes from release `v2.0` for building docker images. This would lead to uses could not get the latest code for developing or testing. IMHO, the release tag could be used here only for the Dockerfile defined in tag `v2.0` or `v2.0` branch.

- How to fix?

This PR is going to set the variable `APISIX_DASHBOARD_VERSION ` to `master`, and then we can use the latest code from master branch, as expected.
