### PR TITLE
fix(cli): support running manager-api cmd in non-default diretory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ endif
 ### api-test:		Run the tests of manager-api
 .PHONY: api-test
 api-test: api-default
-	cd api/ && APISIX_API_WORKDIR=$$PWD go test -v -race -cover -coverprofile=coverage.txt -covermode=atomic ./...
+	cd api/ && APISIX_API_WORKDIR=$$PWD ENV=test go test -v -race -cover -coverprofile=coverage.txt -covermode=atomic ./...
 
 
 ### api-run:		Run the manager-api

--- a/api/cmd/managerapi.go
+++ b/api/cmd/managerapi.go
@@ -57,6 +57,7 @@ func NewManagerAPICommand() *cobra.Command {
 		Short: "APISIX Manager API",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			conf.InitConf()
+			log.InitLogger()
 			droplet.Option.Orchestrator = func(mws []droplet.Middleware) []droplet.Middleware {
 				var newMws []droplet.Middleware
 				// default middleware order: resp_reshape, auto_input, traffic_log

--- a/api/internal/conf/conf.go
+++ b/api/internal/conf/conf.go
@@ -100,11 +100,6 @@ type Config struct {
 	Authentication Authentication
 }
 
-// TODO: it is just for integration tests, we should call "InitLog" explicitly when remove all handler's integration tests
-func init() {
-	InitConf()
-}
-
 func InitConf() {
 	//go test
 	if workDir := os.Getenv("APISIX_API_WORKDIR"); workDir != "" {

--- a/api/internal/conf/conf.go
+++ b/api/internal/conf/conf.go
@@ -34,6 +34,7 @@ const (
 	EnvBETA  = "beta"
 	EnvDEV   = "dev"
 	EnvLOCAL = "local"
+	EnvTEST  = "test"
 
 	WebDir = "html/"
 )
@@ -98,6 +99,13 @@ type Authentication struct {
 type Config struct {
 	Conf           Conf
 	Authentication Authentication
+}
+
+// ENV=test is for integration tests only, other ENV should call "InitConf" explicitly
+func init() {
+	if env := os.Getenv("ENV"); env == EnvTEST {
+		InitConf()
+	}
 }
 
 func InitConf() {

--- a/api/internal/conf/conf.go
+++ b/api/internal/conf/conf.go
@@ -101,6 +101,7 @@ type Config struct {
 	Authentication Authentication
 }
 
+// TODO: we should no longer use init() function after remove all handler's integration tests
 // ENV=test is for integration tests only, other ENV should call "InitConf" explicitly
 func init() {
 	if env := os.Getenv("ENV"); env == EnvTEST {

--- a/api/internal/log/zap.go
+++ b/api/internal/log/zap.go
@@ -27,6 +27,7 @@ import (
 
 var logger *zap.SugaredLogger
 
+// TODO: we should no longer use init() function after remove all handler's integration tests
 // ENV=test is for integration tests only, other ENV should call "InitLogger" explicitly
 func init() {
 	if env := os.Getenv("ENV"); env == conf.EnvTEST {

--- a/api/internal/log/zap.go
+++ b/api/internal/log/zap.go
@@ -27,9 +27,17 @@ import (
 
 var logger *zap.SugaredLogger
 
+// ENV=test is for integration tests only, other ENV should call "InitLogger" explicitly
+func init() {
+	if env := os.Getenv("ENV"); env == conf.EnvTEST {
+		InitLogger()
+	}
+}
+
 func InitLogger() {
 	logger = GetLogger(ErrorLog)
 }
+
 func GetLogger(logType Type) *zap.SugaredLogger {
 	writeSyncer := fileWriter(logType)
 	encoder := getEncoder(logType)

--- a/api/internal/log/zap.go
+++ b/api/internal/log/zap.go
@@ -27,10 +27,6 @@ import (
 
 var logger *zap.SugaredLogger
 
-// TODO: it is just for integration tests, we should call "InitLog" explicitly when remove all handler's integration tests
-func init() {
-	InitLogger()
-}
 func InitLogger() {
 	logger = GetLogger(ErrorLog)
 }

--- a/api/test/shell/cli_test.sh
+++ b/api/test/shell/cli_test.sh
@@ -126,6 +126,28 @@ if [[ $res != "hi~" ]]; then
 fi
 clean_up
 
+# run with -p flag out of the default directory
+workDir=$(pwd)
+rm -fr bin && mkdir bin
+cp ./manager-api ./bin/
+rm -rf html && mkdir html
+cd html
+echo "hi~" >> index.html
+$workDir/bin/manager-api -p $workDir &
+sleep 5
+
+res=$(curl http://127.0.0.1:9000)
+pkill -f manager-api
+cd $workDir
+rm -rf bin
+rm -rf html
+
+if [[ $res != "hi~" ]]; then
+    echo "failed: manager-api can't run with -p flag out of the default directory"
+    exit 1
+fi
+clean_up
+
 # test start info
 
 LOGLEVEL=$(cat conf/conf.yaml | awk '$1=="level:"{print $2}')

--- a/api/test/shell/cli_test.sh
+++ b/api/test/shell/cli_test.sh
@@ -128,24 +128,23 @@ clean_up
 
 # run with -p flag out of the default directory
 workDir=$(pwd)
-rm -fr bin && mkdir bin
-cp ./manager-api ./bin/
-rm -rf html && mkdir html
-cd html
-echo "hi~" >> index.html
-$workDir/bin/manager-api -p $workDir &
+distDir=/tmp/manager-api
+cp -r $workDir $distDir
+cd $distDir
+rm -fr bin && mkdir bin && mv ./manager-api ./bin/
+rm -rf html && mkdir html && echo "hi~" >> html/index.html
+cd bin && ./manager-api -p $distDir &
 sleep 5
 
 res=$(curl http://127.0.0.1:9000)
 pkill -f manager-api
-cd $workDir
-rm -rf bin
-rm -rf html
+rm -fr $distDir
 
 if [[ $res != "hi~" ]]; then
     echo "failed: manager-api can't run with -p flag out of the default directory"
     exit 1
 fi
+cd $workDir
 clean_up
 
 # test start info


### PR DESCRIPTION
Signed-off-by: imjoey <majunjiev@gmail.com>

Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

Fixes #1147 .
___
### Bugfix
- Description

Running the prebuilt `manager-api` under non-default directory may lead to failed to start, see #1147 for details. This is mainly caused by the `-p` flag of `manager-api` is not worked as expected.

- How to fix?

Introduce a new value `test` for `ENV` environment to indicates the program is running a unit testing. If `ENV` is set to `test`, the original `init()` functions are retained, otherwise we explicitly calling `InitConf()` and `InitLogger()` functions to  initialization, right after receiving the input `WorkDir` parameter via `-p` flag. This would ensure configs and logger could be initialized just at the right time.

