### PR TITLE
fix: Remove update_time and create_time from ServerInfo entity

### DIFF
--- a/api/internal/core/entity/entity.go
+++ b/api/internal/core/entity/entity.go
@@ -242,11 +242,11 @@ type GlobalPlugins struct {
 }
 
 type ServerInfo struct {
-	BaseInfo
-	LastReportTime int64  `json:"last_report_time,omitempty"`
-	UpTime         int64  `json:"up_time,omitempty"`
-	BootTime       int64  `json:"boot_time,omitempty"`
-	EtcdVersion    string `json:"etcd_version,omitempty"`
-	Hostname       string `json:"hostname,omitempty"`
-	Version        string `json:"version,omitempty"`
+	ID             interface{} `json:"id"`
+	LastReportTime int64       `json:"last_report_time,omitempty"`
+	UpTime         int64       `json:"up_time,omitempty"`
+	BootTime       int64       `json:"boot_time,omitempty"`
+	EtcdVersion    string      `json:"etcd_version,omitempty"`
+	Hostname       string      `json:"hostname,omitempty"`
+	Version        string      `json:"version,omitempty"`
 }

--- a/api/internal/handler/server_info/server_info_test.go
+++ b/api/internal/handler/server_info/server_info_test.go
@@ -45,7 +45,7 @@ func TestHandler_Get(t *testing.T) {
 				caseDesc:  "get server_info",
 				giveInput: &GetInput{ID: "server_1"},
 				giveRet: &entity.ServerInfo{
-					BaseInfo:       entity.BaseInfo{ID: "server_1"},
+					ID:             "server_1",
 					UpTime:         10,
 					LastReportTime: 1608195454,
 					BootTime:       1608195454,
@@ -54,7 +54,7 @@ func TestHandler_Get(t *testing.T) {
 				},
 				wantGetKey: "server_1",
 				wantRet: &entity.ServerInfo{
-					BaseInfo:       entity.BaseInfo{ID: "server_1"},
+					ID:             "server_1",
 					UpTime:         10,
 					LastReportTime: 1608195454,
 					BootTime:       1608195454,
@@ -110,7 +110,7 @@ func TestHandler_List(t *testing.T) {
 				giveInput: &ListInput{Hostname: ""},
 				giveData: []interface{}{
 					&entity.ServerInfo{
-						BaseInfo:       entity.BaseInfo{ID: "server_1"},
+						ID:             "server_1",
 						UpTime:         10,
 						LastReportTime: 1608195454,
 						BootTime:       1608195454,
@@ -118,7 +118,7 @@ func TestHandler_List(t *testing.T) {
 						Version:        "v3",
 					},
 					&entity.ServerInfo{
-						BaseInfo:       entity.BaseInfo{ID: "server_2"},
+						ID:             "server_2",
 						UpTime:         10,
 						LastReportTime: 1608195454,
 						BootTime:       1608195454,
@@ -129,7 +129,7 @@ func TestHandler_List(t *testing.T) {
 				wantRet: &store.ListOutput{
 					Rows: []interface{}{
 						&entity.ServerInfo{
-							BaseInfo:       entity.BaseInfo{ID: "server_1"},
+							ID:             "server_1",
 							UpTime:         10,
 							LastReportTime: 1608195454,
 							BootTime:       1608195454,
@@ -137,7 +137,7 @@ func TestHandler_List(t *testing.T) {
 							Version:        "v3",
 						},
 						&entity.ServerInfo{
-							BaseInfo:       entity.BaseInfo{ID: "server_2"},
+							ID:             "server_2",
 							UpTime:         10,
 							LastReportTime: 1608195454,
 							BootTime:       1608195454,
@@ -153,7 +153,7 @@ func TestHandler_List(t *testing.T) {
 				giveInput: &ListInput{Hostname: "ubuntu"},
 				giveData: []interface{}{
 					&entity.ServerInfo{
-						BaseInfo:       entity.BaseInfo{ID: "server_1"},
+						ID:             "server_1",
 						UpTime:         10,
 						LastReportTime: 1608195454,
 						BootTime:       1608195454,
@@ -161,7 +161,7 @@ func TestHandler_List(t *testing.T) {
 						Version:        "v3",
 					},
 					&entity.ServerInfo{
-						BaseInfo:       entity.BaseInfo{ID: "server_2"},
+						ID:             "server_2",
 						UpTime:         10,
 						LastReportTime: 1608195454,
 						BootTime:       1608195454,
@@ -172,7 +172,7 @@ func TestHandler_List(t *testing.T) {
 				wantRet: &store.ListOutput{
 					Rows: []interface{}{
 						&entity.ServerInfo{
-							BaseInfo:       entity.BaseInfo{ID: "server_2"},
+							ID:             "server_2",
 							UpTime:         10,
 							LastReportTime: 1608195454,
 							BootTime:       1608195454,

--- a/api/test/e2e/base.go
+++ b/api/test/e2e/base.go
@@ -157,20 +157,21 @@ func BatchTestServerPort(t *testing.T, times int) map[string]int {
 var sleepTime = time.Duration(300) * time.Millisecond
 
 type HttpTestCase struct {
-	Desc          string
-	Object        *httpexpect.Expect
-	Method        string
-	Path          string
-	Query         string
-	Body          string
-	Headers       map[string]string
-	Headers_test  map[string]interface{}
-	ExpectStatus  int
-	ExpectCode    int
-	ExpectMessage string
-	ExpectBody    string
-	ExpectHeaders map[string]string
-	Sleep         time.Duration //ms
+	Desc           string
+	Object         *httpexpect.Expect
+	Method         string
+	Path           string
+	Query          string
+	Body           string
+	Headers        map[string]string
+	Headers_test   map[string]interface{}
+	ExpectStatus   int
+	ExpectCode     int
+	ExpectMessage  string
+	ExpectBody     string
+	UnexpectedBody string
+	ExpectHeaders  map[string]string
+	Sleep          time.Duration //ms
 }
 
 func testCaseCheck(tc HttpTestCase, t *testing.T) {
@@ -208,34 +209,40 @@ func testCaseCheck(tc HttpTestCase, t *testing.T) {
 			req.WithQueryString(tc.Query)
 		}
 
-		//set header
+		// set header
 		for key, val := range tc.Headers {
 			req.WithHeader(key, val)
 		}
 
-		//set body
+		// set body
 		if tc.Body != "" {
 			req.WithText(tc.Body)
 		}
 
-		//respond check
+		// respond check
 		resp := req.Expect()
 
-		//match http status
+		// match http status
 		if tc.ExpectStatus != 0 {
 			resp.Status(tc.ExpectStatus)
 		}
 
-		//match headers
+		// match headers
 		if tc.ExpectHeaders != nil {
 			for key, val := range tc.ExpectHeaders {
 				resp.Header(key).Equal(val)
 			}
 		}
 
-		//match body
+		// match body
 		if tc.ExpectBody != "" {
 			resp.Body().Contains(tc.ExpectBody)
 		}
+
+		// match UnexpectedBody
+		if tc.UnexpectedBody != "" {
+			resp.Body().NotContains(tc.UnexpectedBody)
+		}
+
 	})
 }

--- a/api/test/e2e/server_info_test.go
+++ b/api/test/e2e/server_info_test.go
@@ -88,3 +88,62 @@ func TestServerInfo_List(t *testing.T) {
 		testCaseCheck(tc, t)
 	}
 }
+
+func TestServerInfo_Get_OmitEmpty(t *testing.T) {
+	// wait for apisix report
+	time.Sleep(2 * time.Second)
+	testCases := []HttpTestCase{
+		{
+			Desc:           "get server info",
+			Object:         ManagerApiExpect(t),
+			Path:           "/apisix/admin/server_info/apisix-server1",
+			Method:         http.MethodGet,
+			Headers:        map[string]string{"Authorization": token},
+			ExpectStatus:   http.StatusOK,
+			UnexpectedBody: "\"create_time\":",
+		},
+		{
+			Desc:           "get server info",
+			Object:         ManagerApiExpect(t),
+			Path:           "/apisix/admin/server_info/apisix-server1",
+			Method:         http.MethodGet,
+			Headers:        map[string]string{"Authorization": token},
+			ExpectStatus:   http.StatusOK,
+			UnexpectedBody: "\"update_time\":",
+		},
+	}
+
+	for _, tc := range testCases {
+		testCaseCheck(tc, t)
+	}
+}
+
+func TestServerInfo_List_OmitEmpty(t *testing.T) {
+	testCases := []HttpTestCase{
+		{
+			Desc:           "list all server info",
+			Object:         ManagerApiExpect(t),
+			Path:           "/apisix/admin/server_info",
+			Method:         http.MethodGet,
+			Headers:        map[string]string{"Authorization": token},
+			ExpectStatus:   http.StatusOK,
+			ExpectBody:     "\"total_size\":2",
+			UnexpectedBody: "\"create_time\":",
+		},
+		{
+			Desc:           "list server info with hostname",
+			Object:         ManagerApiExpect(t),
+			Path:           "/apisix/admin/server_info",
+			Query:          "hostname=apisix_",
+			Method:         http.MethodGet,
+			Headers:        map[string]string{"Authorization": token},
+			ExpectStatus:   http.StatusOK,
+			ExpectBody:     "\"total_size\":2",
+			UnexpectedBody: "\"update_time\":",
+		},
+	}
+
+	for _, tc := range testCases {
+		testCaseCheck(tc, t)
+	}
+}


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

Fixes #1176 .
___
### Bugfix
- Description

The empty values of `create_time` and `update_time` should not be returned from server_info interface provided by manager-api . Please see #1176 for details.

- How to fix?

This PR is going to set `create_time` and `update_time` as `omitempty` to disable JSON serialization when returning back to frontend. In addition, adding the relevant test case for changes.

