### PR TITLE
fix: Support version/githash for make api-run command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,8 @@ api-test: api-default
 ### api-run:		Run the manager-api
 .PHONY: api-run
 api-run: api-default
-	cd api/ && go run ./cmd/manager
+	api/build.sh --dry-run
+
 
 ### api-stop:		Stop the manager-api
 api-stop:


### PR DESCRIPTION
Signed-off-by: imjoey <majunjiev@gmail.com>

Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

Fixes #1185 .

___
### Bugfix
- Description

As described in #1185 , currently running `make api-run` cannot show out the relevant `Version` and `GitHash` details. The reason is not setting `-ldflags` for `go run` command.

- How to fix?

This PR is going to add missing output values for `api-run`, via running an enhance version of `api/build.sh`. The new build script could support the dry-run mode with simply running `go run` command.

