### PR TITLE
fix: Set create_time/update_time as omitempty

### DIFF
--- a/api/internal/core/entity/entity.go
+++ b/api/internal/core/entity/entity.go
@@ -25,8 +25,8 @@ import (
 
 type BaseInfo struct {
 	ID         interface{} `json:"id"`
-	CreateTime int64       `json:"create_time"`
-	UpdateTime int64       `json:"update_time"`
+	CreateTime int64       `json:"create_time,omitempty"`
+	UpdateTime int64       `json:"update_time,omitempty"`
 }
 
 func (info *BaseInfo) GetBaseInfo() *BaseInfo {

--- a/api/test/e2e/base.go
+++ b/api/test/e2e/base.go
@@ -157,20 +157,21 @@ func BatchTestServerPort(t *testing.T, times int) map[string]int {
 var sleepTime = time.Duration(300) * time.Millisecond
 
 type HttpTestCase struct {
-	Desc          string
-	Object        *httpexpect.Expect
-	Method        string
-	Path          string
-	Query         string
-	Body          string
-	Headers       map[string]string
-	Headers_test  map[string]interface{}
-	ExpectStatus  int
-	ExpectCode    int
-	ExpectMessage string
-	ExpectBody    string
-	ExpectHeaders map[string]string
-	Sleep         time.Duration //ms
+	Desc           string
+	Object         *httpexpect.Expect
+	Method         string
+	Path           string
+	Query          string
+	Body           string
+	Headers        map[string]string
+	Headers_test   map[string]interface{}
+	ExpectStatus   int
+	ExpectCode     int
+	ExpectMessage  string
+	ExpectBody     string
+	UnexpectedBody string
+	ExpectHeaders  map[string]string
+	Sleep          time.Duration //ms
 }
 
 func testCaseCheck(tc HttpTestCase, t *testing.T) {
@@ -208,34 +209,40 @@ func testCaseCheck(tc HttpTestCase, t *testing.T) {
 			req.WithQueryString(tc.Query)
 		}
 
-		//set header
+		// set header
 		for key, val := range tc.Headers {
 			req.WithHeader(key, val)
 		}
 
-		//set body
+		// set body
 		if tc.Body != "" {
 			req.WithText(tc.Body)
 		}
 
-		//respond check
+		// respond check
 		resp := req.Expect()
 
-		//match http status
+		// match http status
 		if tc.ExpectStatus != 0 {
 			resp.Status(tc.ExpectStatus)
 		}
 
-		//match headers
+		// match headers
 		if tc.ExpectHeaders != nil {
 			for key, val := range tc.ExpectHeaders {
 				resp.Header(key).Equal(val)
 			}
 		}
 
-		//match body
+		// match body
 		if tc.ExpectBody != "" {
 			resp.Body().Contains(tc.ExpectBody)
 		}
+
+		// match UnexpectedBody
+		if tc.UnexpectedBody != "" {
+			resp.Body().NotContains(tc.UnexpectedBody)
+		}
+
 	})
 }

--- a/api/test/e2e/server_info_test.go
+++ b/api/test/e2e/server_info_test.go
@@ -88,3 +88,62 @@ func TestServerInfo_List(t *testing.T) {
 		testCaseCheck(tc, t)
 	}
 }
+
+func TestServerInfo_Get_OmitEmptyValue(t *testing.T) {
+	// wait for apisix report
+	time.Sleep(2 * time.Second)
+	testCases := []HttpTestCase{
+		{
+			Desc:           "get server info",
+			Object:         ManagerApiExpect(t),
+			Path:           "/apisix/admin/server_info/apisix-server1",
+			Method:         http.MethodGet,
+			Headers:        map[string]string{"Authorization": token},
+			ExpectStatus:   http.StatusOK,
+			UnexpectedBody: "\"create_time\":",
+		},
+		{
+			Desc:           "get server info",
+			Object:         ManagerApiExpect(t),
+			Path:           "/apisix/admin/server_info/apisix-server1",
+			Method:         http.MethodGet,
+			Headers:        map[string]string{"Authorization": token},
+			ExpectStatus:   http.StatusOK,
+			UnexpectedBody: "\"update_time\":",
+		},
+	}
+
+	for _, tc := range testCases {
+		testCaseCheck(tc, t)
+	}
+}
+
+func TestServerInfo_List_OmitEmptyValue(t *testing.T) {
+	testCases := []HttpTestCase{
+		{
+			Desc:           "list all server info",
+			Object:         ManagerApiExpect(t),
+			Path:           "/apisix/admin/server_info",
+			Method:         http.MethodGet,
+			Headers:        map[string]string{"Authorization": token},
+			ExpectStatus:   http.StatusOK,
+			ExpectBody:     "\"total_size\":2",
+			UnexpectedBody: "\"create_time\":",
+		},
+		{
+			Desc:           "list server info with hostname",
+			Object:         ManagerApiExpect(t),
+			Path:           "/apisix/admin/server_info",
+			Query:          "hostname=apisix_",
+			Method:         http.MethodGet,
+			Headers:        map[string]string{"Authorization": token},
+			ExpectStatus:   http.StatusOK,
+			ExpectBody:     "\"total_size\":2",
+			UnexpectedBody: "\"update_time\":",
+		},
+	}
+
+	for _, tc := range testCases {
+		testCaseCheck(tc, t)
+	}
+}


### PR DESCRIPTION
Signed-off-by: imjoey <majunjiev@gmail.com>

Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

Fixes #1176 .

___
### Bugfix
- Description

The empty values of `create_time` and `update_time` should not be returned from server_info interface provided by manager-api . Please see #1176 for details.

**Note**:

This PR was previously proposed in #1192 , I could not be able to reopen that PR due to my fault operation after closed it. @nic-chen @liuxiran left their opinions, pls see https://github.com/apache/apisix-dashboard/pull/1192#issuecomment-753858234 and https://github.com/apache/apisix-dashboard/pull/1192#issuecomment-753972035 . 

Firstly I agreed with @nic-chen and @liuxiran for their perfect solutions for all entities. While after some digs, the perfect solution would bring significant changes to refactor the `BaseInfo` in entities ( see https://github.com/apache/apisix-dashboard/pull/1192#issuecomment-754056423 ). IMHO, in order to fix #1176 , this PR could also bring an elegant, effective and maintainable way with relatively less cost.

@nic-chen @liuxiran , please allow me to reopen this PR to ask for more opinions 😄 , in order to have #1176 fixed in v2.3 release.

@membphis @tokers @ShiningRush  @juzhiyuan could you pls leave your comments at your convenience. Much appreciated.

- How to fix?

This PR is going to set `create_time` and `update_time` as `omitempty` to disable JSON serialization when returning back to frontend. In addition, adding the relevant test case for changes.
