### PR TITLE
fix: well handle with malformed auth token in request header (#1206)

### DIFF
--- a/api/internal/filter/authentication.go
+++ b/api/internal/filter/authentication.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/dgrijalva/jwt-go"
 	"github.com/gin-gonic/gin"
+
 	"github.com/apisix/manager-api/internal/conf"
 	"github.com/apisix/manager-api/internal/log"
 )
@@ -41,8 +42,8 @@ func Authentication() gin.HandlerFunc {
 				"message": "Request Unauthorized",
 			}
 
-			if err != nil || !token.Valid {
-				log.Warnf("token validate failed: %s, %v", err, token.Valid)
+			if err != nil || token == nil || !token.Valid {
+				log.Warnf("token validate failed: %s", err)
 				c.AbortWithStatusJSON(http.StatusUnauthorized, errResp)
 				return
 			}

--- a/api/test/e2e/authentication_test.go
+++ b/api/test/e2e/authentication_test.go
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package e2e
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestAuthentication_token(t *testing.T) {
+	tests := []HttpTestCase{
+		{
+			Desc:         "Access with valid authentication token",
+			Object:       ManagerApiExpect(t),
+			Method:       http.MethodGet,
+			Path:         "/apisix/admin/routes",
+			Headers:      map[string]string{"Authorization": token},
+			ExpectStatus: http.StatusOK,
+		},
+		{
+			Desc:         "Access with malformed authentication token",
+			Object:       ManagerApiExpect(t),
+			Method:       http.MethodGet,
+			Path:         "/apisix/admin/routes",
+			Headers:      map[string]string{"Authorization": "Not-A-Valid-Token"},
+			ExpectStatus: http.StatusUnauthorized,
+			ExpectBody:   "\"message\":\"Request Unauthorized\"",
+		},
+		{
+			Desc:         "Access without authentication token",
+			Object:       ManagerApiExpect(t),
+			Method:       http.MethodGet,
+			Path:         "/apisix/admin/routes",
+			ExpectStatus: http.StatusUnauthorized,
+			ExpectBody:   "\"message\":\"Request Unauthorized\"",
+		},
+	}
+
+	for _, tc := range tests {
+		testCaseCheck(tc, t)
+	}
+}


### PR DESCRIPTION
* fix: not panic if auth token is invalid

Signed-off-by: imjoey <majunjiev@gmail.com>

* do not record the false in log

Signed-off-by: imjoey <majunjiev@gmail.com>

Please answer these questions before submitting a pull request

- Why submit this pull request?
- [ ] Bugfix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bugfix
- Description

- How to fix?

___
### New feature or improvement
- Describe the details and related test reports.
