### PR TITLE
feat: add create_time/update_time for global_rule

### DIFF
--- a/api/conf/schema.json
+++ b/api/conf/schema.json
@@ -1,4963 +1,4054 @@
 {
-    "main": {
-        "consumer": {
-            "additionalProperties": false,
-            "properties": {
-                "create_time": {
-                    "type": "integer"
-                },
-                "desc": {
-                    "maxLength": 256,
-                    "type": "string"
-                },
-                "id": {
-                    "anyOf": [
-                        {
-                            "maxLength": 64,
-                            "minLength": 1,
-                            "pattern": "^[a-zA-Z0-9-_.]+$",
-                            "type": "string"
-                        },
-                        {
-                            "minimum": 1,
-                            "type": "integer"
-                        }
-                    ]
-                },
-                "labels": {
-                    "description": "key/value pairs to specify attributes",
-                    "maxProperties": 16,
-                    "patternProperties": {
-                        ".*": {
-                            "description": "value of label",
-                            "maxLength": 64,
-                            "minLength": 1,
-                            "pattern": "^[a-zA-Z0-9-_.]+$",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "plugins": {
-                    "type": "object"
-                },
-                "update_time": {
-                    "type": "integer"
-                },
-                "username": {
-                    "maxLength": 32,
-                    "minLength": 1,
-                    "pattern": "^[a-zA-Z0-9_]+$",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "username"
-            ],
-            "type": "object"
-        },
-        "global_rule": {
-            "additionalProperties": false,
-            "properties": {
-                "create_time": {
-                    "type": "integer"
-                },
-                "id": {
-                    "anyOf": [
-                        {
-                            "maxLength": 64,
-                            "minLength": 1,
-                            "pattern": "^[a-zA-Z0-9-_.]+$",
-                            "type": "string"
-                        },
-                        {
-                            "minimum": 1,
-                            "type": "integer"
-                        }
-                    ]
-                },
-                "plugins": {
-                    "type": "object"
-                },
-                "update_time": {
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "plugins"
-            ],
-            "type": "object"
-        },
-        "plugins": {
-            "items": {
-                "properties": {
-                    "additionalProperties": false,
-                    "name": {
-                        "minLength": 1,
-                        "type": "string"
-                    },
-                    "stream": {
-                        "type": "boolean"
-                    }
-                },
-                "required": [
-                    "name"
-                ],
-                "type": "object"
-            },
-            "type": "array"
-        },
-        "proto": {
-            "additionalProperties": false,
-            "properties": {
-                "content": {
-                    "maxLength": 1048576,
-                    "minLength": 1,
-                    "type": "string"
-                }
-            },
-            "required": [
-                "content"
-            ],
-            "type": "object"
-        },
-        "route": {
-            "additionalProperties": false,
-            "allOf": [
-                {
-                    "oneOf": [
-                        {
-                            "required": [
-                                "uri"
-                            ]
-                        },
-                        {
-                            "required": [
-                                "uris"
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "oneOf": [
-                        {
-                            "not": {
-                                "anyOf": [
-                                    {
-                                        "required": [
-                                            "host"
-                                        ]
-                                    },
-                                    {
-                                        "required": [
-                                            "hosts"
-                                        ]
-                                    }
-                                ]
-                            }
-                        },
-                        {
-                            "required": [
-                                "host"
-                            ]
-                        },
-                        {
-                            "required": [
-                                "hosts"
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "oneOf": [
-                        {
-                            "not": {
-                                "anyOf": [
-                                    {
-                                        "required": [
-                                            "remote_addr"
-                                        ]
-                                    },
-                                    {
-                                        "required": [
-                                            "remote_addrs"
-                                        ]
-                                    }
-                                ]
-                            }
-                        },
-                        {
-                            "required": [
-                                "remote_addr"
-                            ]
-                        },
-                        {
-                            "required": [
-                                "remote_addrs"
-                            ]
-                        }
-                    ]
-                }
-            ],
-            "anyOf": [
-                {
-                    "required": [
-                        "plugins",
-                        "uri"
-                    ]
-                },
-                {
-                    "required": [
-                        "upstream",
-                        "uri"
-                    ]
-                },
-                {
-                    "required": [
-                        "upstream_id",
-                        "uri"
-                    ]
-                },
-                {
-                    "required": [
-                        "service_id",
-                        "uri"
-                    ]
-                },
-                {
-                    "required": [
-                        "plugins",
-                        "uris"
-                    ]
-                },
-                {
-                    "required": [
-                        "upstream",
-                        "uris"
-                    ]
-                },
-                {
-                    "required": [
-                        "upstream_id",
-                        "uris"
-                    ]
-                },
-                {
-                    "required": [
-                        "service_id",
-                        "uris"
-                    ]
-                },
-                {
-                    "required": [
-                        "script",
-                        "uri"
-                    ]
-                },
-                {
-                    "required": [
-                        "script",
-                        "uris"
-                    ]
-                }
-            ],
-            "not": {
-                "anyOf": [
-                    {
-                        "required": [
-                            "plugins",
-                            "script"
-                        ]
-                    }
-                ]
-            },
-            "properties": {
-                "create_time": {
-                    "type": "integer"
-                },
-                "desc": {
-                    "maxLength": 256,
-                    "type": "string"
-                },
-                "enable_websocket": {
-                    "description": "enable websocket for request",
-                    "type": "boolean"
-                },
-                "filter_func": {
-                    "minLength": 10,
-                    "pattern": "^function",
-                    "type": "string"
-                },
-                "host": {
-                    "pattern": "^\\*?[0-9a-zA-Z-._]+$",
-                    "type": "string"
-                },
-                "hosts": {
-                    "items": {
-                        "pattern": "^\\*?[0-9a-zA-Z-._]+$",
-                        "type": "string"
-                    },
-                    "minItems": 1,
-                    "type": "array",
-                    "uniqueItems": true
-                },
-                "id": {
-                    "anyOf": [
-                        {
-                            "maxLength": 64,
-                            "minLength": 1,
-                            "pattern": "^[a-zA-Z0-9-_.]+$",
-                            "type": "string"
-                        },
-                        {
-                            "minimum": 1,
-                            "type": "integer"
-                        }
-                    ]
-                },
-                "labels": {
-                    "description": "key/value pairs to specify attributes",
-                    "maxProperties": 16,
-                    "patternProperties": {
-                        ".*": {
-                            "description": "value of label",
-                            "maxLength": 64,
-                            "minLength": 1,
-                            "pattern": "^[a-zA-Z0-9-_.]+$",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "methods": {
-                    "items": {
-                        "description": "HTTP method",
-                        "enum": [
-                            "CONNECT",
-                            "DELETE",
-                            "GET",
-                            "HEAD",
-                            "OPTIONS",
-                            "PATCH",
-                            "POST",
-                            "PUT",
-                            "TRACE"
-                        ],
-                        "type": "string"
-                    },
-                    "type": "array",
-                    "uniqueItems": true
-                },
-                "name": {
-                    "maxLength": 100,
-                    "minLength": 1,
-                    "type": "string"
-                },
-                "plugins": {
-                    "type": "object"
-                },
-                "priority": {
-                    "default": 0,
-                    "type": "integer"
-                },
-                "remote_addr": {
-                    "anyOf": [
-                        {
-                            "format": "ipv4",
-                            "title": "IPv4",
-                            "type": "string"
-                        },
-                        {
-                            "pattern": "^([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])/([12]?[0-9]|3[0-2])$",
-                            "title": "IPv4/CIDR",
-                            "type": "string"
-                        },
-                        {
-                            "format": "ipv6",
-                            "title": "IPv6",
-                            "type": "string"
-                        },
-                        {
-                            "pattern": "^([a-fA-F0-9]{0,4}:){1,8}(:[a-fA-F0-9]{0,4}){0,8}([a-fA-F0-9]{0,4})?/[0-9]{1,3}$",
-                            "title": "IPv6/CIDR",
-                            "type": "string"
-                        }
-                    ],
-                    "description": "client IP",
-                    "type": "string"
-                },
-                "remote_addrs": {
-                    "items": {
-                        "anyOf": [
-                            {
-                                "format": "ipv4",
-                                "title": "IPv4",
-                                "type": "string"
-                            },
-                            {
-                                "pattern": "^([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])/([12]?[0-9]|3[0-2])$",
-                                "title": "IPv4/CIDR",
-                                "type": "string"
-                            },
-                            {
-                                "format": "ipv6",
-                                "title": "IPv6",
-                                "type": "string"
-                            },
-                            {
-                                "pattern": "^([a-fA-F0-9]{0,4}:){1,8}(:[a-fA-F0-9]{0,4}){0,8}([a-fA-F0-9]{0,4})?/[0-9]{1,3}$",
-                                "title": "IPv6/CIDR",
-                                "type": "string"
-                            }
-                        ],
-                        "description": "client IP",
-                        "type": "string"
-                    },
-                    "minItems": 1,
-                    "type": "array",
-                    "uniqueItems": true
-                },
-                "script": {
-                    "maxLength": 102400,
-                    "minLength": 10,
-                    "type": "string"
-                },
-                "script_id": {
-                    "anyOf": [
-                        {
-                            "maxLength": 64,
-                            "minLength": 1,
-                            "pattern": "^[a-zA-Z0-9-_.]+$",
-                            "type": "string"
-                        },
-                        {
-                            "minimum": 1,
-                            "type": "integer"
-                        }
-                    ]
-                },
-                "service_id": {
-                    "anyOf": [
-                        {
-                            "maxLength": 64,
-                            "minLength": 1,
-                            "pattern": "^[a-zA-Z0-9-_.]+$",
-                            "type": "string"
-                        },
-                        {
-                            "minimum": 1,
-                            "type": "integer"
-                        }
-                    ]
-                },
-                "service_protocol": {
-                    "enum": [
-                        "grpc",
-                        "http"
-                    ]
-                },
-                "status": {
-                    "default": 1,
-                    "description": "route status, 1 to enable, 0 to disable",
-                    "enum": [
-                        0,
-                        1
-                    ],
-                    "type": "integer"
-                },
-                "update_time": {
-                    "type": "integer"
-                },
-                "upstream": {
-                    "additionalProperties": false,
-                    "anyOf": [
-                        {
-                            "required": [
-                                "nodes",
-                                "type"
-                            ]
-                        },
-                        {
-                            "required": [
-                                "service_name",
-                                "type"
-                            ]
-                        }
-                    ],
-                    "properties": {
-                        "checks": {
-                            "additionalProperties": false,
-                            "anyOf": [
-                                {
-                                    "required": [
-                                        "active"
-                                    ]
-                                },
-                                {
-                                    "required": [
-                                        "active",
-                                        "passive"
-                                    ]
-                                }
-                            ],
-                            "properties": {
-                                "active": {
-                                    "properties": {
-                                        "concurrency": {
-                                            "default": 10,
-                                            "type": "integer"
-                                        },
-                                        "healthy": {
-                                            "properties": {
-                                                "http_statuses": {
-                                                    "default": [
-                                                        200,
-                                                        302
-                                                    ],
-                                                    "items": {
-                                                        "maximum": 599,
-                                                        "minimum": 200,
-                                                        "type": "integer"
-                                                    },
-                                                    "minItems": 1,
-                                                    "type": "array",
-                                                    "uniqueItems": true
-                                                },
-                                                "interval": {
-                                                    "default": 0,
-                                                    "minimum": 1,
-                                                    "type": "integer"
-                                                },
-                                                "successes": {
-                                                    "default": 2,
-                                                    "maximum": 254,
-                                                    "minimum": 1,
-                                                    "type": "integer"
-                                                }
-                                            },
-                                            "type": "object"
-                                        },
-                                        "host": {
-                                            "pattern": "^\\*?[0-9a-zA-Z-._]+$",
-                                            "type": "string"
-                                        },
-                                        "http_path": {
-                                            "default": "/",
-                                            "type": "string"
-                                        },
-                                        "https_verify_certificate": {
-                                            "default": true,
-                                            "type": "boolean"
-                                        },
-                                        "port": {
-                                            "maximum": 65535,
-                                            "minimum": 1,
-                                            "type": "integer"
-                                        },
-                                        "req_headers": {
-                                            "items": {
-                                                "type": "string",
-                                                "uniqueItems": true
-                                            },
-                                            "minItems": 1,
-                                            "type": "array"
-                                        },
-                                        "timeout": {
-                                            "default": 1,
-                                            "type": "number"
-                                        },
-                                        "type": {
-                                            "default": "http",
-                                            "enum": [
-                                                "http",
-                                                "https",
-                                                "tcp"
-                                            ],
-                                            "type": "string"
-                                        },
-                                        "unhealthy": {
-                                            "properties": {
-                                                "http_failures": {
-                                                    "default": 5,
-                                                    "maximum": 254,
-                                                    "minimum": 1,
-                                                    "type": "integer"
-                                                },
-                                                "http_statuses": {
-                                                    "default": [
-                                                        404,
-                                                        429,
-                                                        500,
-                                                        501,
-                                                        502,
-                                                        503,
-                                                        504,
-                                                        505
-                                                    ],
-                                                    "items": {
-                                                        "maximum": 599,
-                                                        "minimum": 200,
-                                                        "type": "integer"
-                                                    },
-                                                    "minItems": 1,
-                                                    "type": "array",
-                                                    "uniqueItems": true
-                                                },
-                                                "interval": {
-                                                    "default": 0,
-                                                    "minimum": 1,
-                                                    "type": "integer"
-                                                },
-                                                "tcp_failures": {
-                                                    "default": 2,
-                                                    "maximum": 254,
-                                                    "minimum": 1,
-                                                    "type": "integer"
-                                                },
-                                                "timeouts": {
-                                                    "default": 3,
-                                                    "maximum": 254,
-                                                    "minimum": 1,
-                                                    "type": "integer"
-                                                }
-                                            },
-                                            "type": "object"
-                                        }
-                                    },
-                                    "type": "object"
-                                },
-                                "passive": {
-                                    "properties": {
-                                        "healthy": {
-                                            "properties": {
-                                                "http_statuses": {
-                                                    "default": [
-                                                        200,
-                                                        201,
-                                                        202,
-                                                        203,
-                                                        204,
-                                                        205,
-                                                        206,
-                                                        207,
-                                                        208,
-                                                        226,
-                                                        300,
-                                                        301,
-                                                        302,
-                                                        303,
-                                                        304,
-                                                        305,
-                                                        306,
-                                                        307,
-                                                        308
-                                                    ],
-                                                    "items": {
-                                                        "maximum": 599,
-                                                        "minimum": 200,
-                                                        "type": "integer"
-                                                    },
-                                                    "minItems": 1,
-                                                    "type": "array",
-                                                    "uniqueItems": true
-                                                },
-                                                "successes": {
-                                                    "default": 5,
-                                                    "maximum": 254,
-                                                    "minimum": 1,
-                                                    "type": "integer"
-                                                }
-                                            },
-                                            "type": "object"
-                                        },
-                                        "type": {
-                                            "default": "http",
-                                            "enum": [
-                                                "http",
-                                                "https",
-                                                "tcp"
-                                            ],
-                                            "type": "string"
-                                        },
-                                        "unhealthy": {
-                                            "properties": {
-                                                "http_failures": {
-                                                    "default": 5,
-                                                    "maximum": 254,
-                                                    "minimum": 1,
-                                                    "type": "integer"
-                                                },
-                                                "http_statuses": {
-                                                    "default": [
-                                                        429,
-                                                        500,
-                                                        503
-                                                    ],
-                                                    "items": {
-                                                        "maximum": 599,
-                                                        "minimum": 200,
-                                                        "type": "integer"
-                                                    },
-                                                    "minItems": 1,
-                                                    "type": "array",
-                                                    "uniqueItems": true
-                                                },
-                                                "tcp_failures": {
-                                                    "default": 2,
-                                                    "maximum": 254,
-                                                    "minimum": 1,
-                                                    "type": "integer"
-                                                },
-                                                "timeouts": {
-                                                    "default": 7,
-                                                    "maximum": 254,
-                                                    "minimum": 1,
-                                                    "type": "integer"
-                                                }
-                                            },
-                                            "type": "object"
-                                        }
-                                    },
-                                    "type": "object"
-                                }
-                            },
-                            "type": "object"
-                        },
-                        "create_time": {
-                            "type": "integer"
-                        },
-                        "desc": {
-                            "maxLength": 256,
-                            "type": "string"
-                        },
-                        "discovery_type": {
-                            "description": "discovery type",
-                            "type": "string"
-                        },
-                        "enable_websocket": {
-                            "description": "enable websocket for request",
-                            "type": "boolean"
-                        },
-                        "hash_on": {
-                            "default": "vars",
-                            "enum": [
-                                "consumer",
-                                "cookie",
-                                "header",
-                                "vars"
-                            ],
-                            "type": "string"
-                        },
-                        "id": {
-                            "anyOf": [
-                                {
-                                    "maxLength": 64,
-                                    "minLength": 1,
-                                    "pattern": "^[a-zA-Z0-9-_.]+$",
-                                    "type": "string"
-                                },
-                                {
-                                    "minimum": 1,
-                                    "type": "integer"
-                                }
-                            ]
-                        },
-                        "key": {
-                            "description": "the key of chash for dynamic load balancing",
-                            "type": "string"
-                        },
-                        "labels": {
-                            "description": "key/value pairs to specify attributes",
-                            "maxProperties": 16,
-                            "patternProperties": {
-                                ".*": {
-                                    "description": "value of label",
-                                    "maxLength": 64,
-                                    "minLength": 1,
-                                    "pattern": "^[a-zA-Z0-9-_.]+$",
-                                    "type": "string"
-                                }
-                            },
-                            "type": "object"
-                        },
-                        "name": {
-                            "maxLength": 100,
-                            "minLength": 1,
-                            "type": "string"
-                        },
-                        "nodes": {
-                            "anyOf": [
-                                {
-                                    "minProperties": 1,
-                                    "patternProperties": {
-                                        ".*": {
-                                            "description": "weight of node",
-                                            "minimum": 0,
-                                            "type": "integer"
-                                        }
-                                    },
-                                    "type": "object"
-                                },
-                                {
-                                    "items": {
-                                        "properties": {
-                                            "host": {
-                                                "pattern": "^\\*?[0-9a-zA-Z-._]+$",
-                                                "type": "string"
-                                            },
-                                            "metadata": {
-                                                "description": "metadata of node",
-                                                "type": "object"
-                                            },
-                                            "port": {
-                                                "description": "port of node",
-                                                "minimum": 1,
-                                                "type": "integer"
-                                            },
-                                            "weight": {
-                                                "description": "weight of node",
-                                                "minimum": 0,
-                                                "type": "integer"
-                                            }
-                                        },
-                                        "required": [
-                                            "host",
-                                            "port",
-                                            "weight"
-                                        ],
-                                        "type": "object"
-                                    },
-                                    "type": "array"
-                                }
-                            ]
-                        },
-                        "pass_host": {
-                            "default": "pass",
-                            "description": "mod of host passing",
-                            "enum": [
-                                "node",
-                                "pass",
-                                "rewrite"
-                            ],
-                            "type": "string"
-                        },
-                        "retries": {
-                            "minimum": 0,
-                            "type": "integer"
-                        },
-                        "service_name": {
-                            "maxLength": 100,
-                            "minLength": 1,
-                            "type": "string"
-                        },
-                        "timeout": {
-                            "properties": {
-                                "connect": {
-                                    "minimum": 0,
-                                    "type": "number"
-                                },
-                                "read": {
-                                    "minimum": 0,
-                                    "type": "number"
-                                },
-                                "send": {
-                                    "minimum": 0,
-                                    "type": "number"
-                                }
-                            },
-                            "required": [
-                                "connect",
-                                "read",
-                                "send"
-                            ],
-                            "type": "object"
-                        },
-                        "type": {
-                            "description": "algorithms of load balancing",
-                            "enum": [
-                                "chash",
-                                "ewma",
-                                "roundrobin"
-                            ],
-                            "type": "string"
-                        },
-                        "update_time": {
-                            "type": "integer"
-                        },
-                        "upstream_host": {
-                            "pattern": "^\\*?[0-9a-zA-Z-._]+$",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "upstream_id": {
-                    "anyOf": [
-                        {
-                            "maxLength": 64,
-                            "minLength": 1,
-                            "pattern": "^[a-zA-Z0-9-_.]+$",
-                            "type": "string"
-                        },
-                        {
-                            "minimum": 1,
-                            "type": "integer"
-                        }
-                    ]
-                },
-                "uri": {
-                    "maxLength": 4096,
-                    "minLength": 1,
-                    "type": "string"
-                },
-                "uris": {
-                    "items": {
-                        "description": "HTTP uri",
-                        "type": "string"
-                    },
-                    "minItems": 1,
-                    "type": "array",
-                    "uniqueItems": true
-                },
-                "vars": {
-                    "items": {
-                        "description": "Nginx builtin variable name and value",
-                        "maxItems": 4,
-                        "minItems": 2,
-                        "type": "array"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
-        "service": {
-            "additionalProperties": false,
-            "properties": {
-                "create_time": {
-                    "type": "integer"
-                },
-                "desc": {
-                    "maxLength": 256,
-                    "type": "string"
-                },
-                "enable_websocket": {
-                    "description": "enable websocket for request",
-                    "type": "boolean"
-                },
-                "id": {
-                    "anyOf": [
-                        {
-                            "maxLength": 64,
-                            "minLength": 1,
-                            "pattern": "^[a-zA-Z0-9-_.]+$",
-                            "type": "string"
-                        },
-                        {
-                            "minimum": 1,
-                            "type": "integer"
-                        }
-                    ]
-                },
-                "labels": {
-                    "description": "key/value pairs to specify attributes",
-                    "maxProperties": 16,
-                    "patternProperties": {
-                        ".*": {
-                            "description": "value of label",
-                            "maxLength": 64,
-                            "minLength": 1,
-                            "pattern": "^[a-zA-Z0-9-_.]+$",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "name": {
-                    "maxLength": 100,
-                    "minLength": 1,
-                    "type": "string"
-                },
-                "plugins": {
-                    "type": "object"
-                },
-                "script": {
-                    "maxLength": 102400,
-                    "minLength": 10,
-                    "type": "string"
-                },
-                "update_time": {
-                    "type": "integer"
-                },
-                "upstream": {
-                    "additionalProperties": false,
-                    "anyOf": [
-                        {
-                            "required": [
-                                "nodes",
-                                "type"
-                            ]
-                        },
-                        {
-                            "required": [
-                                "service_name",
-                                "type"
-                            ]
-                        }
-                    ],
-                    "properties": {
-                        "checks": {
-                            "additionalProperties": false,
-                            "anyOf": [
-                                {
-                                    "required": [
-                                        "active"
-                                    ]
-                                },
-                                {
-                                    "required": [
-                                        "active",
-                                        "passive"
-                                    ]
-                                }
-                            ],
-                            "properties": {
-                                "active": {
-                                    "properties": {
-                                        "concurrency": {
-                                            "default": 10,
-                                            "type": "integer"
-                                        },
-                                        "healthy": {
-                                            "properties": {
-                                                "http_statuses": {
-                                                    "default": [
-                                                        200,
-                                                        302
-                                                    ],
-                                                    "items": {
-                                                        "maximum": 599,
-                                                        "minimum": 200,
-                                                        "type": "integer"
-                                                    },
-                                                    "minItems": 1,
-                                                    "type": "array",
-                                                    "uniqueItems": true
-                                                },
-                                                "interval": {
-                                                    "default": 0,
-                                                    "minimum": 1,
-                                                    "type": "integer"
-                                                },
-                                                "successes": {
-                                                    "default": 2,
-                                                    "maximum": 254,
-                                                    "minimum": 1,
-                                                    "type": "integer"
-                                                }
-                                            },
-                                            "type": "object"
-                                        },
-                                        "host": {
-                                            "pattern": "^\\*?[0-9a-zA-Z-._]+$",
-                                            "type": "string"
-                                        },
-                                        "http_path": {
-                                            "default": "/",
-                                            "type": "string"
-                                        },
-                                        "https_verify_certificate": {
-                                            "default": true,
-                                            "type": "boolean"
-                                        },
-                                        "port": {
-                                            "maximum": 65535,
-                                            "minimum": 1,
-                                            "type": "integer"
-                                        },
-                                        "req_headers": {
-                                            "items": {
-                                                "type": "string",
-                                                "uniqueItems": true
-                                            },
-                                            "minItems": 1,
-                                            "type": "array"
-                                        },
-                                        "timeout": {
-                                            "default": 1,
-                                            "type": "number"
-                                        },
-                                        "type": {
-                                            "default": "http",
-                                            "enum": [
-                                                "http",
-                                                "https",
-                                                "tcp"
-                                            ],
-                                            "type": "string"
-                                        },
-                                        "unhealthy": {
-                                            "properties": {
-                                                "http_failures": {
-                                                    "default": 5,
-                                                    "maximum": 254,
-                                                    "minimum": 1,
-                                                    "type": "integer"
-                                                },
-                                                "http_statuses": {
-                                                    "default": [
-                                                        404,
-                                                        429,
-                                                        500,
-                                                        501,
-                                                        502,
-                                                        503,
-                                                        504,
-                                                        505
-                                                    ],
-                                                    "items": {
-                                                        "maximum": 599,
-                                                        "minimum": 200,
-                                                        "type": "integer"
-                                                    },
-                                                    "minItems": 1,
-                                                    "type": "array",
-                                                    "uniqueItems": true
-                                                },
-                                                "interval": {
-                                                    "default": 0,
-                                                    "minimum": 1,
-                                                    "type": "integer"
-                                                },
-                                                "tcp_failures": {
-                                                    "default": 2,
-                                                    "maximum": 254,
-                                                    "minimum": 1,
-                                                    "type": "integer"
-                                                },
-                                                "timeouts": {
-                                                    "default": 3,
-                                                    "maximum": 254,
-                                                    "minimum": 1,
-                                                    "type": "integer"
-                                                }
-                                            },
-                                            "type": "object"
-                                        }
-                                    },
-                                    "type": "object"
-                                },
-                                "passive": {
-                                    "properties": {
-                                        "healthy": {
-                                            "properties": {
-                                                "http_statuses": {
-                                                    "default": [
-                                                        200,
-                                                        201,
-                                                        202,
-                                                        203,
-                                                        204,
-                                                        205,
-                                                        206,
-                                                        207,
-                                                        208,
-                                                        226,
-                                                        300,
-                                                        301,
-                                                        302,
-                                                        303,
-                                                        304,
-                                                        305,
-                                                        306,
-                                                        307,
-                                                        308
-                                                    ],
-                                                    "items": {
-                                                        "maximum": 599,
-                                                        "minimum": 200,
-                                                        "type": "integer"
-                                                    },
-                                                    "minItems": 1,
-                                                    "type": "array",
-                                                    "uniqueItems": true
-                                                },
-                                                "successes": {
-                                                    "default": 5,
-                                                    "maximum": 254,
-                                                    "minimum": 1,
-                                                    "type": "integer"
-                                                }
-                                            },
-                                            "type": "object"
-                                        },
-                                        "type": {
-                                            "default": "http",
-                                            "enum": [
-                                                "http",
-                                                "https",
-                                                "tcp"
-                                            ],
-                                            "type": "string"
-                                        },
-                                        "unhealthy": {
-                                            "properties": {
-                                                "http_failures": {
-                                                    "default": 5,
-                                                    "maximum": 254,
-                                                    "minimum": 1,
-                                                    "type": "integer"
-                                                },
-                                                "http_statuses": {
-                                                    "default": [
-                                                        429,
-                                                        500,
-                                                        503
-                                                    ],
-                                                    "items": {
-                                                        "maximum": 599,
-                                                        "minimum": 200,
-                                                        "type": "integer"
-                                                    },
-                                                    "minItems": 1,
-                                                    "type": "array",
-                                                    "uniqueItems": true
-                                                },
-                                                "tcp_failures": {
-                                                    "default": 2,
-                                                    "maximum": 254,
-                                                    "minimum": 1,
-                                                    "type": "integer"
-                                                },
-                                                "timeouts": {
-                                                    "default": 7,
-                                                    "maximum": 254,
-                                                    "minimum": 1,
-                                                    "type": "integer"
-                                                }
-                                            },
-                                            "type": "object"
-                                        }
-                                    },
-                                    "type": "object"
-                                }
-                            },
-                            "type": "object"
-                        },
-                        "create_time": {
-                            "type": "integer"
-                        },
-                        "desc": {
-                            "maxLength": 256,
-                            "type": "string"
-                        },
-                        "discovery_type": {
-                            "description": "discovery type",
-                            "type": "string"
-                        },
-                        "enable_websocket": {
-                            "description": "enable websocket for request",
-                            "type": "boolean"
-                        },
-                        "hash_on": {
-                            "default": "vars",
-                            "enum": [
-                                "consumer",
-                                "cookie",
-                                "header",
-                                "vars"
-                            ],
-                            "type": "string"
-                        },
-                        "id": {
-                            "anyOf": [
-                                {
-                                    "maxLength": 64,
-                                    "minLength": 1,
-                                    "pattern": "^[a-zA-Z0-9-_.]+$",
-                                    "type": "string"
-                                },
-                                {
-                                    "minimum": 1,
-                                    "type": "integer"
-                                }
-                            ]
-                        },
-                        "key": {
-                            "description": "the key of chash for dynamic load balancing",
-                            "type": "string"
-                        },
-                        "labels": {
-                            "description": "key/value pairs to specify attributes",
-                            "maxProperties": 16,
-                            "patternProperties": {
-                                ".*": {
-                                    "description": "value of label",
-                                    "maxLength": 64,
-                                    "minLength": 1,
-                                    "pattern": "^[a-zA-Z0-9-_.]+$",
-                                    "type": "string"
-                                }
-                            },
-                            "type": "object"
-                        },
-                        "name": {
-                            "maxLength": 100,
-                            "minLength": 1,
-                            "type": "string"
-                        },
-                        "nodes": {
-                            "anyOf": [
-                                {
-                                    "minProperties": 1,
-                                    "patternProperties": {
-                                        ".*": {
-                                            "description": "weight of node",
-                                            "minimum": 0,
-                                            "type": "integer"
-                                        }
-                                    },
-                                    "type": "object"
-                                },
-                                {
-                                    "items": {
-                                        "properties": {
-                                            "host": {
-                                                "pattern": "^\\*?[0-9a-zA-Z-._]+$",
-                                                "type": "string"
-                                            },
-                                            "metadata": {
-                                                "description": "metadata of node",
-                                                "type": "object"
-                                            },
-                                            "port": {
-                                                "description": "port of node",
-                                                "minimum": 1,
-                                                "type": "integer"
-                                            },
-                                            "weight": {
-                                                "description": "weight of node",
-                                                "minimum": 0,
-                                                "type": "integer"
-                                            }
-                                        },
-                                        "required": [
-                                            "host",
-                                            "port",
-                                            "weight"
-                                        ],
-                                        "type": "object"
-                                    },
-                                    "type": "array"
-                                }
-                            ]
-                        },
-                        "pass_host": {
-                            "default": "pass",
-                            "description": "mod of host passing",
-                            "enum": [
-                                "node",
-                                "pass",
-                                "rewrite"
-                            ],
-                            "type": "string"
-                        },
-                        "retries": {
-                            "minimum": 0,
-                            "type": "integer"
-                        },
-                        "service_name": {
-                            "maxLength": 100,
-                            "minLength": 1,
-                            "type": "string"
-                        },
-                        "timeout": {
-                            "properties": {
-                                "connect": {
-                                    "minimum": 0,
-                                    "type": "number"
-                                },
-                                "read": {
-                                    "minimum": 0,
-                                    "type": "number"
-                                },
-                                "send": {
-                                    "minimum": 0,
-                                    "type": "number"
-                                }
-                            },
-                            "required": [
-                                "connect",
-                                "read",
-                                "send"
-                            ],
-                            "type": "object"
-                        },
-                        "type": {
-                            "description": "algorithms of load balancing",
-                            "enum": [
-                                "chash",
-                                "ewma",
-                                "roundrobin"
-                            ],
-                            "type": "string"
-                        },
-                        "update_time": {
-                            "type": "integer"
-                        },
-                        "upstream_host": {
-                            "pattern": "^\\*?[0-9a-zA-Z-._]+$",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "upstream_id": {
-                    "anyOf": [
-                        {
-                            "maxLength": 64,
-                            "minLength": 1,
-                            "pattern": "^[a-zA-Z0-9-_.]+$",
-                            "type": "string"
-                        },
-                        {
-                            "minimum": 1,
-                            "type": "integer"
-                        }
-                    ]
-                }
-            },
-            "type": "object"
-        },
-        "ssl": {
-            "additionalProperties": false,
-            "oneOf": [
-                {
-                    "required": [
-                        "cert",
-                        "key",
-                        "sni"
-                    ]
-                },
-                {
-                    "required": [
-                        "cert",
-                        "key",
-                        "snis"
-                    ]
-                }
-            ],
-            "properties": {
-                "cert": {
-                    "maxLength": 65536,
-                    "minLength": 128,
-                    "type": "string"
-                },
-                "certs": {
-                    "items": {
-                        "maxLength": 65536,
-                        "minLength": 128,
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "create_time": {
-                    "type": "integer"
-                },
-                "exptime": {
-                    "minimum": 1588262400,
-                    "type": "integer"
-                },
-                "id": {
-                    "anyOf": [
-                        {
-                            "maxLength": 64,
-                            "minLength": 1,
-                            "pattern": "^[a-zA-Z0-9-_.]+$",
-                            "type": "string"
-                        },
-                        {
-                            "minimum": 1,
-                            "type": "integer"
-                        }
-                    ]
-                },
-                "key": {
-                    "maxLength": 65536,
-                    "minLength": 128,
-                    "type": "string"
-                },
-                "keys": {
-                    "items": {
-                        "maxLength": 65536,
-                        "minLength": 128,
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "labels": {
-                    "description": "key/value pairs to specify attributes",
-                    "maxProperties": 16,
-                    "patternProperties": {
-                        ".*": {
-                            "description": "value of label",
-                            "maxLength": 64,
-                            "minLength": 1,
-                            "pattern": "^[a-zA-Z0-9-_.]+$",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "sni": {
-                    "pattern": "^\\*?[0-9a-zA-Z-.]+$",
-                    "type": "string"
-                },
-                "snis": {
-                    "items": {
-                        "pattern": "^\\*?[0-9a-zA-Z-.]+$",
-                        "type": "string"
-                    },
-                    "minItems": 1,
-                    "type": "array"
-                },
-                "status": {
-                    "default": 1,
-                    "description": "ssl status, 1 to enable, 0 to disable",
-                    "enum": [
-                        0,
-                        1
-                    ],
-                    "type": "integer"
-                },
-                "update_time": {
-                    "type": "integer"
-                },
-                "validity_end": {
-                    "type": "integer"
-                },
-                "validity_start": {
-                    "type": "integer"
-                }
-            },
-            "type": "object"
-        },
-        "stream_route": {
-            "properties": {
-                "id": {
-                    "anyOf": [
-                        {
-                            "maxLength": 64,
-                            "minLength": 1,
-                            "pattern": "^[a-zA-Z0-9-_.]+$",
-                            "type": "string"
-                        },
-                        {
-                            "minimum": 1,
-                            "type": "integer"
-                        }
-                    ]
-                },
-                "plugins": {
-                    "type": "object"
-                },
-                "remote_addr": {
-                    "anyOf": [
-                        {
-                            "format": "ipv4",
-                            "title": "IPv4",
-                            "type": "string"
-                        },
-                        {
-                            "pattern": "^([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])/([12]?[0-9]|3[0-2])$",
-                            "title": "IPv4/CIDR",
-                            "type": "string"
-                        },
-                        {
-                            "format": "ipv6",
-                            "title": "IPv6",
-                            "type": "string"
-                        },
-                        {
-                            "pattern": "^([a-fA-F0-9]{0,4}:){1,8}(:[a-fA-F0-9]{0,4}){0,8}([a-fA-F0-9]{0,4})?/[0-9]{1,3}$",
-                            "title": "IPv6/CIDR",
-                            "type": "string"
-                        }
-                    ],
-                    "description": "client IP",
-                    "type": "string"
-                },
-                "server_addr": {
-                    "anyOf": [
-                        {
-                            "format": "ipv4",
-                            "title": "IPv4",
-                            "type": "string"
-                        },
-                        {
-                            "pattern": "^([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])/([12]?[0-9]|3[0-2])$",
-                            "title": "IPv4/CIDR",
-                            "type": "string"
-                        },
-                        {
-                            "format": "ipv6",
-                            "title": "IPv6",
-                            "type": "string"
-                        },
-                        {
-                            "pattern": "^([a-fA-F0-9]{0,4}:){1,8}(:[a-fA-F0-9]{0,4}){0,8}([a-fA-F0-9]{0,4})?/[0-9]{1,3}$",
-                            "title": "IPv6/CIDR",
-                            "type": "string"
-                        }
-                    ],
-                    "description": "server IP",
-                    "type": "string"
-                },
-                "server_port": {
-                    "description": "server port",
-                    "type": "integer"
-                },
-                "upstream": {
-                    "additionalProperties": false,
-                    "anyOf": [
-                        {
-                            "required": [
-                                "nodes",
-                                "type"
-                            ]
-                        },
-                        {
-                            "required": [
-                                "service_name",
-                                "type"
-                            ]
-                        }
-                    ],
-                    "properties": {
-                        "checks": {
-                            "additionalProperties": false,
-                            "anyOf": [
-                                {
-                                    "required": [
-                                        "active"
-                                    ]
-                                },
-                                {
-                                    "required": [
-                                        "active",
-                                        "passive"
-                                    ]
-                                }
-                            ],
-                            "properties": {
-                                "active": {
-                                    "properties": {
-                                        "concurrency": {
-                                            "default": 10,
-                                            "type": "integer"
-                                        },
-                                        "healthy": {
-                                            "properties": {
-                                                "http_statuses": {
-                                                    "default": [
-                                                        200,
-                                                        302
-                                                    ],
-                                                    "items": {
-                                                        "maximum": 599,
-                                                        "minimum": 200,
-                                                        "type": "integer"
-                                                    },
-                                                    "minItems": 1,
-                                                    "type": "array",
-                                                    "uniqueItems": true
-                                                },
-                                                "interval": {
-                                                    "default": 0,
-                                                    "minimum": 1,
-                                                    "type": "integer"
-                                                },
-                                                "successes": {
-                                                    "default": 2,
-                                                    "maximum": 254,
-                                                    "minimum": 1,
-                                                    "type": "integer"
-                                                }
-                                            },
-                                            "type": "object"
-                                        },
-                                        "host": {
-                                            "pattern": "^\\*?[0-9a-zA-Z-._]+$",
-                                            "type": "string"
-                                        },
-                                        "http_path": {
-                                            "default": "/",
-                                            "type": "string"
-                                        },
-                                        "https_verify_certificate": {
-                                            "default": true,
-                                            "type": "boolean"
-                                        },
-                                        "port": {
-                                            "maximum": 65535,
-                                            "minimum": 1,
-                                            "type": "integer"
-                                        },
-                                        "req_headers": {
-                                            "items": {
-                                                "type": "string",
-                                                "uniqueItems": true
-                                            },
-                                            "minItems": 1,
-                                            "type": "array"
-                                        },
-                                        "timeout": {
-                                            "default": 1,
-                                            "type": "number"
-                                        },
-                                        "type": {
-                                            "default": "http",
-                                            "enum": [
-                                                "http",
-                                                "https",
-                                                "tcp"
-                                            ],
-                                            "type": "string"
-                                        },
-                                        "unhealthy": {
-                                            "properties": {
-                                                "http_failures": {
-                                                    "default": 5,
-                                                    "maximum": 254,
-                                                    "minimum": 1,
-                                                    "type": "integer"
-                                                },
-                                                "http_statuses": {
-                                                    "default": [
-                                                        404,
-                                                        429,
-                                                        500,
-                                                        501,
-                                                        502,
-                                                        503,
-                                                        504,
-                                                        505
-                                                    ],
-                                                    "items": {
-                                                        "maximum": 599,
-                                                        "minimum": 200,
-                                                        "type": "integer"
-                                                    },
-                                                    "minItems": 1,
-                                                    "type": "array",
-                                                    "uniqueItems": true
-                                                },
-                                                "interval": {
-                                                    "default": 0,
-                                                    "minimum": 1,
-                                                    "type": "integer"
-                                                },
-                                                "tcp_failures": {
-                                                    "default": 2,
-                                                    "maximum": 254,
-                                                    "minimum": 1,
-                                                    "type": "integer"
-                                                },
-                                                "timeouts": {
-                                                    "default": 3,
-                                                    "maximum": 254,
-                                                    "minimum": 1,
-                                                    "type": "integer"
-                                                }
-                                            },
-                                            "type": "object"
-                                        }
-                                    },
-                                    "type": "object"
-                                },
-                                "passive": {
-                                    "properties": {
-                                        "healthy": {
-                                            "properties": {
-                                                "http_statuses": {
-                                                    "default": [
-                                                        200,
-                                                        201,
-                                                        202,
-                                                        203,
-                                                        204,
-                                                        205,
-                                                        206,
-                                                        207,
-                                                        208,
-                                                        226,
-                                                        300,
-                                                        301,
-                                                        302,
-                                                        303,
-                                                        304,
-                                                        305,
-                                                        306,
-                                                        307,
-                                                        308
-                                                    ],
-                                                    "items": {
-                                                        "maximum": 599,
-                                                        "minimum": 200,
-                                                        "type": "integer"
-                                                    },
-                                                    "minItems": 1,
-                                                    "type": "array",
-                                                    "uniqueItems": true
-                                                },
-                                                "successes": {
-                                                    "default": 5,
-                                                    "maximum": 254,
-                                                    "minimum": 1,
-                                                    "type": "integer"
-                                                }
-                                            },
-                                            "type": "object"
-                                        },
-                                        "type": {
-                                            "default": "http",
-                                            "enum": [
-                                                "http",
-                                                "https",
-                                                "tcp"
-                                            ],
-                                            "type": "string"
-                                        },
-                                        "unhealthy": {
-                                            "properties": {
-                                                "http_failures": {
-                                                    "default": 5,
-                                                    "maximum": 254,
-                                                    "minimum": 1,
-                                                    "type": "integer"
-                                                },
-                                                "http_statuses": {
-                                                    "default": [
-                                                        429,
-                                                        500,
-                                                        503
-                                                    ],
-                                                    "items": {
-                                                        "maximum": 599,
-                                                        "minimum": 200,
-                                                        "type": "integer"
-                                                    },
-                                                    "minItems": 1,
-                                                    "type": "array",
-                                                    "uniqueItems": true
-                                                },
-                                                "tcp_failures": {
-                                                    "default": 2,
-                                                    "maximum": 254,
-                                                    "minimum": 1,
-                                                    "type": "integer"
-                                                },
-                                                "timeouts": {
-                                                    "default": 7,
-                                                    "maximum": 254,
-                                                    "minimum": 1,
-                                                    "type": "integer"
-                                                }
-                                            },
-                                            "type": "object"
-                                        }
-                                    },
-                                    "type": "object"
-                                }
-                            },
-                            "type": "object"
-                        },
-                        "create_time": {
-                            "type": "integer"
-                        },
-                        "desc": {
-                            "maxLength": 256,
-                            "type": "string"
-                        },
-                        "discovery_type": {
-                            "description": "discovery type",
-                            "type": "string"
-                        },
-                        "enable_websocket": {
-                            "description": "enable websocket for request",
-                            "type": "boolean"
-                        },
-                        "hash_on": {
-                            "default": "vars",
-                            "enum": [
-                                "consumer",
-                                "cookie",
-                                "header",
-                                "vars"
-                            ],
-                            "type": "string"
-                        },
-                        "id": {
-                            "anyOf": [
-                                {
-                                    "maxLength": 64,
-                                    "minLength": 1,
-                                    "pattern": "^[a-zA-Z0-9-_.]+$",
-                                    "type": "string"
-                                },
-                                {
-                                    "minimum": 1,
-                                    "type": "integer"
-                                }
-                            ]
-                        },
-                        "key": {
-                            "description": "the key of chash for dynamic load balancing",
-                            "type": "string"
-                        },
-                        "labels": {
-                            "description": "key/value pairs to specify attributes",
-                            "maxProperties": 16,
-                            "patternProperties": {
-                                ".*": {
-                                    "description": "value of label",
-                                    "maxLength": 64,
-                                    "minLength": 1,
-                                    "pattern": "^[a-zA-Z0-9-_.]+$",
-                                    "type": "string"
-                                }
-                            },
-                            "type": "object"
-                        },
-                        "name": {
-                            "maxLength": 100,
-                            "minLength": 1,
-                            "type": "string"
-                        },
-                        "nodes": {
-                            "anyOf": [
-                                {
-                                    "minProperties": 1,
-                                    "patternProperties": {
-                                        ".*": {
-                                            "description": "weight of node",
-                                            "minimum": 0,
-                                            "type": "integer"
-                                        }
-                                    },
-                                    "type": "object"
-                                },
-                                {
-                                    "items": {
-                                        "properties": {
-                                            "host": {
-                                                "pattern": "^\\*?[0-9a-zA-Z-._]+$",
-                                                "type": "string"
-                                            },
-                                            "metadata": {
-                                                "description": "metadata of node",
-                                                "type": "object"
-                                            },
-                                            "port": {
-                                                "description": "port of node",
-                                                "minimum": 1,
-                                                "type": "integer"
-                                            },
-                                            "weight": {
-                                                "description": "weight of node",
-                                                "minimum": 0,
-                                                "type": "integer"
-                                            }
-                                        },
-                                        "required": [
-                                            "host",
-                                            "port",
-                                            "weight"
-                                        ],
-                                        "type": "object"
-                                    },
-                                    "type": "array"
-                                }
-                            ]
-                        },
-                        "pass_host": {
-                            "default": "pass",
-                            "description": "mod of host passing",
-                            "enum": [
-                                "node",
-                                "pass",
-                                "rewrite"
-                            ],
-                            "type": "string"
-                        },
-                        "retries": {
-                            "minimum": 0,
-                            "type": "integer"
-                        },
-                        "service_name": {
-                            "maxLength": 100,
-                            "minLength": 1,
-                            "type": "string"
-                        },
-                        "timeout": {
-                            "properties": {
-                                "connect": {
-                                    "minimum": 0,
-                                    "type": "number"
-                                },
-                                "read": {
-                                    "minimum": 0,
-                                    "type": "number"
-                                },
-                                "send": {
-                                    "minimum": 0,
-                                    "type": "number"
-                                }
-                            },
-                            "required": [
-                                "connect",
-                                "read",
-                                "send"
-                            ],
-                            "type": "object"
-                        },
-                        "type": {
-                            "description": "algorithms of load balancing",
-                            "enum": [
-                                "chash",
-                                "ewma",
-                                "roundrobin"
-                            ],
-                            "type": "string"
-                        },
-                        "update_time": {
-                            "type": "integer"
-                        },
-                        "upstream_host": {
-                            "pattern": "^\\*?[0-9a-zA-Z-._]+$",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "upstream_id": {
-                    "anyOf": [
-                        {
-                            "maxLength": 64,
-                            "minLength": 1,
-                            "pattern": "^[a-zA-Z0-9-_.]+$",
-                            "type": "string"
-                        },
-                        {
-                            "minimum": 1,
-                            "type": "integer"
-                        }
-                    ]
-                }
-            },
-            "type": "object"
-        },
-        "upstream": {
-            "additionalProperties": false,
-            "anyOf": [
-                {
-                    "required": [
-                        "nodes",
-                        "type"
-                    ]
-                },
-                {
-                    "required": [
-                        "service_name",
-                        "type"
-                    ]
-                }
-            ],
-            "properties": {
-                "checks": {
-                    "additionalProperties": false,
-                    "anyOf": [
-                        {
-                            "required": [
-                                "active"
-                            ]
-                        },
-                        {
-                            "required": [
-                                "active",
-                                "passive"
-                            ]
-                        }
-                    ],
-                    "properties": {
-                        "active": {
-                            "properties": {
-                                "concurrency": {
-                                    "default": 10,
-                                    "type": "integer"
-                                },
-                                "healthy": {
-                                    "properties": {
-                                        "http_statuses": {
-                                            "default": [
-                                                200,
-                                                302
-                                            ],
-                                            "items": {
-                                                "maximum": 599,
-                                                "minimum": 200,
-                                                "type": "integer"
-                                            },
-                                            "minItems": 1,
-                                            "type": "array",
-                                            "uniqueItems": true
-                                        },
-                                        "interval": {
-                                            "default": 0,
-                                            "minimum": 1,
-                                            "type": "integer"
-                                        },
-                                        "successes": {
-                                            "default": 2,
-                                            "maximum": 254,
-                                            "minimum": 1,
-                                            "type": "integer"
-                                        }
-                                    },
-                                    "type": "object"
-                                },
-                                "host": {
-                                    "pattern": "^\\*?[0-9a-zA-Z-._]+$",
-                                    "type": "string"
-                                },
-                                "http_path": {
-                                    "default": "/",
-                                    "type": "string"
-                                },
-                                "https_verify_certificate": {
-                                    "default": true,
-                                    "type": "boolean"
-                                },
-                                "port": {
-                                    "maximum": 65535,
-                                    "minimum": 1,
-                                    "type": "integer"
-                                },
-                                "req_headers": {
-                                    "items": {
-                                        "type": "string",
-                                        "uniqueItems": true
-                                    },
-                                    "minItems": 1,
-                                    "type": "array"
-                                },
-                                "timeout": {
-                                    "default": 1,
-                                    "type": "number"
-                                },
-                                "type": {
-                                    "default": "http",
-                                    "enum": [
-                                        "http",
-                                        "https",
-                                        "tcp"
-                                    ],
-                                    "type": "string"
-                                },
-                                "unhealthy": {
-                                    "properties": {
-                                        "http_failures": {
-                                            "default": 5,
-                                            "maximum": 254,
-                                            "minimum": 1,
-                                            "type": "integer"
-                                        },
-                                        "http_statuses": {
-                                            "default": [
-                                                404,
-                                                429,
-                                                500,
-                                                501,
-                                                502,
-                                                503,
-                                                504,
-                                                505
-                                            ],
-                                            "items": {
-                                                "maximum": 599,
-                                                "minimum": 200,
-                                                "type": "integer"
-                                            },
-                                            "minItems": 1,
-                                            "type": "array",
-                                            "uniqueItems": true
-                                        },
-                                        "interval": {
-                                            "default": 0,
-                                            "minimum": 1,
-                                            "type": "integer"
-                                        },
-                                        "tcp_failures": {
-                                            "default": 2,
-                                            "maximum": 254,
-                                            "minimum": 1,
-                                            "type": "integer"
-                                        },
-                                        "timeouts": {
-                                            "default": 3,
-                                            "maximum": 254,
-                                            "minimum": 1,
-                                            "type": "integer"
-                                        }
-                                    },
-                                    "type": "object"
-                                }
-                            },
-                            "type": "object"
-                        },
-                        "passive": {
-                            "properties": {
-                                "healthy": {
-                                    "properties": {
-                                        "http_statuses": {
-                                            "default": [
-                                                200,
-                                                201,
-                                                202,
-                                                203,
-                                                204,
-                                                205,
-                                                206,
-                                                207,
-                                                208,
-                                                226,
-                                                300,
-                                                301,
-                                                302,
-                                                303,
-                                                304,
-                                                305,
-                                                306,
-                                                307,
-                                                308
-                                            ],
-                                            "items": {
-                                                "maximum": 599,
-                                                "minimum": 200,
-                                                "type": "integer"
-                                            },
-                                            "minItems": 1,
-                                            "type": "array",
-                                            "uniqueItems": true
-                                        },
-                                        "successes": {
-                                            "default": 5,
-                                            "maximum": 254,
-                                            "minimum": 1,
-                                            "type": "integer"
-                                        }
-                                    },
-                                    "type": "object"
-                                },
-                                "type": {
-                                    "default": "http",
-                                    "enum": [
-                                        "http",
-                                        "https",
-                                        "tcp"
-                                    ],
-                                    "type": "string"
-                                },
-                                "unhealthy": {
-                                    "properties": {
-                                        "http_failures": {
-                                            "default": 5,
-                                            "maximum": 254,
-                                            "minimum": 1,
-                                            "type": "integer"
-                                        },
-                                        "http_statuses": {
-                                            "default": [
-                                                429,
-                                                500,
-                                                503
-                                            ],
-                                            "items": {
-                                                "maximum": 599,
-                                                "minimum": 200,
-                                                "type": "integer"
-                                            },
-                                            "minItems": 1,
-                                            "type": "array",
-                                            "uniqueItems": true
-                                        },
-                                        "tcp_failures": {
-                                            "default": 2,
-                                            "maximum": 254,
-                                            "minimum": 1,
-                                            "type": "integer"
-                                        },
-                                        "timeouts": {
-                                            "default": 7,
-                                            "maximum": 254,
-                                            "minimum": 1,
-                                            "type": "integer"
-                                        }
-                                    },
-                                    "type": "object"
-                                }
-                            },
-                            "type": "object"
-                        }
-                    },
-                    "type": "object"
-                },
-                "create_time": {
-                    "type": "integer"
-                },
-                "desc": {
-                    "maxLength": 256,
-                    "type": "string"
-                },
-                "discovery_type": {
-                    "description": "discovery type",
-                    "type": "string"
-                },
-                "enable_websocket": {
-                    "description": "enable websocket for request",
-                    "type": "boolean"
-                },
-                "hash_on": {
-                    "default": "vars",
-                    "enum": [
-                        "consumer",
-                        "cookie",
-                        "header",
-                        "vars"
-                    ],
-                    "type": "string"
-                },
-                "id": {
-                    "anyOf": [
-                        {
-                            "maxLength": 64,
-                            "minLength": 1,
-                            "pattern": "^[a-zA-Z0-9-_.]+$",
-                            "type": "string"
-                        },
-                        {
-                            "minimum": 1,
-                            "type": "integer"
-                        }
-                    ]
-                },
-                "key": {
-                    "description": "the key of chash for dynamic load balancing",
-                    "type": "string"
-                },
-                "labels": {
-                    "description": "key/value pairs to specify attributes",
-                    "maxProperties": 16,
-                    "patternProperties": {
-                        ".*": {
-                            "description": "value of label",
-                            "maxLength": 64,
-                            "minLength": 1,
-                            "pattern": "^[a-zA-Z0-9-_.]+$",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "name": {
-                    "maxLength": 100,
-                    "minLength": 1,
-                    "type": "string"
-                },
-                "nodes": {
-                    "anyOf": [
-                        {
-                            "minProperties": 1,
-                            "patternProperties": {
-                                ".*": {
-                                    "description": "weight of node",
-                                    "minimum": 0,
-                                    "type": "integer"
-                                }
-                            },
-                            "type": "object"
-                        },
-                        {
-                            "items": {
-                                "properties": {
-                                    "host": {
-                                        "pattern": "^\\*?[0-9a-zA-Z-._]+$",
-                                        "type": "string"
-                                    },
-                                    "metadata": {
-                                        "description": "metadata of node",
-                                        "type": "object"
-                                    },
-                                    "port": {
-                                        "description": "port of node",
-                                        "minimum": 1,
-                                        "type": "integer"
-                                    },
-                                    "weight": {
-                                        "description": "weight of node",
-                                        "minimum": 0,
-                                        "type": "integer"
-                                    }
-                                },
-                                "required": [
-                                    "host",
-                                    "port",
-                                    "weight"
-                                ],
-                                "type": "object"
-                            },
-                            "type": "array"
-                        }
-                    ]
-                },
-                "pass_host": {
-                    "default": "pass",
-                    "description": "mod of host passing",
-                    "enum": [
-                        "node",
-                        "pass",
-                        "rewrite"
-                    ],
-                    "type": "string"
-                },
-                "retries": {
-                    "minimum": 0,
-                    "type": "integer"
-                },
-                "service_name": {
-                    "maxLength": 100,
-                    "minLength": 1,
-                    "type": "string"
-                },
-                "timeout": {
-                    "properties": {
-                        "connect": {
-                            "minimum": 0,
-                            "type": "number"
-                        },
-                        "read": {
-                            "minimum": 0,
-                            "type": "number"
-                        },
-                        "send": {
-                            "minimum": 0,
-                            "type": "number"
-                        }
-                    },
-                    "required": [
-                        "connect",
-                        "read",
-                        "send"
-                    ],
-                    "type": "object"
-                },
-                "type": {
-                    "description": "algorithms of load balancing",
-                    "enum": [
-                        "chash",
-                        "ewma",
-                        "roundrobin"
-                    ],
-                    "type": "string"
-                },
-                "update_time": {
-                    "type": "integer"
-                },
-                "upstream_host": {
-                    "pattern": "^\\*?[0-9a-zA-Z-._]+$",
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "upstream_hash_header_schema": {
-            "pattern": "^[a-zA-Z0-9-_]+$",
-            "type": "string"
-        },
-        "upstream_hash_vars_schema": {
-            "pattern": "^((uri|server_name|server_addr|request_uri|remote_port|remote_addr|query_string|host|hostname)|arg_[0-9a-zA-z_-]+)$",
-            "type": "string"
-        }
-    },
-    "plugins": {
-        "api-breaker": {
-            "priority": 1005,
-            "schema": {
-                "properties": {
-                    "break_response_code": {
-                        "maximum": 599,
-                        "minimum": 200,
-                        "type": "integer"
-                    },
-                    "healthy": {
-                        "default": {
-                            "http_statuses": [
-                                200
-                            ],
-                            "successes": 3
-                        },
-                        "properties": {
-                            "http_statuses": {
-                                "default": [
-                                    200
-                                ],
-                                "items": {
-                                    "maximum": 499,
-                                    "minimum": 200,
-                                    "type": "integer"
-                                },
-                                "minItems": 1,
-                                "type": "array",
-                                "uniqueItems": true
-                            },
-                            "successes": {
-                                "default": 3,
-                                "minimum": 1,
-                                "type": "integer"
-                            }
-                        },
-                        "type": "object"
-                    },
-                    "max_breaker_sec": {
-                        "default": 300,
-                        "minimum": 3,
-                        "type": "integer"
-                    },
-                    "unhealthy": {
-                        "default": {
-                            "failures": 3,
-                            "http_statuses": [
-                                500
-                            ]
-                        },
-                        "properties": {
-                            "failures": {
-                                "default": 3,
-                                "minimum": 1,
-                                "type": "integer"
-                            },
-                            "http_statuses": {
-                                "default": [
-                                    500
-                                ],
-                                "items": {
-                                    "maximum": 599,
-                                    "minimum": 500,
-                                    "type": "integer"
-                                },
-                                "minItems": 1,
-                                "type": "array",
-                                "uniqueItems": true
-                            }
-                        },
-                        "type": "object"
-                    }
-                },
-                "required": [
-                    "break_response_code"
-                ],
-                "type": "object"
-            },
-            "version": 0.1
-        },
-        "authz-keycloak": {
-            "priority": 2000,
-            "schema": {
-                "properties": {
-                    "audience": {
-                        "maxLength": 100,
-                        "minLength": 1,
-                        "type": "string"
-                    },
-                    "grant_type": {
-                        "default": "urn:ietf:params:oauth:grant-type:uma-ticket",
-                        "enum": [
-                            "urn:ietf:params:oauth:grant-type:uma-ticket"
-                        ],
-                        "maxLength": 100,
-                        "minLength": 1,
-                        "type": "string"
-                    },
-                    "keepalive": {
-                        "default": true,
-                        "type": "boolean"
-                    },
-                    "keepalive_pool": {
-                        "default": 5,
-                        "minimum": 1,
-                        "type": "integer"
-                    },
-                    "keepalive_timeout": {
-                        "default": 60000,
-                        "minimum": 1000,
-                        "type": "integer"
-                    },
-                    "permissions": {
-                        "items": {
-                            "maxLength": 100,
-                            "minLength": 1,
-                            "type": "string"
-                        },
-                        "type": "array",
-                        "uniqueItems": true
-                    },
-                    "policy_enforcement_mode": {
-                        "default": "ENFORCING",
-                        "enum": [
-                            "ENFORCING",
-                            "PERMISSIVE"
-                        ],
-                        "type": "string"
-                    },
-                    "ssl_verify": {
-                        "default": true,
-                        "type": "boolean"
-                    },
-                    "timeout": {
-                        "default": 3000,
-                        "minimum": 1000,
-                        "type": "integer"
-                    },
-                    "token_endpoint": {
-                        "maxLength": 4096,
-                        "minLength": 1,
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "token_endpoint"
-                ],
-                "type": "object"
-            },
-            "version": 0.1
-        },
-        "basic-auth": {
-            "consumer_schema": {
-                "additionalProperties": false,
-                "properties": {
-                    "password": {
-                        "type": "string"
-                    },
-                    "username": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "password",
-                    "username"
-                ],
-                "title": "work with consumer object",
-                "type": "object"
-            },
-            "priority": 2520,
-            "schema": {
-                "additionalProperties": false,
-                "properties": {
-                    "disable": {
-                        "type": "boolean"
-                    }
-                },
-                "title": "work with route or service object",
-                "type": "object"
-            },
-            "type": "auth",
-            "version": 0.1
-        },
-        "batch-requests": {
-            "metadata_schema": {
-                "additionalProperties": false,
-                "properties": {
-                    "max_body_size": {
-                        "default": 1048576,
-                        "description": "max pipeline body size in bytes",
-                        "exclusiveMinimum": 0,
-                        "type": "integer"
-                    }
-                },
-                "type": "object"
-            },
-            "priority": 4010,
-            "schema": {
-                "additionalProperties": false,
-                "properties": {
-                    "disable": {
-                        "type": "boolean"
-                    }
-                },
-                "type": "object"
-            },
-            "version": 0.1
-        },
-        "consumer-restriction": {
-            "priority": 2400,
-            "schema": {
-                "oneOf": [
-                    {
-                        "properties": {
-                            "blacklist": {
-                                "items": {
-                                    "type": "string"
-                                },
-                                "minItems": 1,
-                                "type": "array"
-                            },
-                            "rejected_code": {
-                                "default": 403,
-                                "minimum": 200,
-                                "type": "integer"
-                            },
-                            "type": {
-                                "default": "consumer_name",
-                                "enum": [
-                                    "consumer_name",
-                                    "service_id"
-                                ],
-                                "type": "string"
-                            }
-                        },
-                        "required": [
-                            "blacklist"
-                        ],
-                        "title": "blacklist"
-                    },
-                    {
-                        "properties": {
-                            "rejected_code": {
-                                "default": 403,
-                                "minimum": 200,
-                                "type": "integer"
-                            },
-                            "type": {
-                                "default": "consumer_name",
-                                "enum": [
-                                    "consumer_name",
-                                    "service_id"
-                                ],
-                                "type": "string"
-                            },
-                            "whitelist": {
-                                "items": {
-                                    "type": "string"
-                                },
-                                "minItems": 1,
-                                "type": "array"
-                            }
-                        },
-                        "required": [
-                            "whitelist"
-                        ],
-                        "title": "whitelist"
-                    }
-                ],
-                "properties": {
-                    "disable": {
-                        "type": "boolean"
-                    }
-                },
-                "type": "object"
-            },
-            "version": 0.1
-        },
-        "cors": {
-            "priority": 4000,
-            "schema": {
-                "properties": {
-                    "allow_credential": {
-                        "default": false,
-                        "description": "allow client append credential. according to CORS specification,if you set this option to 'true', you can not use '*' for other options.",
-                        "type": "boolean"
-                    },
-                    "allow_headers": {
-                        "default": "*",
-                        "description": "you can use '*' to allow all header when no credentials,'**' to allow forcefully(it will bring some security risks, be carefully),multiple header use ',' to split. default: *.",
-                        "type": "string"
-                    },
-                    "allow_methods": {
-                        "default": "*",
-                        "description": "you can use '*' to allow all methods when no credentials and '**','**' to allow forcefully(it will bring some security risks, be carefully),multiple method use ',' to split. default: *.",
-                        "type": "string"
-                    },
-                    "allow_origins": {
-                        "default": "*",
-                        "description": "you can use '*' to allow all origins when no credentials,'**' to allow forcefully(it will bring some security risks, be carefully),multiple origin use ',' to split. default: *.",
-                        "type": "string"
-                    },
-                    "expose_headers": {
-                        "default": "*",
-                        "description": "you can use '*' to expose all header when no credentials,multiple header use ',' to split. default: *.",
-                        "type": "string"
-                    },
-                    "max_age": {
-                        "default": 5,
-                        "description": "maximum number of seconds the results can be cached.-1 mean no cached,the max value is depend on browser,more detail plz check MDN. default: 5.",
-                        "type": "integer"
-                    }
-                },
-                "type": "object"
-            },
-            "version": 0.1
-        },
-        "echo": {
-            "priority": 412,
-            "schema": {
-                "additionalProperties": false,
-                "anyOf": [
-                    {
-                        "required": [
-                            "before_body"
-                        ]
-                    },
-                    {
-                        "required": [
-                            "body"
-                        ]
-                    },
-                    {
-                        "required": [
-                            "after_body"
-                        ]
-                    }
-                ],
-                "minProperties": 1,
-                "properties": {
-                    "after_body": {
-                        "description": "body after the modification of filter phase.",
-                        "type": "string"
-                    },
-                    "auth_value": {
-                        "description": "auth value",
-                        "type": "string"
-                    },
-                    "before_body": {
-                        "description": "body before the filter phase.",
-                        "type": "string"
-                    },
-                    "body": {
-                        "description": "body to replace upstream response.",
-                        "type": "string"
-                    },
-                    "headers": {
-                        "description": "new headers for response",
-                        "minProperties": 1,
-                        "type": "object"
-                    }
-                },
-                "type": "object"
-            },
-            "version": 0.1
-        },
-        "fault-injection": {
-            "priority": 11000,
-            "schema": {
-                "minProperties": 1,
-                "properties": {
-                    "abort": {
-                        "properties": {
-                            "body": {
-                                "minLength": 0,
-                                "type": "string"
-                            },
-                            "http_status": {
-                                "minimum": 200,
-                                "type": "integer"
-                            },
-                            "percentage": {
-                                "maximum": 100,
-                                "minimum": 0,
-                                "type": "integer"
-                            }
-                        },
-                        "required": [
-                            "http_status"
-                        ],
-                        "type": "object"
-                    },
-                    "delay": {
-                        "properties": {
-                            "duration": {
-                                "minimum": 0,
-                                "type": "number"
-                            },
-                            "percentage": {
-                                "maximum": 100,
-                                "minimum": 0,
-                                "type": "integer"
-                            }
-                        },
-                        "required": [
-                            "duration"
-                        ],
-                        "type": "object"
-                    }
-                },
-                "type": "object"
-            },
-            "version": 0.1
-        },
-        "grpc-transcode": {
-            "priority": 506,
-            "schema": {
-                "additionalProperties": true,
-                "properties": {
-                    "deadline": {
-                        "default": 0,
-                        "description": "deadline for grpc, millisecond",
-                        "type": "number"
-                    },
-                    "method": {
-                        "description": "the method name in the grpc service.",
-                        "type": "string"
-                    },
-                    "pb_option": {
-                        "items": {
-                            "anyOf": [
-                                {
-                                    "description": "enum as result",
-                                    "enum": [
-                                        "int64_as_hexstring",
-                                        "int64_as_number",
-                                        "int64_as_string"
-                                    ],
-                                    "type": "string"
-                                },
-                                {
-                                    "description": "int64 as result",
-                                    "enum": [
-                                        "enum_as_value",
-                                        "ienum_as_name"
-                                    ],
-                                    "type": "string"
-                                },
-                                {
-                                    "description": "default values option",
-                                    "enum": [
-                                        "auto_default_values",
-                                        "no_default_values",
-                                        "use_default_metatable",
-                                        "use_default_values"
-                                    ],
-                                    "type": "string"
-                                },
-                                {
-                                    "description": "hooks option",
-                                    "enum": [
-                                        "disable_hooks",
-                                        "enable_hooks"
-                                    ],
-                                    "type": "string"
-                                }
-                            ],
-                            "type": "string"
-                        },
-                        "minItems": 1,
-                        "type": "array"
-                    },
-                    "proto_id": {
-                        "anyOf": [
-                            {
-                                "maxLength": 64,
-                                "minLength": 1,
-                                "pattern": "^[a-zA-Z0-9-_.]+$",
-                                "type": "string"
-                            },
-                            {
-                                "minimum": 1,
-                                "type": "integer"
-                            }
-                        ]
-                    },
-                    "service": {
-                        "description": "the grpc service name",
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "method",
-                    "proto_id",
-                    "service"
-                ],
-                "type": "object"
-            },
-            "version": 0.1
-        },
-        "hmac-auth": {
-            "consumer_schema": {
-                "additionalProperties": false,
-                "properties": {
-                    "access_key": {
-                        "maxLength": 256,
-                        "minLength": 1,
-                        "type": "string"
-                    },
-                    "algorithm": {
-                        "default": "hmac-sha256",
-                        "enum": [
-                            "hmac-sha1",
-                            "hmac-sha256",
-                            "hmac-sha512"
-                        ],
-                        "type": "string"
-                    },
-                    "clock_skew": {
-                        "default": 0,
-                        "type": "integer"
-                    },
-                    "encode_uri_params": {
-                        "default": true,
-                        "title": "Whether to escape the uri parameter",
-                        "type": "boolean"
-                    },
-                    "keep_headers": {
-                        "default": false,
-                        "title": "whether to keep the http request header",
-                        "type": "boolean"
-                    },
-                    "secret_key": {
-                        "maxLength": 256,
-                        "minLength": 1,
-                        "type": "string"
-                    },
-                    "signed_headers": {
-                        "items": {
-                            "maxLength": 50,
-                            "minLength": 1,
-                            "type": "string"
-                        },
-                        "type": "array"
-                    }
-                },
-                "required": [
-                    "access_key",
-                    "secret_key"
-                ],
-                "title": "work with consumer object",
-                "type": "object"
-            },
-            "priority": 2530,
-            "schema": {
-                "additionalProperties": false,
-                "properties": {
-                    "disable": {
-                        "type": "boolean"
-                    }
-                },
-                "title": "work with route or service object",
-                "type": "object"
-            },
-            "type": "auth",
-            "version": 0.1
-        },
-        "http-logger": {
-            "metadata_schema": {
-                "additionalProperties": false,
-                "properties": {
-                    "log_format": {
-                        "default": {
-                            "@timestamp": "$time_iso8601",
-                            "client_ip": "$remote_addr",
-                            "host": "$host"
-                        },
-                        "type": "object"
-                    }
-                },
-                "type": "object"
-            },
-            "priority": 410,
-            "schema": {
-                "properties": {
-                    "auth_header": {
-                        "default": "",
-                        "type": "string"
-                    },
-                    "batch_max_size": {
-                        "default": 1000,
-                        "minimum": 1,
-                        "type": "integer"
-                    },
-                    "buffer_duration": {
-                        "default": 60,
-                        "minimum": 1,
-                        "type": "integer"
-                    },
-                    "concat_method": {
-                        "default": "json",
-                        "enum": [
-                            "json",
-                            "new_line"
-                        ],
-                        "type": "string"
-                    },
-                    "inactive_timeout": {
-                        "default": 5,
-                        "minimum": 1,
-                        "type": "integer"
-                    },
-                    "include_req_body": {
-                        "default": false,
-                        "type": "boolean"
-                    },
-                    "max_retry_count": {
-                        "default": 0,
-                        "minimum": 0,
-                        "type": "integer"
-                    },
-                    "name": {
-                        "default": "http logger",
-                        "type": "string"
-                    },
-                    "retry_delay": {
-                        "default": 1,
-                        "minimum": 0,
-                        "type": "integer"
-                    },
-                    "timeout": {
-                        "default": 3,
-                        "minimum": 1,
-                        "type": "integer"
-                    },
-                    "uri": {
-                        "pattern": "^[^\\/]+:\\/\\/([\\da-zA-Z.-]+|\\[[\\da-fA-F:]+\\])(:\\d+)?",
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "uri"
-                ],
-                "type": "object"
-            },
-            "version": 0.1
-        },
-        "ip-restriction": {
-            "priority": 3000,
-            "schema": {
-                "oneOf": [
-                    {
-                        "additionalProperties": false,
-                        "properties": {
-                            "whitelist": {
-                                "items": {
-                                    "anyOf": [
-                                        {
-                                            "format": "ipv4",
-                                            "title": "IPv4",
-                                            "type": "string"
-                                        },
-                                        {
-                                            "pattern": "^([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])/([12]?[0-9]|3[0-2])$",
-                                            "title": "IPv4/CIDR",
-                                            "type": "string"
-                                        },
-                                        {
-                                            "format": "ipv6",
-                                            "title": "IPv6",
-                                            "type": "string"
-                                        },
-                                        {
-                                            "pattern": "^([a-fA-F0-9]{0,4}:){1,8}(:[a-fA-F0-9]{0,4}){0,8}([a-fA-F0-9]{0,4})?/[0-9]{1,3}$",
-                                            "title": "IPv6/CIDR",
-                                            "type": "string"
-                                        }
-                                    ]
-                                },
-                                "minItems": 1,
-                                "type": "array"
-                            }
-                        },
-                        "required": [
-                            "whitelist"
-                        ],
-                        "title": "whitelist"
-                    },
-                    {
-                        "additionalProperties": false,
-                        "properties": {
-                            "blacklist": {
-                                "items": {
-                                    "anyOf": [
-                                        {
-                                            "format": "ipv4",
-                                            "title": "IPv4",
-                                            "type": "string"
-                                        },
-                                        {
-                                            "pattern": "^([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])/([12]?[0-9]|3[0-2])$",
-                                            "title": "IPv4/CIDR",
-                                            "type": "string"
-                                        },
-                                        {
-                                            "format": "ipv6",
-                                            "title": "IPv6",
-                                            "type": "string"
-                                        },
-                                        {
-                                            "pattern": "^([a-fA-F0-9]{0,4}:){1,8}(:[a-fA-F0-9]{0,4}){0,8}([a-fA-F0-9]{0,4})?/[0-9]{1,3}$",
-                                            "title": "IPv6/CIDR",
-                                            "type": "string"
-                                        }
-                                    ]
-                                },
-                                "minItems": 1,
-                                "type": "array"
-                            }
-                        },
-                        "required": [
-                            "blacklist"
-                        ],
-                        "title": "blacklist"
-                    }
-                ],
-                "properties": {
-                    "disable": {
-                        "type": "boolean"
-                    }
-                },
-                "type": "object"
-            },
-            "version": 0.1
-        },
-        "jwt-auth": {
-            "consumer_schema": {
-                "dependencies": {
-                    "algorithm": {
-                        "oneOf": [
-                            {
-                                "properties": {
-                                    "algorithm": {
-                                        "default": "HS256",
-                                        "enum": [
-                                            "HS256",
-                                            "HS512"
-                                        ]
-                                    }
-                                }
-                            },
-                            {
-                                "properties": {
-                                    "algorithm": {
-                                        "enum": [
-                                            "RS256"
-                                        ]
-                                    },
-                                    "private_key": {
-                                        "type": "string"
-                                    },
-                                    "public_key": {
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "private_key",
-                                    "public_key"
-                                ]
-                            }
-                        ]
-                    }
-                },
-                "properties": {
-                    "algorithm": {
-                        "default": "HS256",
-                        "enum": [
-                            "HS256",
-                            "HS512",
-                            "RS256"
-                        ],
-                        "type": "string"
-                    },
-                    "base64_secret": {
-                        "default": false,
-                        "type": "boolean"
-                    },
-                    "exp": {
-                        "default": 86400,
-                        "minimum": 1,
-                        "type": "integer"
-                    },
-                    "key": {
-                        "type": "string"
-                    },
-                    "secret": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "key"
-                ],
-                "type": "object"
-            },
-            "priority": 2510,
-            "schema": {
-                "additionalProperties": false,
-                "properties": {
-                    "disable": {
-                        "type": "boolean"
-                    }
-                },
-                "type": "object"
-            },
-            "type": "auth",
-            "version": 0.1
-        },
-        "kafka-logger": {
-            "priority": 403,
-            "schema": {
-                "properties": {
-                    "batch_max_size": {
-                        "default": 1000,
-                        "minimum": 1,
-                        "type": "integer"
-                    },
-                    "broker_list": {
-                        "type": "object"
-                    },
-                    "buffer_duration": {
-                        "default": 60,
-                        "minimum": 1,
-                        "type": "integer"
-                    },
-                    "inactive_timeout": {
-                        "default": 5,
-                        "minimum": 1,
-                        "type": "integer"
-                    },
-                    "include_req_body": {
-                        "default": false,
-                        "type": "boolean"
-                    },
-                    "kafka_topic": {
-                        "type": "string"
-                    },
-                    "key": {
-                        "type": "string"
-                    },
-                    "max_retry_count": {
-                        "default": 0,
-                        "minimum": 0,
-                        "type": "integer"
-                    },
-                    "meta_format": {
-                        "default": "default",
-                        "enum": [
-                            "default",
-                            "origin"
-                        ],
-                        "type": "string"
-                    },
-                    "name": {
-                        "default": "kafka logger",
-                        "type": "string"
-                    },
-                    "retry_delay": {
-                        "default": 1,
-                        "minimum": 0,
-                        "type": "integer"
-                    },
-                    "timeout": {
-                        "default": 3,
-                        "minimum": 1,
-                        "type": "integer"
-                    }
-                },
-                "required": [
-                    "broker_list",
-                    "kafka_topic"
-                ],
-                "type": "object"
-            },
-            "version": 0.1
-        },
-        "key-auth": {
-            "consumer_schema": {
-                "additionalProperties": false,
-                "properties": {
-                    "key": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "key"
-                ],
-                "type": "object"
-            },
-            "priority": 2500,
-            "schema": {
-                "additionalProperties": false,
-                "properties": {
-                    "disable": {
-                        "type": "boolean"
-                    }
-                },
-                "type": "object"
-            },
-            "type": "auth",
-            "version": 0.1
-        },
-        "limit-conn": {
-            "priority": 1003,
-            "schema": {
-                "properties": {
-                    "burst": {
-                        "minimum": 0,
-                        "type": "integer"
-                    },
-                    "conn": {
-                        "exclusiveMinimum": 0,
-                        "type": "integer"
-                    },
-                    "default_conn_delay": {
-                        "exclusiveMinimum": 0,
-                        "type": "number"
-                    },
-                    "key": {
-                        "enum": [
-                            "consumer_name",
-                            "http_x_forwarded_for",
-                            "http_x_real_ip",
-                            "remote_addr",
-                            "server_addr"
-                        ],
-                        "type": "string"
-                    },
-                    "rejected_code": {
-                        "default": 503,
-                        "minimum": 200,
-                        "type": "integer"
-                    }
-                },
-                "required": [
-                    "burst",
-                    "conn",
-                    "default_conn_delay",
-                    "key"
-                ],
-                "type": "object"
-            },
-            "version": 0.1
-        },
-        "limit-count": {
-            "priority": 1002,
-            "schema": {
-                "dependencies": {
-                    "policy": {
-                        "oneOf": [
-                            {
-                                "properties": {
-                                    "policy": {
-                                        "enum": [
-                                            "local"
-                                        ]
-                                    }
-                                }
-                            },
-                            {
-                                "properties": {
-                                    "policy": {
-                                        "enum": [
-                                            "redis"
-                                        ]
-                                    },
-                                    "redis_host": {
-                                        "minLength": 2,
-                                        "type": "string"
-                                    },
-                                    "redis_password": {
-                                        "minLength": 0,
-                                        "type": "string"
-                                    },
-                                    "redis_port": {
-                                        "default": 6379,
-                                        "minimum": 1,
-                                        "type": "integer"
-                                    },
-                                    "redis_timeout": {
-                                        "default": 1000,
-                                        "minimum": 1,
-                                        "type": "integer"
-                                    }
-                                },
-                                "required": [
-                                    "redis_host"
-                                ]
-                            },
-                            {
-                                "properties": {
-                                    "policy": {
-                                        "enum": [
-                                            "redis-cluster"
-                                        ]
-                                    },
-                                    "redis_cluster_nodes": {
-                                        "items": {
-                                            "maxLength": 100,
-                                            "minLength": 2,
-                                            "type": "string"
-                                        },
-                                        "minItems": 2,
-                                        "type": "array"
-                                    },
-                                    "redis_password": {
-                                        "minLength": 0,
-                                        "type": "string"
-                                    },
-                                    "redis_timeout": {
-                                        "default": 1000,
-                                        "minimum": 1,
-                                        "type": "integer"
-                                    }
-                                },
-                                "required": [
-                                    "redis_cluster_nodes"
-                                ]
-                            }
-                        ]
-                    }
-                },
-                "properties": {
-                    "count": {
-                        "minimum": 0,
-                        "type": "integer"
-                    },
-                    "key": {
-                        "default": "remote_addr",
-                        "enum": [
-                            "consumer_name",
-                            "http_x_forwarded_for",
-                            "http_x_real_ip",
-                            "remote_addr",
-                            "server_addr",
-                            "service_id"
-                        ],
-                        "type": "string"
-                    },
-                    "policy": {
-                        "default": "local",
-                        "enum": [
-                            "local",
-                            "redis",
-                            "redis-cluster"
-                        ],
-                        "type": "string"
-                    },
-                    "rejected_code": {
-                        "default": 503,
-                        "maximum": 600,
-                        "minimum": 200,
-                        "type": "integer"
-                    },
-                    "time_window": {
-                        "minimum": 0,
-                        "type": "integer"
-                    }
-                },
-                "required": [
-                    "count",
-                    "time_window"
-                ],
-                "type": "object"
-            },
-            "version": 0.4
-        },
-        "limit-req": {
-            "priority": 1001,
-            "schema": {
-                "properties": {
-                    "burst": {
-                        "minimum": 0,
-                        "type": "number"
-                    },
-                    "key": {
-                        "enum": [
-                            "consumer_name",
-                            "http_x_forwarded_for",
-                            "http_x_real_ip",
-                            "remote_addr",
-                            "server_addr"
-                        ],
-                        "type": "string"
-                    },
-                    "rate": {
-                        "minimum": 0,
-                        "type": "number"
-                    },
-                    "rejected_code": {
-                        "default": 503,
-                        "minimum": 200,
-                        "type": "integer"
-                    }
-                },
-                "required": [
-                    "burst",
-                    "key",
-                    "rate"
-                ],
-                "type": "object"
-            },
-            "version": 0.1
-        },
-        "mqtt-proxy": {
-            "priority": 1000,
-            "schema": {
-                "properties": {
-                    "protocol_level": {
-                        "type": "integer"
-                    },
-                    "protocol_name": {
-                        "type": "string"
-                    },
-                    "upstream": {
-                        "properties": {
-                            "ip": {
-                                "type": "string"
-                            },
-                            "port": {
-                                "type": "number"
-                            }
-                        },
-                        "type": "object"
-                    }
-                },
-                "required": [
-                    "protocol_level",
-                    "protocol_name",
-                    "upstream"
-                ],
-                "type": "object"
-            },
-            "version": 0.1
-        },
-        "openid-connect": {
-            "priority": 2599,
-            "schema": {
-                "properties": {
-                    "bearer_only": {
-                        "default": false,
-                        "type": "boolean"
-                    },
-                    "client_id": {
-                        "type": "string"
-                    },
-                    "client_secret": {
-                        "type": "string"
-                    },
-                    "discovery": {
-                        "type": "string"
-                    },
-                    "introspection_endpoint": {
-                        "type": "string"
-                    },
-                    "introspection_endpoint_auth_method": {
-                        "default": "client_secret_basic",
-                        "type": "string"
-                    },
-                    "logout_path": {
-                        "default": "/logout",
-                        "type": "string"
-                    },
-                    "public_key": {
-                        "type": "string"
-                    },
-                    "realm": {
-                        "default": "apisix",
-                        "type": "string"
-                    },
-                    "redirect_uri": {
-                        "description": "use ngx.var.request_uri if not configured",
-                        "type": "string"
-                    },
-                    "scope": {
-                        "default": "openid",
-                        "type": "string"
-                    },
-                    "ssl_verify": {
-                        "default": false,
-                        "type": "boolean"
-                    },
-                    "timeout": {
-                        "default": 3,
-                        "description": "timeout in seconds",
-                        "minimum": 1,
-                        "type": "integer"
-                    },
-                    "token_signing_alg_values_expected": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "client_id",
-                    "client_secret",
-                    "discovery"
-                ],
-                "type": "object"
-            },
-            "version": 0.1
-        },
-        "prometheus": {
-            "priority": 500,
-            "schema": {
-                "additionalProperties": false,
-                "properties": {
-                    "disable": {
-                        "type": "boolean"
-                    }
-                },
-                "type": "object"
-            },
-            "version": 0.2
-        },
-        "proxy-cache": {
-            "priority": 1009,
-            "schema": {
-                "properties": {
-                    "cache_bypass": {
-                        "items": {
-                            "pattern": "(^[^\\$].+$|^\\$[0-9a-zA-Z_]+$)",
-                            "type": "string"
-                        },
-                        "minItems": 1,
-                        "type": "array"
-                    },
-                    "cache_http_status": {
-                        "default": [
-                            200,
-                            301,
-                            404
-                        ],
-                        "items": {
-                            "description": "http response status",
-                            "maximum": 599,
-                            "minimum": 200,
-                            "type": "integer"
-                        },
-                        "minItems": 1,
-                        "type": "array",
-                        "uniqueItems": true
-                    },
-                    "cache_key": {
-                        "default": [
-                            "$host",
-                            "$request_uri"
-                        ],
-                        "items": {
-                            "description": "a key for caching",
-                            "pattern": "(^[^\\$].+$|^\\$[0-9a-zA-Z_]+$)",
-                            "type": "string"
-                        },
-                        "minItems": 1,
-                        "type": "array"
-                    },
-                    "cache_method": {
-                        "default": [
-                            "GET",
-                            "HEAD"
-                        ],
-                        "items": {
-                            "description": "http method",
-                            "enum": [
-                                "CONNECT",
-                                "DELETE",
-                                "GET",
-                                "HEAD",
-                                "OPTIONS",
-                                "PATCH",
-                                "POST",
-                                "PUT",
-                                "TRACE"
-                            ],
-                            "type": "string"
-                        },
-                        "minItems": 1,
-                        "type": "array",
-                        "uniqueItems": true
-                    },
-                    "cache_zone": {
-                        "default": "disk_cache_one",
-                        "maxLength": 100,
-                        "minLength": 1,
-                        "type": "string"
-                    },
-                    "hide_cache_headers": {
-                        "default": false,
-                        "type": "boolean"
-                    },
-                    "no_cache": {
-                        "items": {
-                            "pattern": "(^[^\\$].+$|^\\$[0-9a-zA-Z_]+$)",
-                            "type": "string"
-                        },
-                        "minItems": 1,
-                        "type": "array"
-                    }
-                },
-                "type": "object"
-            },
-            "version": 0.1
-        },
-        "proxy-mirror": {
-            "priority": 1010,
-            "schema": {
-                "minProperties": 1,
-                "properties": {
-                    "host": {
-                        "pattern": "^http(s)?:\\/\\/[a-zA-Z0-9][-a-zA-Z0-9]{0,62}(\\.[a-zA-Z0-9][-a-zA-Z0-9]{0,62})+(:[0-9]{1,5})?$",
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "host"
-                ],
-                "type": "object"
-            },
-            "version": 0.1
-        },
-        "proxy-rewrite": {
-            "priority": 1008,
-            "schema": {
-                "additionalProperties": false,
-                "minProperties": 1,
-                "properties": {
-                    "headers": {
-                        "description": "new headers for request",
-                        "minProperties": 1,
-                        "type": "object"
-                    },
-                    "host": {
-                        "description": "new host for upstream",
-                        "pattern": "^[0-9a-zA-Z-.]+$",
-                        "type": "string"
-                    },
-                    "regex_uri": {
-                        "description": "new uri that substitute from client uri for upstream, lower priority than uri property",
-                        "items": {
-                            "description": "regex uri",
-                            "type": "string"
-                        },
-                        "maxItems": 2,
-                        "minItems": 2,
-                        "type": "array"
-                    },
-                    "scheme": {
-                        "description": "new scheme for upstream",
-                        "enum": [
-                            "http",
-                            "https"
-                        ],
-                        "type": "string"
-                    },
-                    "uri": {
-                        "description": "new uri for upstream",
-                        "maxLength": 4096,
-                        "minLength": 1,
-                        "pattern": "^\\/.*",
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "version": 0.1
-        },
-        "redirect": {
-            "priority": 900,
-            "schema": {
-                "oneOf": [
-                    {
-                        "required": [
-                            "uri"
-                        ]
-                    },
-                    {
-                        "required": [
-                            "http_to_https"
-                        ]
-                    }
-                ],
-                "properties": {
-                    "http_to_https": {
-                        "type": "boolean"
-                    },
-                    "ret_code": {
-                        "default": 302,
-                        "minimum": 200,
-                        "type": "integer"
-                    },
-                    "uri": {
-                        "minLength": 2,
-                        "pattern": "(\\\\\\$[0-9a-zA-Z_]+)|\\$\\{([0-9a-zA-Z_]+)\\}|\\$([0-9a-zA-Z_]+)|(\\$|[^$\\\\]+)",
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "version": 0.1
-        },
-        "referer-restriction": {
-            "priority": 2990,
-            "schema": {
-                "additionalProperties": false,
-                "properties": {
-                    "bypass_missing": {
-                        "default": false,
-                        "type": "boolean"
-                    },
-                    "whitelist": {
-                        "items": {
-                            "pattern": "^\\*?[0-9a-zA-Z-._]+$",
-                            "type": "string"
-                        },
-                        "minItems": 1,
-                        "type": "array"
-                    }
-                },
-                "required": [
-                    "whitelist"
-                ],
-                "type": "object"
-            },
-            "version": 0.1
-        },
-        "request-id": {
-            "priority": 11010,
-            "schema": {
-                "properties": {
-                    "header_name": {
-                        "default": "X-Request-Id",
-                        "type": "string"
-                    },
-                    "include_in_response": {
-                        "default": true,
-                        "type": "boolean"
-                    }
-                },
-                "type": "object"
-            },
-            "version": 0.1
-        },
-        "request-validation": {
-            "priority": 2800,
-            "schema": {
-                "anyOf": [
-                    {
-                        "properties": {
-                            "body_schema": {
-                                "type": "object"
-                            }
-                        },
-                        "required": [
-                            "body_schema"
-                        ],
-                        "title": "Body schema"
-                    },
-                    {
-                        "properties": {
-                            "header_schema": {
-                                "type": "object"
-                            }
-                        },
-                        "required": [
-                            "header_schema"
-                        ],
-                        "title": "Header schema"
-                    }
-                ],
-                "properties": {
-                    "disable": {
-                        "type": "boolean"
-                    }
-                },
-                "type": "object"
-            },
-            "type": "validation",
-            "version": 0.1
-        },
-        "response-rewrite": {
-            "priority": 899,
-            "schema": {
-                "additionalProperties": false,
-                "minProperties": 1,
-                "properties": {
-                    "body": {
-                        "description": "new body for response",
-                        "type": "string"
-                    },
-                    "body_base64": {
-                        "default": false,
-                        "description": "whether new body for response need base64 decode before return",
-                        "type": "boolean"
-                    },
-                    "headers": {
-                        "description": "new headers for response",
-                        "minProperties": 1,
-                        "type": "object"
-                    },
-                    "status_code": {
-                        "description": "new status code for response",
-                        "maximum": 598,
-                        "minimum": 200,
-                        "type": "integer"
-                    }
-                },
-                "type": "object"
-            },
-            "version": 0.1
-        },
-        "serverless-post-function": {
-            "priority": -2000,
-            "schema": {
-                "properties": {
-                    "functions": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "minItems": 1,
-                        "type": "array"
-                    },
-                    "phase": {
-                        "default": "access",
-                        "enum": [
-                            "access",
-                            "balancer",
-                            "body_filter",
-                            "header_filter",
-                            "log",
-                            "rewrite"
-                        ],
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "functions"
-                ],
-                "type": "object"
-            },
-            "version": 0.1
-        },
-        "serverless-pre-function": {
-            "priority": 10000,
-            "schema": {
-                "properties": {
-                    "functions": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "minItems": 1,
-                        "type": "array"
-                    },
-                    "phase": {
-                        "default": "access",
-                        "enum": [
-                            "access",
-                            "balancer",
-                            "body_filter",
-                            "header_filter",
-                            "log",
-                            "rewrite"
-                        ],
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "functions"
-                ],
-                "type": "object"
-            },
-            "version": 0.1
-        },
-        "sls-logger": {
-            "priority": 406,
-            "schema": {
-                "properties": {
-                    "access_key_id": {
-                        "type": "string"
-                    },
-                    "access_key_secret": {
-                        "type": "string"
-                    },
-                    "batch_max_size": {
-                        "default": 1000,
-                        "minimum": 1,
-                        "type": "integer"
-                    },
-                    "buffer_duration": {
-                        "default": 60,
-                        "minimum": 1,
-                        "type": "integer"
-                    },
-                    "host": {
-                        "type": "string"
-                    },
-                    "inactive_timeout": {
-                        "default": 5,
-                        "minimum": 1,
-                        "type": "integer"
-                    },
-                    "include_req_body": {
-                        "default": false,
-                        "type": "boolean"
-                    },
-                    "logstore": {
-                        "type": "string"
-                    },
-                    "max_retry_count": {
-                        "default": 0,
-                        "minimum": 0,
-                        "type": "integer"
-                    },
-                    "name": {
-                        "default": "sls-logger",
-                        "type": "string"
-                    },
-                    "port": {
-                        "type": "integer"
-                    },
-                    "project": {
-                        "type": "string"
-                    },
-                    "retry_delay": {
-                        "default": 1,
-                        "minimum": 0,
-                        "type": "integer"
-                    },
-                    "timeout": {
-                        "default": 5000,
-                        "minimum": 1,
-                        "type": "integer"
-                    }
-                },
-                "required": [
-                    "access_key_id",
-                    "access_key_secret",
-                    "host",
-                    "logstore",
-                    "port",
-                    "project"
-                ],
-                "type": "object"
-            },
-            "version": 0.1
-        },
-        "syslog": {
-            "priority": 401,
-            "schema": {
-                "properties": {
-                    "batch_max_size": {
-                        "default": 1000,
-                        "minimum": 1,
-                        "type": "integer"
-                    },
-                    "buffer_duration": {
-                        "default": 60,
-                        "minimum": 1,
-                        "type": "integer"
-                    },
-                    "drop_limit": {
-                        "default": 1048576,
-                        "type": "integer"
-                    },
-                    "flush_limit": {
-                        "default": 4096,
-                        "minimum": 1,
-                        "type": "integer"
-                    },
-                    "host": {
-                        "type": "string"
-                    },
-                    "include_req_body": {
-                        "default": false,
-                        "type": "boolean"
-                    },
-                    "max_retry_times": {
-                        "default": 1,
-                        "minimum": 1,
-                        "type": "integer"
-                    },
-                    "name": {
-                        "default": "sys logger",
-                        "type": "string"
-                    },
-                    "pool_size": {
-                        "default": 5,
-                        "minimum": 5,
-                        "type": "integer"
-                    },
-                    "port": {
-                        "type": "integer"
-                    },
-                    "retry_interval": {
-                        "default": 1,
-                        "minimum": 0,
-                        "type": "integer"
-                    },
-                    "sock_type": {
-                        "default": "tcp",
-                        "enum": [
-                            "tcp",
-                            "udp"
-                        ],
-                        "type": "string"
-                    },
-                    "timeout": {
-                        "default": 3,
-                        "minimum": 1,
-                        "type": "integer"
-                    },
-                    "tls": {
-                        "default": false,
-                        "type": "boolean"
-                    }
-                },
-                "required": [
-                    "host",
-                    "port"
-                ],
-                "type": "object"
-            },
-            "version": 0.1
-        },
-        "tcp-logger": {
-            "priority": 405,
-            "schema": {
-                "properties": {
-                    "batch_max_size": {
-                        "default": 1000,
-                        "minimum": 1,
-                        "type": "integer"
-                    },
-                    "buffer_duration": {
-                        "default": 60,
-                        "minimum": 1,
-                        "type": "integer"
-                    },
-                    "host": {
-                        "type": "string"
-                    },
-                    "inactive_timeout": {
-                        "default": 5,
-                        "minimum": 1,
-                        "type": "integer"
-                    },
-                    "include_req_body": {
-                        "default": false,
-                        "type": "boolean"
-                    },
-                    "max_retry_count": {
-                        "default": 0,
-                        "minimum": 0,
-                        "type": "integer"
-                    },
-                    "name": {
-                        "default": "tcp logger",
-                        "type": "string"
-                    },
-                    "port": {
-                        "minimum": 0,
-                        "type": "integer"
-                    },
-                    "retry_delay": {
-                        "default": 1,
-                        "minimum": 0,
-                        "type": "integer"
-                    },
-                    "timeout": {
-                        "default": 1000,
-                        "minimum": 1,
-                        "type": "integer"
-                    },
-                    "tls": {
-                        "default": false,
-                        "type": "boolean"
-                    },
-                    "tls_options": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "host",
-                    "port"
-                ],
-                "type": "object"
-            },
-            "version": 0.1
-        },
-        "traffic-split": {
-            "priority": 966,
-            "schema": {
-                "properties": {
-                    "rules": {
-                        "items": {
-                            "properties": {
-                                "match": {
-                                    "default": [
-                                        {
-                                            "vars": [
-                                                [
-                                                    0,
-                                                    ">",
-                                                    "server_port"
-                                                ]
-                                            ]
-                                        }
-                                    ],
-                                    "items": {
-                                        "properties": {
-                                            "vars": {
-                                                "items": {
-                                                    "additionalItems": {
-                                                        "anyOf": [
-                                                            {
-                                                                "type": "string"
-                                                            },
-                                                            {
-                                                                "type": "number"
-                                                            },
-                                                            {
-                                                                "type": "boolean"
-                                                            },
-                                                            {
-                                                                "items": {
-                                                                    "anyOf": [
-                                                                        {
-                                                                            "maxLength": 100,
-                                                                            "minLength": 1,
-                                                                            "type": "string"
-                                                                        },
-                                                                        {
-                                                                            "type": "number"
-                                                                        },
-                                                                        {
-                                                                            "type": "boolean"
-                                                                        }
-                                                                    ]
-                                                                },
-                                                                "type": "array",
-                                                                "uniqueItems": true
-                                                            }
-                                                        ]
-                                                    },
-                                                    "items": [
-                                                        {
-                                                            "maxLength": 100,
-                                                            "minLength": 1,
-                                                            "type": "string"
-                                                        },
-                                                        {
-                                                            "maxLength": 2,
-                                                            "minLength": 1,
-                                                            "type": "string"
-                                                        }
-                                                    ],
-                                                    "maxItems": 10,
-                                                    "minItems": 0,
-                                                    "type": "array"
-                                                },
-                                                "type": "array"
-                                            }
-                                        },
-                                        "type": "object"
-                                    },
-                                    "type": "array"
-                                },
-                                "weighted_upstreams": {
-                                    "default": [
-                                        {
-                                            "weight": 1
-                                        }
-                                    ],
-                                    "items": {
-                                        "properties": {
-                                            "upstream": {
-                                                "additionalProperties": false,
-                                                "anyOf": [
-                                                    {
-                                                        "required": [
-                                                            "nodes",
-                                                            "type"
-                                                        ]
-                                                    },
-                                                    {
-                                                        "required": [
-                                                            "service_name",
-                                                            "type"
-                                                        ]
-                                                    }
-                                                ],
-                                                "properties": {
-                                                    "checks": {
-                                                        "additionalProperties": false,
-                                                        "anyOf": [
-                                                            {
-                                                                "required": [
-                                                                    "active"
-                                                                ]
-                                                            },
-                                                            {
-                                                                "required": [
-                                                                    "active",
-                                                                    "passive"
-                                                                ]
-                                                            }
-                                                        ],
-                                                        "properties": {
-                                                            "active": {
-                                                                "properties": {
-                                                                    "concurrency": {
-                                                                        "default": 10,
-                                                                        "type": "integer"
-                                                                    },
-                                                                    "healthy": {
-                                                                        "properties": {
-                                                                            "http_statuses": {
-                                                                                "default": [
-                                                                                    200,
-                                                                                    302
-                                                                                ],
-                                                                                "items": {
-                                                                                    "maximum": 599,
-                                                                                    "minimum": 200,
-                                                                                    "type": "integer"
-                                                                                },
-                                                                                "minItems": 1,
-                                                                                "type": "array",
-                                                                                "uniqueItems": true
-                                                                            },
-                                                                            "interval": {
-                                                                                "default": 0,
-                                                                                "minimum": 1,
-                                                                                "type": "integer"
-                                                                            },
-                                                                            "successes": {
-                                                                                "default": 2,
-                                                                                "maximum": 254,
-                                                                                "minimum": 1,
-                                                                                "type": "integer"
-                                                                            }
-                                                                        },
-                                                                        "type": "object"
-                                                                    },
-                                                                    "host": {
-                                                                        "pattern": "^\\*?[0-9a-zA-Z-._]+$",
-                                                                        "type": "string"
-                                                                    },
-                                                                    "http_path": {
-                                                                        "default": "/",
-                                                                        "type": "string"
-                                                                    },
-                                                                    "https_verify_certificate": {
-                                                                        "default": true,
-                                                                        "type": "boolean"
-                                                                    },
-                                                                    "port": {
-                                                                        "maximum": 65535,
-                                                                        "minimum": 1,
-                                                                        "type": "integer"
-                                                                    },
-                                                                    "req_headers": {
-                                                                        "items": {
-                                                                            "type": "string",
-                                                                            "uniqueItems": true
-                                                                        },
-                                                                        "minItems": 1,
-                                                                        "type": "array"
-                                                                    },
-                                                                    "timeout": {
-                                                                        "default": 1,
-                                                                        "type": "number"
-                                                                    },
-                                                                    "type": {
-                                                                        "default": "http",
-                                                                        "enum": [
-                                                                            "http",
-                                                                            "https",
-                                                                            "tcp"
-                                                                        ],
-                                                                        "type": "string"
-                                                                    },
-                                                                    "unhealthy": {
-                                                                        "properties": {
-                                                                            "http_failures": {
-                                                                                "default": 5,
-                                                                                "maximum": 254,
-                                                                                "minimum": 1,
-                                                                                "type": "integer"
-                                                                            },
-                                                                            "http_statuses": {
-                                                                                "default": [
-                                                                                    404,
-                                                                                    429,
-                                                                                    500,
-                                                                                    501,
-                                                                                    502,
-                                                                                    503,
-                                                                                    504,
-                                                                                    505
-                                                                                ],
-                                                                                "items": {
-                                                                                    "maximum": 599,
-                                                                                    "minimum": 200,
-                                                                                    "type": "integer"
-                                                                                },
-                                                                                "minItems": 1,
-                                                                                "type": "array",
-                                                                                "uniqueItems": true
-                                                                            },
-                                                                            "interval": {
-                                                                                "default": 0,
-                                                                                "minimum": 1,
-                                                                                "type": "integer"
-                                                                            },
-                                                                            "tcp_failures": {
-                                                                                "default": 2,
-                                                                                "maximum": 254,
-                                                                                "minimum": 1,
-                                                                                "type": "integer"
-                                                                            },
-                                                                            "timeouts": {
-                                                                                "default": 3,
-                                                                                "maximum": 254,
-                                                                                "minimum": 1,
-                                                                                "type": "integer"
-                                                                            }
-                                                                        },
-                                                                        "type": "object"
-                                                                    }
-                                                                },
-                                                                "type": "object"
-                                                            },
-                                                            "passive": {
-                                                                "properties": {
-                                                                    "healthy": {
-                                                                        "properties": {
-                                                                            "http_statuses": {
-                                                                                "default": [
-                                                                                    200,
-                                                                                    201,
-                                                                                    202,
-                                                                                    203,
-                                                                                    204,
-                                                                                    205,
-                                                                                    206,
-                                                                                    207,
-                                                                                    208,
-                                                                                    226,
-                                                                                    300,
-                                                                                    301,
-                                                                                    302,
-                                                                                    303,
-                                                                                    304,
-                                                                                    305,
-                                                                                    306,
-                                                                                    307,
-                                                                                    308
-                                                                                ],
-                                                                                "items": {
-                                                                                    "maximum": 599,
-                                                                                    "minimum": 200,
-                                                                                    "type": "integer"
-                                                                                },
-                                                                                "minItems": 1,
-                                                                                "type": "array",
-                                                                                "uniqueItems": true
-                                                                            },
-                                                                            "successes": {
-                                                                                "default": 5,
-                                                                                "maximum": 254,
-                                                                                "minimum": 1,
-                                                                                "type": "integer"
-                                                                            }
-                                                                        },
-                                                                        "type": "object"
-                                                                    },
-                                                                    "type": {
-                                                                        "default": "http",
-                                                                        "enum": [
-                                                                            "http",
-                                                                            "https",
-                                                                            "tcp"
-                                                                        ],
-                                                                        "type": "string"
-                                                                    },
-                                                                    "unhealthy": {
-                                                                        "properties": {
-                                                                            "http_failures": {
-                                                                                "default": 5,
-                                                                                "maximum": 254,
-                                                                                "minimum": 1,
-                                                                                "type": "integer"
-                                                                            },
-                                                                            "http_statuses": {
-                                                                                "default": [
-                                                                                    429,
-                                                                                    500,
-                                                                                    503
-                                                                                ],
-                                                                                "items": {
-                                                                                    "maximum": 599,
-                                                                                    "minimum": 200,
-                                                                                    "type": "integer"
-                                                                                },
-                                                                                "minItems": 1,
-                                                                                "type": "array",
-                                                                                "uniqueItems": true
-                                                                            },
-                                                                            "tcp_failures": {
-                                                                                "default": 2,
-                                                                                "maximum": 254,
-                                                                                "minimum": 1,
-                                                                                "type": "integer"
-                                                                            },
-                                                                            "timeouts": {
-                                                                                "default": 7,
-                                                                                "maximum": 254,
-                                                                                "minimum": 1,
-                                                                                "type": "integer"
-                                                                            }
-                                                                        },
-                                                                        "type": "object"
-                                                                    }
-                                                                },
-                                                                "type": "object"
-                                                            }
-                                                        },
-                                                        "type": "object"
-                                                    },
-                                                    "create_time": {
-                                                        "type": "integer"
-                                                    },
-                                                    "desc": {
-                                                        "maxLength": 256,
-                                                        "type": "string"
-                                                    },
-                                                    "discovery_type": {
-                                                        "description": "discovery type",
-                                                        "type": "string"
-                                                    },
-                                                    "enable_websocket": {
-                                                        "description": "enable websocket for request",
-                                                        "type": "boolean"
-                                                    },
-                                                    "hash_on": {
-                                                        "default": "vars",
-                                                        "enum": [
-                                                            "consumer",
-                                                            "cookie",
-                                                            "header",
-                                                            "vars"
-                                                        ],
-                                                        "type": "string"
-                                                    },
-                                                    "id": {
-                                                        "anyOf": [
-                                                            {
-                                                                "maxLength": 64,
-                                                                "minLength": 1,
-                                                                "pattern": "^[a-zA-Z0-9-_.]+$",
-                                                                "type": "string"
-                                                            },
-                                                            {
-                                                                "minimum": 1,
-                                                                "type": "integer"
-                                                            }
-                                                        ]
-                                                    },
-                                                    "key": {
-                                                        "description": "the key of chash for dynamic load balancing",
-                                                        "type": "string"
-                                                    },
-                                                    "labels": {
-                                                        "description": "key/value pairs to specify attributes",
-                                                        "maxProperties": 16,
-                                                        "patternProperties": {
-                                                            ".*": {
-                                                                "description": "value of label",
-                                                                "maxLength": 64,
-                                                                "minLength": 1,
-                                                                "pattern": "^[a-zA-Z0-9-_.]+$",
-                                                                "type": "string"
-                                                            }
-                                                        },
-                                                        "type": "object"
-                                                    },
-                                                    "name": {
-                                                        "maxLength": 100,
-                                                        "minLength": 1,
-                                                        "type": "string"
-                                                    },
-                                                    "nodes": {
-                                                        "anyOf": [
-                                                            {
-                                                                "minProperties": 1,
-                                                                "patternProperties": {
-                                                                    ".*": {
-                                                                        "description": "weight of node",
-                                                                        "minimum": 0,
-                                                                        "type": "integer"
-                                                                    }
-                                                                },
-                                                                "type": "object"
-                                                            },
-                                                            {
-                                                                "items": {
-                                                                    "properties": {
-                                                                        "host": {
-                                                                            "pattern": "^\\*?[0-9a-zA-Z-._]+$",
-                                                                            "type": "string"
-                                                                        },
-                                                                        "metadata": {
-                                                                            "description": "metadata of node",
-                                                                            "type": "object"
-                                                                        },
-                                                                        "port": {
-                                                                            "description": "port of node",
-                                                                            "minimum": 1,
-                                                                            "type": "integer"
-                                                                        },
-                                                                        "weight": {
-                                                                            "description": "weight of node",
-                                                                            "minimum": 0,
-                                                                            "type": "integer"
-                                                                        }
-                                                                    },
-                                                                    "required": [
-                                                                        "host",
-                                                                        "port",
-                                                                        "weight"
-                                                                    ],
-                                                                    "type": "object"
-                                                                },
-                                                                "type": "array"
-                                                            }
-                                                        ]
-                                                    },
-                                                    "pass_host": {
-                                                        "default": "pass",
-                                                        "description": "mod of host passing",
-                                                        "enum": [
-                                                            "node",
-                                                            "pass",
-                                                            "rewrite"
-                                                        ],
-                                                        "type": "string"
-                                                    },
-                                                    "retries": {
-                                                        "minimum": 0,
-                                                        "type": "integer"
-                                                    },
-                                                    "service_name": {
-                                                        "maxLength": 100,
-                                                        "minLength": 1,
-                                                        "type": "string"
-                                                    },
-                                                    "timeout": {
-                                                        "properties": {
-                                                            "connect": {
-                                                                "minimum": 0,
-                                                                "type": "number"
-                                                            },
-                                                            "read": {
-                                                                "minimum": 0,
-                                                                "type": "number"
-                                                            },
-                                                            "send": {
-                                                                "minimum": 0,
-                                                                "type": "number"
-                                                            }
-                                                        },
-                                                        "required": [
-                                                            "connect",
-                                                            "read",
-                                                            "send"
-                                                        ],
-                                                        "type": "object"
-                                                    },
-                                                    "type": {
-                                                        "description": "algorithms of load balancing",
-                                                        "enum": [
-                                                            "chash",
-                                                            "ewma",
-                                                            "roundrobin"
-                                                        ],
-                                                        "type": "string"
-                                                    },
-                                                    "update_time": {
-                                                        "type": "integer"
-                                                    },
-                                                    "upstream_host": {
-                                                        "pattern": "^\\*?[0-9a-zA-Z-._]+$",
-                                                        "type": "string"
-                                                    }
-                                                },
-                                                "type": "object"
-                                            },
-                                            "upstream_id": {
-                                                "anyOf": [
-                                                    {
-                                                        "maxLength": 64,
-                                                        "minLength": 1,
-                                                        "pattern": "^[a-zA-Z0-9-_.]+$",
-                                                        "type": "string"
-                                                    },
-                                                    {
-                                                        "minimum": 1,
-                                                        "type": "integer"
-                                                    }
-                                                ]
-                                            },
-                                            "weight": {
-                                                "default": 1,
-                                                "description": "used to split traffic between differentupstreams for plugin configuration",
-                                                "minimum": 0,
-                                                "type": "integer"
-                                            }
-                                        },
-                                        "type": "object"
-                                    },
-                                    "maxItems": 20,
-                                    "minItems": 1,
-                                    "type": "array"
-                                }
-                            },
-                            "type": "object"
-                        },
-                        "type": "array"
-                    }
-                },
-                "type": "object"
-            },
-            "version": 0.1
-        },
-        "udp-logger": {
-            "priority": 400,
-            "schema": {
-                "properties": {
-                    "batch_max_size": {
-                        "default": 1000,
-                        "minimum": 1,
-                        "type": "integer"
-                    },
-                    "buffer_duration": {
-                        "default": 60,
-                        "minimum": 1,
-                        "type": "integer"
-                    },
-                    "host": {
-                        "type": "string"
-                    },
-                    "inactive_timeout": {
-                        "default": 5,
-                        "minimum": 1,
-                        "type": "integer"
-                    },
-                    "include_req_body": {
-                        "default": false,
-                        "type": "boolean"
-                    },
-                    "name": {
-                        "default": "udp logger",
-                        "type": "string"
-                    },
-                    "port": {
-                        "minimum": 0,
-                        "type": "integer"
-                    },
-                    "timeout": {
-                        "default": 3,
-                        "minimum": 1,
-                        "type": "integer"
-                    }
-                },
-                "required": [
-                    "host",
-                    "port"
-                ],
-                "type": "object"
-            },
-            "version": 0.1
-        },
-        "uri-blocker": {
-            "priority": 2900,
-            "schema": {
-                "properties": {
-                    "block_rules": {
-                        "items": {
-                            "maxLength": 4096,
-                            "minLength": 1,
-                            "type": "string"
-                        },
-                        "type": "array",
-                        "uniqueItems": true
-                    },
-                    "rejected_code": {
-                        "default": 403,
-                        "minimum": 200,
-                        "type": "integer"
-                    }
-                },
-                "required": [
-                    "block_rules"
-                ],
-                "type": "object"
-            },
-            "version": 0.1
-        },
-        "wolf-rbac": {
-            "priority": 2555,
-            "schema": {
-                "properties": {
-                    "appid": {
-                        "default": "unset",
-                        "type": "string"
-                    },
-                    "header_prefix": {
-                        "default": "X-",
-                        "type": "string"
-                    },
-                    "server": {
-                        "default": "http://127.0.0.1:10080",
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "type": "auth",
-            "version": 0.1
-        },
-        "zipkin": {
-            "priority": 11011,
-            "schema": {
-                "properties": {
-                    "endpoint": {
-                        "type": "string"
-                    },
-                    "sample_ratio": {
-                        "maximum": 1,
-                        "minimum": 0.00001,
-                        "type": "number"
-                    },
-                    "server_addr": {
-                        "description": "default is $server_addr, you can specify your external ip address",
-                        "pattern": "^[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}$",
-                        "type": "string"
-                    },
-                    "service_name": {
-                        "default": "APISIX",
-                        "description": "service name for zipkin reporter",
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "endpoint",
-                    "sample_ratio"
-                ],
-                "type": "object"
-            },
-            "version": 0.1
-        }
-    }
+	"main": {
+		"consumer": {
+			"additionalProperties": false,
+			"properties": {
+				"create_time": {
+					"type": "integer"
+				},
+				"desc": {
+					"maxLength": 256,
+					"type": "string"
+				},
+				"id": {
+					"anyOf": [{
+						"maxLength": 64,
+						"minLength": 1,
+						"pattern": "^[a-zA-Z0-9-_.]+$",
+						"type": "string"
+					}, {
+						"minimum": 1,
+						"type": "integer"
+					}]
+				},
+				"labels": {
+					"description": "key/value pairs to specify attributes",
+					"maxProperties": 16,
+					"patternProperties": {
+						".*": {
+							"description": "value of label",
+							"maxLength": 64,
+							"minLength": 1,
+							"pattern": "^[a-zA-Z0-9-_.]+$",
+							"type": "string"
+						}
+					},
+					"type": "object"
+				},
+				"plugins": {
+					"type": "object"
+				},
+				"update_time": {
+					"type": "integer"
+				},
+				"username": {
+					"maxLength": 32,
+					"minLength": 1,
+					"pattern": "^[a-zA-Z0-9_]+$",
+					"type": "string"
+				}
+			},
+			"required": ["username"],
+			"type": "object"
+		},
+		"global_rule": {
+			"additionalProperties": false,
+			"properties": {
+				"create_time": {
+					"type": "integer"
+				},
+				"id": {
+					"anyOf": [{
+						"maxLength": 64,
+						"minLength": 1,
+						"pattern": "^[a-zA-Z0-9-_.]+$",
+						"type": "string"
+					}, {
+						"minimum": 1,
+						"type": "integer"
+					}]
+				},
+				"plugins": {
+					"type": "object"
+				},
+				"update_time": {
+					"type": "integer"
+				}
+			},
+			"required": ["plugins"],
+			"type": "object"
+		},
+		"plugins": {
+			"items": {
+				"properties": {
+					"additionalProperties": false,
+					"name": {
+						"minLength": 1,
+						"type": "string"
+					},
+					"stream": {
+						"type": "boolean"
+					}
+				},
+				"required": ["name"],
+				"type": "object"
+			},
+			"type": "array"
+		},
+		"proto": {
+			"additionalProperties": false,
+			"properties": {
+				"content": {
+					"maxLength": 1048576,
+					"minLength": 1,
+					"type": "string"
+				}
+			},
+			"required": ["content"],
+			"type": "object"
+		},
+		"route": {
+			"additionalProperties": false,
+			"allOf": [{
+				"oneOf": [{
+					"required": ["uri"]
+				}, {
+					"required": ["uris"]
+				}]
+			}, {
+				"oneOf": [{
+					"not": {
+						"anyOf": [{
+							"required": ["host"]
+						}, {
+							"required": ["hosts"]
+						}]
+					}
+				}, {
+					"required": ["host"]
+				}, {
+					"required": ["hosts"]
+				}]
+			}, {
+				"oneOf": [{
+					"not": {
+						"anyOf": [{
+							"required": ["remote_addr"]
+						}, {
+							"required": ["remote_addrs"]
+						}]
+					}
+				}, {
+					"required": ["remote_addr"]
+				}, {
+					"required": ["remote_addrs"]
+				}]
+			}],
+			"anyOf": [{
+				"required": ["plugins", "uri"]
+			}, {
+				"required": ["upstream", "uri"]
+			}, {
+				"required": ["upstream_id", "uri"]
+			}, {
+				"required": ["service_id", "uri"]
+			}, {
+				"required": ["plugins", "uris"]
+			}, {
+				"required": ["upstream", "uris"]
+			}, {
+				"required": ["upstream_id", "uris"]
+			}, {
+				"required": ["service_id", "uris"]
+			}, {
+				"required": ["script", "uri"]
+			}, {
+				"required": ["script", "uris"]
+			}],
+			"not": {
+				"anyOf": [{
+					"required": ["plugins", "script"]
+				}]
+			},
+			"properties": {
+				"create_time": {
+					"type": "integer"
+				},
+				"desc": {
+					"maxLength": 256,
+					"type": "string"
+				},
+				"enable_websocket": {
+					"description": "enable websocket for request",
+					"type": "boolean"
+				},
+				"filter_func": {
+					"minLength": 10,
+					"pattern": "^function",
+					"type": "string"
+				},
+				"host": {
+					"pattern": "^\\*?[0-9a-zA-Z-._]+$",
+					"type": "string"
+				},
+				"hosts": {
+					"items": {
+						"pattern": "^\\*?[0-9a-zA-Z-._]+$",
+						"type": "string"
+					},
+					"minItems": 1,
+					"type": "array",
+					"uniqueItems": true
+				},
+				"id": {
+					"anyOf": [{
+						"maxLength": 64,
+						"minLength": 1,
+						"pattern": "^[a-zA-Z0-9-_.]+$",
+						"type": "string"
+					}, {
+						"minimum": 1,
+						"type": "integer"
+					}]
+				},
+				"labels": {
+					"description": "key/value pairs to specify attributes",
+					"maxProperties": 16,
+					"patternProperties": {
+						".*": {
+							"description": "value of label",
+							"maxLength": 64,
+							"minLength": 1,
+							"pattern": "^[a-zA-Z0-9-_.]+$",
+							"type": "string"
+						}
+					},
+					"type": "object"
+				},
+				"methods": {
+					"items": {
+						"description": "HTTP method",
+						"enum": ["CONNECT", "DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT", "TRACE"],
+						"type": "string"
+					},
+					"type": "array",
+					"uniqueItems": true
+				},
+				"name": {
+					"maxLength": 100,
+					"minLength": 1,
+					"type": "string"
+				},
+				"plugins": {
+					"type": "object"
+				},
+				"priority": {
+					"default": 0,
+					"type": "integer"
+				},
+				"remote_addr": {
+					"anyOf": [{
+						"format": "ipv4",
+						"title": "IPv4",
+						"type": "string"
+					}, {
+						"pattern": "^([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])/([12]?[0-9]|3[0-2])$",
+						"title": "IPv4/CIDR",
+						"type": "string"
+					}, {
+						"format": "ipv6",
+						"title": "IPv6",
+						"type": "string"
+					}, {
+						"pattern": "^([a-fA-F0-9]{0,4}:){1,8}(:[a-fA-F0-9]{0,4}){0,8}([a-fA-F0-9]{0,4})?/[0-9]{1,3}$",
+						"title": "IPv6/CIDR",
+						"type": "string"
+					}],
+					"description": "client IP",
+					"type": "string"
+				},
+				"remote_addrs": {
+					"items": {
+						"anyOf": [{
+							"format": "ipv4",
+							"title": "IPv4",
+							"type": "string"
+						}, {
+							"pattern": "^([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])/([12]?[0-9]|3[0-2])$",
+							"title": "IPv4/CIDR",
+							"type": "string"
+						}, {
+							"format": "ipv6",
+							"title": "IPv6",
+							"type": "string"
+						}, {
+							"pattern": "^([a-fA-F0-9]{0,4}:){1,8}(:[a-fA-F0-9]{0,4}){0,8}([a-fA-F0-9]{0,4})?/[0-9]{1,3}$",
+							"title": "IPv6/CIDR",
+							"type": "string"
+						}],
+						"description": "client IP",
+						"type": "string"
+					},
+					"minItems": 1,
+					"type": "array",
+					"uniqueItems": true
+				},
+				"script": {
+					"maxLength": 102400,
+					"minLength": 10,
+					"type": "string"
+				},
+				"script_id": {
+					"anyOf": [{
+						"maxLength": 64,
+						"minLength": 1,
+						"pattern": "^[a-zA-Z0-9-_.]+$",
+						"type": "string"
+					}, {
+						"minimum": 1,
+						"type": "integer"
+					}]
+				},
+				"service_id": {
+					"anyOf": [{
+						"maxLength": 64,
+						"minLength": 1,
+						"pattern": "^[a-zA-Z0-9-_.]+$",
+						"type": "string"
+					}, {
+						"minimum": 1,
+						"type": "integer"
+					}]
+				},
+				"service_protocol": {
+					"enum": ["grpc", "http"]
+				},
+				"status": {
+					"default": 1,
+					"description": "route status, 1 to enable, 0 to disable",
+					"enum": [0, 1],
+					"type": "integer"
+				},
+				"update_time": {
+					"type": "integer"
+				},
+				"upstream": {
+					"additionalProperties": false,
+					"anyOf": [{
+						"required": ["nodes", "type"]
+					}, {
+						"required": ["service_name", "type"]
+					}],
+					"properties": {
+						"checks": {
+							"additionalProperties": false,
+							"anyOf": [{
+								"required": ["active"]
+							}, {
+								"required": ["active", "passive"]
+							}],
+							"properties": {
+								"active": {
+									"properties": {
+										"concurrency": {
+											"default": 10,
+											"type": "integer"
+										},
+										"healthy": {
+											"properties": {
+												"http_statuses": {
+													"default": [200, 302],
+													"items": {
+														"maximum": 599,
+														"minimum": 200,
+														"type": "integer"
+													},
+													"minItems": 1,
+													"type": "array",
+													"uniqueItems": true
+												},
+												"interval": {
+													"default": 0,
+													"minimum": 1,
+													"type": "integer"
+												},
+												"successes": {
+													"default": 2,
+													"maximum": 254,
+													"minimum": 1,
+													"type": "integer"
+												}
+											},
+											"type": "object"
+										},
+										"host": {
+											"pattern": "^\\*?[0-9a-zA-Z-._]+$",
+											"type": "string"
+										},
+										"http_path": {
+											"default": "/",
+											"type": "string"
+										},
+										"https_verify_certificate": {
+											"default": true,
+											"type": "boolean"
+										},
+										"port": {
+											"maximum": 65535,
+											"minimum": 1,
+											"type": "integer"
+										},
+										"req_headers": {
+											"items": {
+												"type": "string",
+												"uniqueItems": true
+											},
+											"minItems": 1,
+											"type": "array"
+										},
+										"timeout": {
+											"default": 1,
+											"type": "number"
+										},
+										"type": {
+											"default": "http",
+											"enum": ["http", "https", "tcp"],
+											"type": "string"
+										},
+										"unhealthy": {
+											"properties": {
+												"http_failures": {
+													"default": 5,
+													"maximum": 254,
+													"minimum": 1,
+													"type": "integer"
+												},
+												"http_statuses": {
+													"default": [404, 429, 500, 501, 502, 503, 504, 505],
+													"items": {
+														"maximum": 599,
+														"minimum": 200,
+														"type": "integer"
+													},
+													"minItems": 1,
+													"type": "array",
+													"uniqueItems": true
+												},
+												"interval": {
+													"default": 0,
+													"minimum": 1,
+													"type": "integer"
+												},
+												"tcp_failures": {
+													"default": 2,
+													"maximum": 254,
+													"minimum": 1,
+													"type": "integer"
+												},
+												"timeouts": {
+													"default": 3,
+													"maximum": 254,
+													"minimum": 1,
+													"type": "integer"
+												}
+											},
+											"type": "object"
+										}
+									},
+									"type": "object"
+								},
+								"passive": {
+									"properties": {
+										"healthy": {
+											"properties": {
+												"http_statuses": {
+													"default": [200, 201, 202, 203, 204, 205, 206, 207, 208, 226, 300, 301, 302, 303, 304, 305, 306, 307, 308],
+													"items": {
+														"maximum": 599,
+														"minimum": 200,
+														"type": "integer"
+													},
+													"minItems": 1,
+													"type": "array",
+													"uniqueItems": true
+												},
+												"successes": {
+													"default": 5,
+													"maximum": 254,
+													"minimum": 1,
+													"type": "integer"
+												}
+											},
+											"type": "object"
+										},
+										"type": {
+											"default": "http",
+											"enum": ["http", "https", "tcp"],
+											"type": "string"
+										},
+										"unhealthy": {
+											"properties": {
+												"http_failures": {
+													"default": 5,
+													"maximum": 254,
+													"minimum": 1,
+													"type": "integer"
+												},
+												"http_statuses": {
+													"default": [429, 500, 503],
+													"items": {
+														"maximum": 599,
+														"minimum": 200,
+														"type": "integer"
+													},
+													"minItems": 1,
+													"type": "array",
+													"uniqueItems": true
+												},
+												"tcp_failures": {
+													"default": 2,
+													"maximum": 254,
+													"minimum": 1,
+													"type": "integer"
+												},
+												"timeouts": {
+													"default": 7,
+													"maximum": 254,
+													"minimum": 1,
+													"type": "integer"
+												}
+											},
+											"type": "object"
+										}
+									},
+									"type": "object"
+								}
+							},
+							"type": "object"
+						},
+						"create_time": {
+							"type": "integer"
+						},
+						"desc": {
+							"maxLength": 256,
+							"type": "string"
+						},
+						"discovery_type": {
+							"description": "discovery type",
+							"type": "string"
+						},
+						"enable_websocket": {
+							"description": "enable websocket for request",
+							"type": "boolean"
+						},
+						"hash_on": {
+							"default": "vars",
+							"enum": ["consumer", "cookie", "header", "vars"],
+							"type": "string"
+						},
+						"id": {
+							"anyOf": [{
+								"maxLength": 64,
+								"minLength": 1,
+								"pattern": "^[a-zA-Z0-9-_.]+$",
+								"type": "string"
+							}, {
+								"minimum": 1,
+								"type": "integer"
+							}]
+						},
+						"key": {
+							"description": "the key of chash for dynamic load balancing",
+							"type": "string"
+						},
+						"labels": {
+							"description": "key/value pairs to specify attributes",
+							"maxProperties": 16,
+							"patternProperties": {
+								".*": {
+									"description": "value of label",
+									"maxLength": 64,
+									"minLength": 1,
+									"pattern": "^[a-zA-Z0-9-_.]+$",
+									"type": "string"
+								}
+							},
+							"type": "object"
+						},
+						"name": {
+							"maxLength": 100,
+							"minLength": 1,
+							"type": "string"
+						},
+						"nodes": {
+							"anyOf": [{
+								"minProperties": 1,
+								"patternProperties": {
+									".*": {
+										"description": "weight of node",
+										"minimum": 0,
+										"type": "integer"
+									}
+								},
+								"type": "object"
+							}, {
+								"items": {
+									"properties": {
+										"host": {
+											"pattern": "^\\*?[0-9a-zA-Z-._]+$",
+											"type": "string"
+										},
+										"metadata": {
+											"description": "metadata of node",
+											"type": "object"
+										},
+										"port": {
+											"description": "port of node",
+											"minimum": 1,
+											"type": "integer"
+										},
+										"weight": {
+											"description": "weight of node",
+											"minimum": 0,
+											"type": "integer"
+										}
+									},
+									"required": ["host", "port", "weight"],
+									"type": "object"
+								},
+								"type": "array"
+							}]
+						},
+						"pass_host": {
+							"default": "pass",
+							"description": "mod of host passing",
+							"enum": ["node", "pass", "rewrite"],
+							"type": "string"
+						},
+						"retries": {
+							"minimum": 0,
+							"type": "integer"
+						},
+						"service_name": {
+							"maxLength": 100,
+							"minLength": 1,
+							"type": "string"
+						},
+						"timeout": {
+							"properties": {
+								"connect": {
+									"minimum": 0,
+									"type": "number"
+								},
+								"read": {
+									"minimum": 0,
+									"type": "number"
+								},
+								"send": {
+									"minimum": 0,
+									"type": "number"
+								}
+							},
+							"required": ["connect", "read", "send"],
+							"type": "object"
+						},
+						"type": {
+							"description": "algorithms of load balancing",
+							"enum": ["chash", "ewma", "roundrobin"],
+							"type": "string"
+						},
+						"update_time": {
+							"type": "integer"
+						},
+						"upstream_host": {
+							"pattern": "^\\*?[0-9a-zA-Z-._]+$",
+							"type": "string"
+						}
+					},
+					"type": "object"
+				},
+				"upstream_id": {
+					"anyOf": [{
+						"maxLength": 64,
+						"minLength": 1,
+						"pattern": "^[a-zA-Z0-9-_.]+$",
+						"type": "string"
+					}, {
+						"minimum": 1,
+						"type": "integer"
+					}]
+				},
+				"uri": {
+					"maxLength": 4096,
+					"minLength": 1,
+					"type": "string"
+				},
+				"uris": {
+					"items": {
+						"description": "HTTP uri",
+						"type": "string"
+					},
+					"minItems": 1,
+					"type": "array",
+					"uniqueItems": true
+				},
+				"vars": {
+					"items": {
+						"description": "Nginx builtin variable name and value",
+						"maxItems": 4,
+						"minItems": 2,
+						"type": "array"
+					},
+					"type": "array"
+				}
+			},
+			"type": "object"
+		},
+		"service": {
+			"additionalProperties": false,
+			"properties": {
+				"create_time": {
+					"type": "integer"
+				},
+				"desc": {
+					"maxLength": 256,
+					"type": "string"
+				},
+				"enable_websocket": {
+					"description": "enable websocket for request",
+					"type": "boolean"
+				},
+				"id": {
+					"anyOf": [{
+						"maxLength": 64,
+						"minLength": 1,
+						"pattern": "^[a-zA-Z0-9-_.]+$",
+						"type": "string"
+					}, {
+						"minimum": 1,
+						"type": "integer"
+					}]
+				},
+				"labels": {
+					"description": "key/value pairs to specify attributes",
+					"maxProperties": 16,
+					"patternProperties": {
+						".*": {
+							"description": "value of label",
+							"maxLength": 64,
+							"minLength": 1,
+							"pattern": "^[a-zA-Z0-9-_.]+$",
+							"type": "string"
+						}
+					},
+					"type": "object"
+				},
+				"name": {
+					"maxLength": 100,
+					"minLength": 1,
+					"type": "string"
+				},
+				"plugins": {
+					"type": "object"
+				},
+				"script": {
+					"maxLength": 102400,
+					"minLength": 10,
+					"type": "string"
+				},
+				"update_time": {
+					"type": "integer"
+				},
+				"upstream": {
+					"additionalProperties": false,
+					"anyOf": [{
+						"required": ["nodes", "type"]
+					}, {
+						"required": ["service_name", "type"]
+					}],
+					"properties": {
+						"checks": {
+							"additionalProperties": false,
+							"anyOf": [{
+								"required": ["active"]
+							}, {
+								"required": ["active", "passive"]
+							}],
+							"properties": {
+								"active": {
+									"properties": {
+										"concurrency": {
+											"default": 10,
+											"type": "integer"
+										},
+										"healthy": {
+											"properties": {
+												"http_statuses": {
+													"default": [200, 302],
+													"items": {
+														"maximum": 599,
+														"minimum": 200,
+														"type": "integer"
+													},
+													"minItems": 1,
+													"type": "array",
+													"uniqueItems": true
+												},
+												"interval": {
+													"default": 0,
+													"minimum": 1,
+													"type": "integer"
+												},
+												"successes": {
+													"default": 2,
+													"maximum": 254,
+													"minimum": 1,
+													"type": "integer"
+												}
+											},
+											"type": "object"
+										},
+										"host": {
+											"pattern": "^\\*?[0-9a-zA-Z-._]+$",
+											"type": "string"
+										},
+										"http_path": {
+											"default": "/",
+											"type": "string"
+										},
+										"https_verify_certificate": {
+											"default": true,
+											"type": "boolean"
+										},
+										"port": {
+											"maximum": 65535,
+											"minimum": 1,
+											"type": "integer"
+										},
+										"req_headers": {
+											"items": {
+												"type": "string",
+												"uniqueItems": true
+											},
+											"minItems": 1,
+											"type": "array"
+										},
+										"timeout": {
+											"default": 1,
+											"type": "number"
+										},
+										"type": {
+											"default": "http",
+											"enum": ["http", "https", "tcp"],
+											"type": "string"
+										},
+										"unhealthy": {
+											"properties": {
+												"http_failures": {
+													"default": 5,
+													"maximum": 254,
+													"minimum": 1,
+													"type": "integer"
+												},
+												"http_statuses": {
+													"default": [404, 429, 500, 501, 502, 503, 504, 505],
+													"items": {
+														"maximum": 599,
+														"minimum": 200,
+														"type": "integer"
+													},
+													"minItems": 1,
+													"type": "array",
+													"uniqueItems": true
+												},
+												"interval": {
+													"default": 0,
+													"minimum": 1,
+													"type": "integer"
+												},
+												"tcp_failures": {
+													"default": 2,
+													"maximum": 254,
+													"minimum": 1,
+													"type": "integer"
+												},
+												"timeouts": {
+													"default": 3,
+													"maximum": 254,
+													"minimum": 1,
+													"type": "integer"
+												}
+											},
+											"type": "object"
+										}
+									},
+									"type": "object"
+								},
+								"passive": {
+									"properties": {
+										"healthy": {
+											"properties": {
+												"http_statuses": {
+													"default": [200, 201, 202, 203, 204, 205, 206, 207, 208, 226, 300, 301, 302, 303, 304, 305, 306, 307, 308],
+													"items": {
+														"maximum": 599,
+														"minimum": 200,
+														"type": "integer"
+													},
+													"minItems": 1,
+													"type": "array",
+													"uniqueItems": true
+												},
+												"successes": {
+													"default": 5,
+													"maximum": 254,
+													"minimum": 1,
+													"type": "integer"
+												}
+											},
+											"type": "object"
+										},
+										"type": {
+											"default": "http",
+											"enum": ["http", "https", "tcp"],
+											"type": "string"
+										},
+										"unhealthy": {
+											"properties": {
+												"http_failures": {
+													"default": 5,
+													"maximum": 254,
+													"minimum": 1,
+													"type": "integer"
+												},
+												"http_statuses": {
+													"default": [429, 500, 503],
+													"items": {
+														"maximum": 599,
+														"minimum": 200,
+														"type": "integer"
+													},
+													"minItems": 1,
+													"type": "array",
+													"uniqueItems": true
+												},
+												"tcp_failures": {
+													"default": 2,
+													"maximum": 254,
+													"minimum": 1,
+													"type": "integer"
+												},
+												"timeouts": {
+													"default": 7,
+													"maximum": 254,
+													"minimum": 1,
+													"type": "integer"
+												}
+											},
+											"type": "object"
+										}
+									},
+									"type": "object"
+								}
+							},
+							"type": "object"
+						},
+						"create_time": {
+							"type": "integer"
+						},
+						"desc": {
+							"maxLength": 256,
+							"type": "string"
+						},
+						"discovery_type": {
+							"description": "discovery type",
+							"type": "string"
+						},
+						"enable_websocket": {
+							"description": "enable websocket for request",
+							"type": "boolean"
+						},
+						"hash_on": {
+							"default": "vars",
+							"enum": ["consumer", "cookie", "header", "vars"],
+							"type": "string"
+						},
+						"id": {
+							"anyOf": [{
+								"maxLength": 64,
+								"minLength": 1,
+								"pattern": "^[a-zA-Z0-9-_.]+$",
+								"type": "string"
+							}, {
+								"minimum": 1,
+								"type": "integer"
+							}]
+						},
+						"key": {
+							"description": "the key of chash for dynamic load balancing",
+							"type": "string"
+						},
+						"labels": {
+							"description": "key/value pairs to specify attributes",
+							"maxProperties": 16,
+							"patternProperties": {
+								".*": {
+									"description": "value of label",
+									"maxLength": 64,
+									"minLength": 1,
+									"pattern": "^[a-zA-Z0-9-_.]+$",
+									"type": "string"
+								}
+							},
+							"type": "object"
+						},
+						"name": {
+							"maxLength": 100,
+							"minLength": 1,
+							"type": "string"
+						},
+						"nodes": {
+							"anyOf": [{
+								"minProperties": 1,
+								"patternProperties": {
+									".*": {
+										"description": "weight of node",
+										"minimum": 0,
+										"type": "integer"
+									}
+								},
+								"type": "object"
+							}, {
+								"items": {
+									"properties": {
+										"host": {
+											"pattern": "^\\*?[0-9a-zA-Z-._]+$",
+											"type": "string"
+										},
+										"metadata": {
+											"description": "metadata of node",
+											"type": "object"
+										},
+										"port": {
+											"description": "port of node",
+											"minimum": 1,
+											"type": "integer"
+										},
+										"weight": {
+											"description": "weight of node",
+											"minimum": 0,
+											"type": "integer"
+										}
+									},
+									"required": ["host", "port", "weight"],
+									"type": "object"
+								},
+								"type": "array"
+							}]
+						},
+						"pass_host": {
+							"default": "pass",
+							"description": "mod of host passing",
+							"enum": ["node", "pass", "rewrite"],
+							"type": "string"
+						},
+						"retries": {
+							"minimum": 0,
+							"type": "integer"
+						},
+						"service_name": {
+							"maxLength": 100,
+							"minLength": 1,
+							"type": "string"
+						},
+						"timeout": {
+							"properties": {
+								"connect": {
+									"minimum": 0,
+									"type": "number"
+								},
+								"read": {
+									"minimum": 0,
+									"type": "number"
+								},
+								"send": {
+									"minimum": 0,
+									"type": "number"
+								}
+							},
+							"required": ["connect", "read", "send"],
+							"type": "object"
+						},
+						"type": {
+							"description": "algorithms of load balancing",
+							"enum": ["chash", "ewma", "roundrobin"],
+							"type": "string"
+						},
+						"update_time": {
+							"type": "integer"
+						},
+						"upstream_host": {
+							"pattern": "^\\*?[0-9a-zA-Z-._]+$",
+							"type": "string"
+						}
+					},
+					"type": "object"
+				},
+				"upstream_id": {
+					"anyOf": [{
+						"maxLength": 64,
+						"minLength": 1,
+						"pattern": "^[a-zA-Z0-9-_.]+$",
+						"type": "string"
+					}, {
+						"minimum": 1,
+						"type": "integer"
+					}]
+				}
+			},
+			"type": "object"
+		},
+		"ssl": {
+			"additionalProperties": false,
+			"oneOf": [{
+				"required": ["cert", "key", "sni"]
+			}, {
+				"required": ["cert", "key", "snis"]
+			}],
+			"properties": {
+				"cert": {
+					"maxLength": 65536,
+					"minLength": 128,
+					"type": "string"
+				},
+				"certs": {
+					"items": {
+						"maxLength": 65536,
+						"minLength": 128,
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"create_time": {
+					"type": "integer"
+				},
+				"exptime": {
+					"minimum": 1588262400,
+					"type": "integer"
+				},
+				"id": {
+					"anyOf": [{
+						"maxLength": 64,
+						"minLength": 1,
+						"pattern": "^[a-zA-Z0-9-_.]+$",
+						"type": "string"
+					}, {
+						"minimum": 1,
+						"type": "integer"
+					}]
+				},
+				"key": {
+					"maxLength": 65536,
+					"minLength": 128,
+					"type": "string"
+				},
+				"keys": {
+					"items": {
+						"maxLength": 65536,
+						"minLength": 128,
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"labels": {
+					"description": "key/value pairs to specify attributes",
+					"maxProperties": 16,
+					"patternProperties": {
+						".*": {
+							"description": "value of label",
+							"maxLength": 64,
+							"minLength": 1,
+							"pattern": "^[a-zA-Z0-9-_.]+$",
+							"type": "string"
+						}
+					},
+					"type": "object"
+				},
+				"sni": {
+					"pattern": "^\\*?[0-9a-zA-Z-.]+$",
+					"type": "string"
+				},
+				"snis": {
+					"items": {
+						"pattern": "^\\*?[0-9a-zA-Z-.]+$",
+						"type": "string"
+					},
+					"minItems": 1,
+					"type": "array"
+				},
+				"status": {
+					"default": 1,
+					"description": "ssl status, 1 to enable, 0 to disable",
+					"enum": [0, 1],
+					"type": "integer"
+				},
+				"update_time": {
+					"type": "integer"
+				},
+				"validity_end": {
+					"type": "integer"
+				},
+				"validity_start": {
+					"type": "integer"
+				}
+			},
+			"type": "object"
+		},
+		"stream_route": {
+			"properties": {
+				"id": {
+					"anyOf": [{
+						"maxLength": 64,
+						"minLength": 1,
+						"pattern": "^[a-zA-Z0-9-_.]+$",
+						"type": "string"
+					}, {
+						"minimum": 1,
+						"type": "integer"
+					}]
+				},
+				"plugins": {
+					"type": "object"
+				},
+				"remote_addr": {
+					"anyOf": [{
+						"format": "ipv4",
+						"title": "IPv4",
+						"type": "string"
+					}, {
+						"pattern": "^([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])/([12]?[0-9]|3[0-2])$",
+						"title": "IPv4/CIDR",
+						"type": "string"
+					}, {
+						"format": "ipv6",
+						"title": "IPv6",
+						"type": "string"
+					}, {
+						"pattern": "^([a-fA-F0-9]{0,4}:){1,8}(:[a-fA-F0-9]{0,4}){0,8}([a-fA-F0-9]{0,4})?/[0-9]{1,3}$",
+						"title": "IPv6/CIDR",
+						"type": "string"
+					}],
+					"description": "client IP",
+					"type": "string"
+				},
+				"server_addr": {
+					"anyOf": [{
+						"format": "ipv4",
+						"title": "IPv4",
+						"type": "string"
+					}, {
+						"pattern": "^([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])/([12]?[0-9]|3[0-2])$",
+						"title": "IPv4/CIDR",
+						"type": "string"
+					}, {
+						"format": "ipv6",
+						"title": "IPv6",
+						"type": "string"
+					}, {
+						"pattern": "^([a-fA-F0-9]{0,4}:){1,8}(:[a-fA-F0-9]{0,4}){0,8}([a-fA-F0-9]{0,4})?/[0-9]{1,3}$",
+						"title": "IPv6/CIDR",
+						"type": "string"
+					}],
+					"description": "server IP",
+					"type": "string"
+				},
+				"server_port": {
+					"description": "server port",
+					"type": "integer"
+				},
+				"upstream": {
+					"additionalProperties": false,
+					"anyOf": [{
+						"required": ["nodes", "type"]
+					}, {
+						"required": ["service_name", "type"]
+					}],
+					"properties": {
+						"checks": {
+							"additionalProperties": false,
+							"anyOf": [{
+								"required": ["active"]
+							}, {
+								"required": ["active", "passive"]
+							}],
+							"properties": {
+								"active": {
+									"properties": {
+										"concurrency": {
+											"default": 10,
+											"type": "integer"
+										},
+										"healthy": {
+											"properties": {
+												"http_statuses": {
+													"default": [200, 302],
+													"items": {
+														"maximum": 599,
+														"minimum": 200,
+														"type": "integer"
+													},
+													"minItems": 1,
+													"type": "array",
+													"uniqueItems": true
+												},
+												"interval": {
+													"default": 0,
+													"minimum": 1,
+													"type": "integer"
+												},
+												"successes": {
+													"default": 2,
+													"maximum": 254,
+													"minimum": 1,
+													"type": "integer"
+												}
+											},
+											"type": "object"
+										},
+										"host": {
+											"pattern": "^\\*?[0-9a-zA-Z-._]+$",
+											"type": "string"
+										},
+										"http_path": {
+											"default": "/",
+											"type": "string"
+										},
+										"https_verify_certificate": {
+											"default": true,
+											"type": "boolean"
+										},
+										"port": {
+											"maximum": 65535,
+											"minimum": 1,
+											"type": "integer"
+										},
+										"req_headers": {
+											"items": {
+												"type": "string",
+												"uniqueItems": true
+											},
+											"minItems": 1,
+											"type": "array"
+										},
+										"timeout": {
+											"default": 1,
+											"type": "number"
+										},
+										"type": {
+											"default": "http",
+											"enum": ["http", "https", "tcp"],
+											"type": "string"
+										},
+										"unhealthy": {
+											"properties": {
+												"http_failures": {
+													"default": 5,
+													"maximum": 254,
+													"minimum": 1,
+													"type": "integer"
+												},
+												"http_statuses": {
+													"default": [404, 429, 500, 501, 502, 503, 504, 505],
+													"items": {
+														"maximum": 599,
+														"minimum": 200,
+														"type": "integer"
+													},
+													"minItems": 1,
+													"type": "array",
+													"uniqueItems": true
+												},
+												"interval": {
+													"default": 0,
+													"minimum": 1,
+													"type": "integer"
+												},
+												"tcp_failures": {
+													"default": 2,
+													"maximum": 254,
+													"minimum": 1,
+													"type": "integer"
+												},
+												"timeouts": {
+													"default": 3,
+													"maximum": 254,
+													"minimum": 1,
+													"type": "integer"
+												}
+											},
+											"type": "object"
+										}
+									},
+									"type": "object"
+								},
+								"passive": {
+									"properties": {
+										"healthy": {
+											"properties": {
+												"http_statuses": {
+													"default": [200, 201, 202, 203, 204, 205, 206, 207, 208, 226, 300, 301, 302, 303, 304, 305, 306, 307, 308],
+													"items": {
+														"maximum": 599,
+														"minimum": 200,
+														"type": "integer"
+													},
+													"minItems": 1,
+													"type": "array",
+													"uniqueItems": true
+												},
+												"successes": {
+													"default": 5,
+													"maximum": 254,
+													"minimum": 1,
+													"type": "integer"
+												}
+											},
+											"type": "object"
+										},
+										"type": {
+											"default": "http",
+											"enum": ["http", "https", "tcp"],
+											"type": "string"
+										},
+										"unhealthy": {
+											"properties": {
+												"http_failures": {
+													"default": 5,
+													"maximum": 254,
+													"minimum": 1,
+													"type": "integer"
+												},
+												"http_statuses": {
+													"default": [429, 500, 503],
+													"items": {
+														"maximum": 599,
+														"minimum": 200,
+														"type": "integer"
+													},
+													"minItems": 1,
+													"type": "array",
+													"uniqueItems": true
+												},
+												"tcp_failures": {
+													"default": 2,
+													"maximum": 254,
+													"minimum": 1,
+													"type": "integer"
+												},
+												"timeouts": {
+													"default": 7,
+													"maximum": 254,
+													"minimum": 1,
+													"type": "integer"
+												}
+											},
+											"type": "object"
+										}
+									},
+									"type": "object"
+								}
+							},
+							"type": "object"
+						},
+						"create_time": {
+							"type": "integer"
+						},
+						"desc": {
+							"maxLength": 256,
+							"type": "string"
+						},
+						"discovery_type": {
+							"description": "discovery type",
+							"type": "string"
+						},
+						"enable_websocket": {
+							"description": "enable websocket for request",
+							"type": "boolean"
+						},
+						"hash_on": {
+							"default": "vars",
+							"enum": ["consumer", "cookie", "header", "vars"],
+							"type": "string"
+						},
+						"id": {
+							"anyOf": [{
+								"maxLength": 64,
+								"minLength": 1,
+								"pattern": "^[a-zA-Z0-9-_.]+$",
+								"type": "string"
+							}, {
+								"minimum": 1,
+								"type": "integer"
+							}]
+						},
+						"key": {
+							"description": "the key of chash for dynamic load balancing",
+							"type": "string"
+						},
+						"labels": {
+							"description": "key/value pairs to specify attributes",
+							"maxProperties": 16,
+							"patternProperties": {
+								".*": {
+									"description": "value of label",
+									"maxLength": 64,
+									"minLength": 1,
+									"pattern": "^[a-zA-Z0-9-_.]+$",
+									"type": "string"
+								}
+							},
+							"type": "object"
+						},
+						"name": {
+							"maxLength": 100,
+							"minLength": 1,
+							"type": "string"
+						},
+						"nodes": {
+							"anyOf": [{
+								"minProperties": 1,
+								"patternProperties": {
+									".*": {
+										"description": "weight of node",
+										"minimum": 0,
+										"type": "integer"
+									}
+								},
+								"type": "object"
+							}, {
+								"items": {
+									"properties": {
+										"host": {
+											"pattern": "^\\*?[0-9a-zA-Z-._]+$",
+											"type": "string"
+										},
+										"metadata": {
+											"description": "metadata of node",
+											"type": "object"
+										},
+										"port": {
+											"description": "port of node",
+											"minimum": 1,
+											"type": "integer"
+										},
+										"weight": {
+											"description": "weight of node",
+											"minimum": 0,
+											"type": "integer"
+										}
+									},
+									"required": ["host", "port", "weight"],
+									"type": "object"
+								},
+								"type": "array"
+							}]
+						},
+						"pass_host": {
+							"default": "pass",
+							"description": "mod of host passing",
+							"enum": ["node", "pass", "rewrite"],
+							"type": "string"
+						},
+						"retries": {
+							"minimum": 0,
+							"type": "integer"
+						},
+						"service_name": {
+							"maxLength": 100,
+							"minLength": 1,
+							"type": "string"
+						},
+						"timeout": {
+							"properties": {
+								"connect": {
+									"minimum": 0,
+									"type": "number"
+								},
+								"read": {
+									"minimum": 0,
+									"type": "number"
+								},
+								"send": {
+									"minimum": 0,
+									"type": "number"
+								}
+							},
+							"required": ["connect", "read", "send"],
+							"type": "object"
+						},
+						"type": {
+							"description": "algorithms of load balancing",
+							"enum": ["chash", "ewma", "roundrobin"],
+							"type": "string"
+						},
+						"update_time": {
+							"type": "integer"
+						},
+						"upstream_host": {
+							"pattern": "^\\*?[0-9a-zA-Z-._]+$",
+							"type": "string"
+						}
+					},
+					"type": "object"
+				},
+				"upstream_id": {
+					"anyOf": [{
+						"maxLength": 64,
+						"minLength": 1,
+						"pattern": "^[a-zA-Z0-9-_.]+$",
+						"type": "string"
+					}, {
+						"minimum": 1,
+						"type": "integer"
+					}]
+				}
+			},
+			"type": "object"
+		},
+		"upstream": {
+			"additionalProperties": false,
+			"anyOf": [{
+				"required": ["nodes", "type"]
+			}, {
+				"required": ["service_name", "type"]
+			}],
+			"properties": {
+				"checks": {
+					"additionalProperties": false,
+					"anyOf": [{
+						"required": ["active"]
+					}, {
+						"required": ["active", "passive"]
+					}],
+					"properties": {
+						"active": {
+							"properties": {
+								"concurrency": {
+									"default": 10,
+									"type": "integer"
+								},
+								"healthy": {
+									"properties": {
+										"http_statuses": {
+											"default": [200, 302],
+											"items": {
+												"maximum": 599,
+												"minimum": 200,
+												"type": "integer"
+											},
+											"minItems": 1,
+											"type": "array",
+											"uniqueItems": true
+										},
+										"interval": {
+											"default": 0,
+											"minimum": 1,
+											"type": "integer"
+										},
+										"successes": {
+											"default": 2,
+											"maximum": 254,
+											"minimum": 1,
+											"type": "integer"
+										}
+									},
+									"type": "object"
+								},
+								"host": {
+									"pattern": "^\\*?[0-9a-zA-Z-._]+$",
+									"type": "string"
+								},
+								"http_path": {
+									"default": "/",
+									"type": "string"
+								},
+								"https_verify_certificate": {
+									"default": true,
+									"type": "boolean"
+								},
+								"port": {
+									"maximum": 65535,
+									"minimum": 1,
+									"type": "integer"
+								},
+								"req_headers": {
+									"items": {
+										"type": "string",
+										"uniqueItems": true
+									},
+									"minItems": 1,
+									"type": "array"
+								},
+								"timeout": {
+									"default": 1,
+									"type": "number"
+								},
+								"type": {
+									"default": "http",
+									"enum": ["http", "https", "tcp"],
+									"type": "string"
+								},
+								"unhealthy": {
+									"properties": {
+										"http_failures": {
+											"default": 5,
+											"maximum": 254,
+											"minimum": 1,
+											"type": "integer"
+										},
+										"http_statuses": {
+											"default": [404, 429, 500, 501, 502, 503, 504, 505],
+											"items": {
+												"maximum": 599,
+												"minimum": 200,
+												"type": "integer"
+											},
+											"minItems": 1,
+											"type": "array",
+											"uniqueItems": true
+										},
+										"interval": {
+											"default": 0,
+											"minimum": 1,
+											"type": "integer"
+										},
+										"tcp_failures": {
+											"default": 2,
+											"maximum": 254,
+											"minimum": 1,
+											"type": "integer"
+										},
+										"timeouts": {
+											"default": 3,
+											"maximum": 254,
+											"minimum": 1,
+											"type": "integer"
+										}
+									},
+									"type": "object"
+								}
+							},
+							"type": "object"
+						},
+						"passive": {
+							"properties": {
+								"healthy": {
+									"properties": {
+										"http_statuses": {
+											"default": [200, 201, 202, 203, 204, 205, 206, 207, 208, 226, 300, 301, 302, 303, 304, 305, 306, 307, 308],
+											"items": {
+												"maximum": 599,
+												"minimum": 200,
+												"type": "integer"
+											},
+											"minItems": 1,
+											"type": "array",
+											"uniqueItems": true
+										},
+										"successes": {
+											"default": 5,
+											"maximum": 254,
+											"minimum": 1,
+											"type": "integer"
+										}
+									},
+									"type": "object"
+								},
+								"type": {
+									"default": "http",
+									"enum": ["http", "https", "tcp"],
+									"type": "string"
+								},
+								"unhealthy": {
+									"properties": {
+										"http_failures": {
+											"default": 5,
+											"maximum": 254,
+											"minimum": 1,
+											"type": "integer"
+										},
+										"http_statuses": {
+											"default": [429, 500, 503],
+											"items": {
+												"maximum": 599,
+												"minimum": 200,
+												"type": "integer"
+											},
+											"minItems": 1,
+											"type": "array",
+											"uniqueItems": true
+										},
+										"tcp_failures": {
+											"default": 2,
+											"maximum": 254,
+											"minimum": 1,
+											"type": "integer"
+										},
+										"timeouts": {
+											"default": 7,
+											"maximum": 254,
+											"minimum": 1,
+											"type": "integer"
+										}
+									},
+									"type": "object"
+								}
+							},
+							"type": "object"
+						}
+					},
+					"type": "object"
+				},
+				"create_time": {
+					"type": "integer"
+				},
+				"desc": {
+					"maxLength": 256,
+					"type": "string"
+				},
+				"discovery_type": {
+					"description": "discovery type",
+					"type": "string"
+				},
+				"enable_websocket": {
+					"description": "enable websocket for request",
+					"type": "boolean"
+				},
+				"hash_on": {
+					"default": "vars",
+					"enum": ["consumer", "cookie", "header", "vars"],
+					"type": "string"
+				},
+				"id": {
+					"anyOf": [{
+						"maxLength": 64,
+						"minLength": 1,
+						"pattern": "^[a-zA-Z0-9-_.]+$",
+						"type": "string"
+					}, {
+						"minimum": 1,
+						"type": "integer"
+					}]
+				},
+				"key": {
+					"description": "the key of chash for dynamic load balancing",
+					"type": "string"
+				},
+				"labels": {
+					"description": "key/value pairs to specify attributes",
+					"maxProperties": 16,
+					"patternProperties": {
+						".*": {
+							"description": "value of label",
+							"maxLength": 64,
+							"minLength": 1,
+							"pattern": "^[a-zA-Z0-9-_.]+$",
+							"type": "string"
+						}
+					},
+					"type": "object"
+				},
+				"name": {
+					"maxLength": 100,
+					"minLength": 1,
+					"type": "string"
+				},
+				"nodes": {
+					"anyOf": [{
+						"minProperties": 1,
+						"patternProperties": {
+							".*": {
+								"description": "weight of node",
+								"minimum": 0,
+								"type": "integer"
+							}
+						},
+						"type": "object"
+					}, {
+						"items": {
+							"properties": {
+								"host": {
+									"pattern": "^\\*?[0-9a-zA-Z-._]+$",
+									"type": "string"
+								},
+								"metadata": {
+									"description": "metadata of node",
+									"type": "object"
+								},
+								"port": {
+									"description": "port of node",
+									"minimum": 1,
+									"type": "integer"
+								},
+								"weight": {
+									"description": "weight of node",
+									"minimum": 0,
+									"type": "integer"
+								}
+							},
+							"required": ["host", "port", "weight"],
+							"type": "object"
+						},
+						"type": "array"
+					}]
+				},
+				"pass_host": {
+					"default": "pass",
+					"description": "mod of host passing",
+					"enum": ["node", "pass", "rewrite"],
+					"type": "string"
+				},
+				"retries": {
+					"minimum": 0,
+					"type": "integer"
+				},
+				"service_name": {
+					"maxLength": 100,
+					"minLength": 1,
+					"type": "string"
+				},
+				"timeout": {
+					"properties": {
+						"connect": {
+							"minimum": 0,
+							"type": "number"
+						},
+						"read": {
+							"minimum": 0,
+							"type": "number"
+						},
+						"send": {
+							"minimum": 0,
+							"type": "number"
+						}
+					},
+					"required": ["connect", "read", "send"],
+					"type": "object"
+				},
+				"type": {
+					"description": "algorithms of load balancing",
+					"enum": ["chash", "ewma", "roundrobin"],
+					"type": "string"
+				},
+				"update_time": {
+					"type": "integer"
+				},
+				"upstream_host": {
+					"pattern": "^\\*?[0-9a-zA-Z-._]+$",
+					"type": "string"
+				}
+			},
+			"type": "object"
+		},
+		"upstream_hash_header_schema": {
+			"pattern": "^[a-zA-Z0-9-_]+$",
+			"type": "string"
+		},
+		"upstream_hash_vars_schema": {
+			"pattern": "^((uri|server_name|server_addr|request_uri|remote_port|remote_addr|query_string|host|hostname)|arg_[0-9a-zA-z_-]+)$",
+			"type": "string"
+		}
+	},
+	"plugins": {
+		"api-breaker": {
+			"priority": 1005,
+			"schema": {
+				"properties": {
+					"break_response_code": {
+						"maximum": 599,
+						"minimum": 200,
+						"type": "integer"
+					},
+					"healthy": {
+						"default": {
+							"http_statuses": [200],
+							"successes": 3
+						},
+						"properties": {
+							"http_statuses": {
+								"default": [200],
+								"items": {
+									"maximum": 499,
+									"minimum": 200,
+									"type": "integer"
+								},
+								"minItems": 1,
+								"type": "array",
+								"uniqueItems": true
+							},
+							"successes": {
+								"default": 3,
+								"minimum": 1,
+								"type": "integer"
+							}
+						},
+						"type": "object"
+					},
+					"max_breaker_sec": {
+						"default": 300,
+						"minimum": 3,
+						"type": "integer"
+					},
+					"unhealthy": {
+						"default": {
+							"failures": 3,
+							"http_statuses": [500]
+						},
+						"properties": {
+							"failures": {
+								"default": 3,
+								"minimum": 1,
+								"type": "integer"
+							},
+							"http_statuses": {
+								"default": [500],
+								"items": {
+									"maximum": 599,
+									"minimum": 500,
+									"type": "integer"
+								},
+								"minItems": 1,
+								"type": "array",
+								"uniqueItems": true
+							}
+						},
+						"type": "object"
+					}
+				},
+				"required": ["break_response_code"],
+				"type": "object"
+			},
+			"version": 0.1
+		},
+		"authz-keycloak": {
+			"priority": 2000,
+			"schema": {
+				"properties": {
+					"audience": {
+						"maxLength": 100,
+						"minLength": 1,
+						"type": "string"
+					},
+					"grant_type": {
+						"default": "urn:ietf:params:oauth:grant-type:uma-ticket",
+						"enum": ["urn:ietf:params:oauth:grant-type:uma-ticket"],
+						"maxLength": 100,
+						"minLength": 1,
+						"type": "string"
+					},
+					"keepalive": {
+						"default": true,
+						"type": "boolean"
+					},
+					"keepalive_pool": {
+						"default": 5,
+						"minimum": 1,
+						"type": "integer"
+					},
+					"keepalive_timeout": {
+						"default": 60000,
+						"minimum": 1000,
+						"type": "integer"
+					},
+					"permissions": {
+						"items": {
+							"maxLength": 100,
+							"minLength": 1,
+							"type": "string"
+						},
+						"type": "array",
+						"uniqueItems": true
+					},
+					"policy_enforcement_mode": {
+						"default": "ENFORCING",
+						"enum": ["ENFORCING", "PERMISSIVE"],
+						"type": "string"
+					},
+					"ssl_verify": {
+						"default": true,
+						"type": "boolean"
+					},
+					"timeout": {
+						"default": 3000,
+						"minimum": 1000,
+						"type": "integer"
+					},
+					"token_endpoint": {
+						"maxLength": 4096,
+						"minLength": 1,
+						"type": "string"
+					}
+				},
+				"required": ["token_endpoint"],
+				"type": "object"
+			},
+			"version": 0.1
+		},
+		"basic-auth": {
+			"consumer_schema": {
+				"additionalProperties": false,
+				"properties": {
+					"password": {
+						"type": "string"
+					},
+					"username": {
+						"type": "string"
+					}
+				},
+				"required": ["password", "username"],
+				"title": "work with consumer object",
+				"type": "object"
+			},
+			"priority": 2520,
+			"schema": {
+				"additionalProperties": false,
+				"properties": {
+					"disable": {
+						"type": "boolean"
+					}
+				},
+				"title": "work with route or service object",
+				"type": "object"
+			},
+			"type": "auth",
+			"version": 0.1
+		},
+		"batch-requests": {
+			"metadata_schema": {
+				"additionalProperties": false,
+				"properties": {
+					"max_body_size": {
+						"default": 1048576,
+						"description": "max pipeline body size in bytes",
+						"exclusiveMinimum": 0,
+						"type": "integer"
+					}
+				},
+				"type": "object"
+			},
+			"priority": 4010,
+			"schema": {
+				"additionalProperties": false,
+				"properties": {
+					"disable": {
+						"type": "boolean"
+					}
+				},
+				"type": "object"
+			},
+			"version": 0.1
+		},
+		"consumer-restriction": {
+			"priority": 2400,
+			"schema": {
+				"oneOf": [{
+					"properties": {
+						"blacklist": {
+							"items": {
+								"type": "string"
+							},
+							"minItems": 1,
+							"type": "array"
+						},
+						"rejected_code": {
+							"default": 403,
+							"minimum": 200,
+							"type": "integer"
+						},
+						"type": {
+							"default": "consumer_name",
+							"enum": ["consumer_name", "service_id"],
+							"type": "string"
+						}
+					},
+					"required": ["blacklist"],
+					"title": "blacklist"
+				}, {
+					"properties": {
+						"rejected_code": {
+							"default": 403,
+							"minimum": 200,
+							"type": "integer"
+						},
+						"type": {
+							"default": "consumer_name",
+							"enum": ["consumer_name", "service_id"],
+							"type": "string"
+						},
+						"whitelist": {
+							"items": {
+								"type": "string"
+							},
+							"minItems": 1,
+							"type": "array"
+						}
+					},
+					"required": ["whitelist"],
+					"title": "whitelist"
+				}],
+				"properties": {
+					"disable": {
+						"type": "boolean"
+					}
+				},
+				"type": "object"
+			},
+			"version": 0.1
+		},
+		"cors": {
+			"priority": 4000,
+			"schema": {
+				"properties": {
+					"allow_credential": {
+						"default": false,
+						"description": "allow client append credential. according to CORS specification,if you set this option to 'true', you can not use '*' for other options.",
+						"type": "boolean"
+					},
+					"allow_headers": {
+						"default": "*",
+						"description": "you can use '*' to allow all header when no credentials,'**' to allow forcefully(it will bring some security risks, be carefully),multiple header use ',' to split. default: *.",
+						"type": "string"
+					},
+					"allow_methods": {
+						"default": "*",
+						"description": "you can use '*' to allow all methods when no credentials and '**','**' to allow forcefully(it will bring some security risks, be carefully),multiple method use ',' to split. default: *.",
+						"type": "string"
+					},
+					"allow_origins": {
+						"default": "*",
+						"description": "you can use '*' to allow all origins when no credentials,'**' to allow forcefully(it will bring some security risks, be carefully),multiple origin use ',' to split. default: *.",
+						"type": "string"
+					},
+					"expose_headers": {
+						"default": "*",
+						"description": "you can use '*' to expose all header when no credentials,multiple header use ',' to split. default: *.",
+						"type": "string"
+					},
+					"max_age": {
+						"default": 5,
+						"description": "maximum number of seconds the results can be cached.-1 mean no cached,the max value is depend on browser,more detail plz check MDN. default: 5.",
+						"type": "integer"
+					}
+				},
+				"type": "object"
+			},
+			"version": 0.1
+		},
+		"echo": {
+			"priority": 412,
+			"schema": {
+				"additionalProperties": false,
+				"anyOf": [{
+					"required": ["before_body"]
+				}, {
+					"required": ["body"]
+				}, {
+					"required": ["after_body"]
+				}],
+				"minProperties": 1,
+				"properties": {
+					"after_body": {
+						"description": "body after the modification of filter phase.",
+						"type": "string"
+					},
+					"auth_value": {
+						"description": "auth value",
+						"type": "string"
+					},
+					"before_body": {
+						"description": "body before the filter phase.",
+						"type": "string"
+					},
+					"body": {
+						"description": "body to replace upstream response.",
+						"type": "string"
+					},
+					"headers": {
+						"description": "new headers for response",
+						"minProperties": 1,
+						"type": "object"
+					}
+				},
+				"type": "object"
+			},
+			"version": 0.1
+		},
+		"fault-injection": {
+			"priority": 11000,
+			"schema": {
+				"minProperties": 1,
+				"properties": {
+					"abort": {
+						"properties": {
+							"body": {
+								"minLength": 0,
+								"type": "string"
+							},
+							"http_status": {
+								"minimum": 200,
+								"type": "integer"
+							},
+							"percentage": {
+								"maximum": 100,
+								"minimum": 0,
+								"type": "integer"
+							}
+						},
+						"required": ["http_status"],
+						"type": "object"
+					},
+					"delay": {
+						"properties": {
+							"duration": {
+								"minimum": 0,
+								"type": "number"
+							},
+							"percentage": {
+								"maximum": 100,
+								"minimum": 0,
+								"type": "integer"
+							}
+						},
+						"required": ["duration"],
+						"type": "object"
+					}
+				},
+				"type": "object"
+			},
+			"version": 0.1
+		},
+		"grpc-transcode": {
+			"priority": 506,
+			"schema": {
+				"additionalProperties": true,
+				"properties": {
+					"deadline": {
+						"default": 0,
+						"description": "deadline for grpc, millisecond",
+						"type": "number"
+					},
+					"method": {
+						"description": "the method name in the grpc service.",
+						"type": "string"
+					},
+					"pb_option": {
+						"items": {
+							"anyOf": [{
+								"description": "enum as result",
+								"enum": ["int64_as_hexstring", "int64_as_number", "int64_as_string"],
+								"type": "string"
+							}, {
+								"description": "int64 as result",
+								"enum": ["enum_as_value", "ienum_as_name"],
+								"type": "string"
+							}, {
+								"description": "default values option",
+								"enum": ["auto_default_values", "no_default_values", "use_default_metatable", "use_default_values"],
+								"type": "string"
+							}, {
+								"description": "hooks option",
+								"enum": ["disable_hooks", "enable_hooks"],
+								"type": "string"
+							}],
+							"type": "string"
+						},
+						"minItems": 1,
+						"type": "array"
+					},
+					"proto_id": {
+						"anyOf": [{
+							"maxLength": 64,
+							"minLength": 1,
+							"pattern": "^[a-zA-Z0-9-_.]+$",
+							"type": "string"
+						}, {
+							"minimum": 1,
+							"type": "integer"
+						}]
+					},
+					"service": {
+						"description": "the grpc service name",
+						"type": "string"
+					}
+				},
+				"required": ["method", "proto_id", "service"],
+				"type": "object"
+			},
+			"version": 0.1
+		},
+		"hmac-auth": {
+			"consumer_schema": {
+				"additionalProperties": false,
+				"properties": {
+					"access_key": {
+						"maxLength": 256,
+						"minLength": 1,
+						"type": "string"
+					},
+					"algorithm": {
+						"default": "hmac-sha256",
+						"enum": ["hmac-sha1", "hmac-sha256", "hmac-sha512"],
+						"type": "string"
+					},
+					"clock_skew": {
+						"default": 0,
+						"type": "integer"
+					},
+					"encode_uri_params": {
+						"default": true,
+						"title": "Whether to escape the uri parameter",
+						"type": "boolean"
+					},
+					"keep_headers": {
+						"default": false,
+						"title": "whether to keep the http request header",
+						"type": "boolean"
+					},
+					"secret_key": {
+						"maxLength": 256,
+						"minLength": 1,
+						"type": "string"
+					},
+					"signed_headers": {
+						"items": {
+							"maxLength": 50,
+							"minLength": 1,
+							"type": "string"
+						},
+						"type": "array"
+					}
+				},
+				"required": ["access_key", "secret_key"],
+				"title": "work with consumer object",
+				"type": "object"
+			},
+			"priority": 2530,
+			"schema": {
+				"additionalProperties": false,
+				"properties": {
+					"disable": {
+						"type": "boolean"
+					}
+				},
+				"title": "work with route or service object",
+				"type": "object"
+			},
+			"type": "auth",
+			"version": 0.1
+		},
+		"http-logger": {
+			"metadata_schema": {
+				"additionalProperties": false,
+				"properties": {
+					"log_format": {
+						"default": {
+							"@timestamp": "$time_iso8601",
+							"client_ip": "$remote_addr",
+							"host": "$host"
+						},
+						"type": "object"
+					}
+				},
+				"type": "object"
+			},
+			"priority": 410,
+			"schema": {
+				"properties": {
+					"auth_header": {
+						"default": "",
+						"type": "string"
+					},
+					"batch_max_size": {
+						"default": 1000,
+						"minimum": 1,
+						"type": "integer"
+					},
+					"buffer_duration": {
+						"default": 60,
+						"minimum": 1,
+						"type": "integer"
+					},
+					"concat_method": {
+						"default": "json",
+						"enum": ["json", "new_line"],
+						"type": "string"
+					},
+					"inactive_timeout": {
+						"default": 5,
+						"minimum": 1,
+						"type": "integer"
+					},
+					"include_req_body": {
+						"default": false,
+						"type": "boolean"
+					},
+					"max_retry_count": {
+						"default": 0,
+						"minimum": 0,
+						"type": "integer"
+					},
+					"name": {
+						"default": "http logger",
+						"type": "string"
+					},
+					"retry_delay": {
+						"default": 1,
+						"minimum": 0,
+						"type": "integer"
+					},
+					"timeout": {
+						"default": 3,
+						"minimum": 1,
+						"type": "integer"
+					},
+					"uri": {
+						"pattern": "^[^\\/]+:\\/\\/([\\da-zA-Z.-]+|\\[[\\da-fA-F:]+\\])(:\\d+)?",
+						"type": "string"
+					}
+				},
+				"required": ["uri"],
+				"type": "object"
+			},
+			"version": 0.1
+		},
+		"ip-restriction": {
+			"priority": 3000,
+			"schema": {
+				"oneOf": [{
+					"additionalProperties": false,
+					"properties": {
+						"whitelist": {
+							"items": {
+								"anyOf": [{
+									"format": "ipv4",
+									"title": "IPv4",
+									"type": "string"
+								}, {
+									"pattern": "^([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])/([12]?[0-9]|3[0-2])$",
+									"title": "IPv4/CIDR",
+									"type": "string"
+								}, {
+									"format": "ipv6",
+									"title": "IPv6",
+									"type": "string"
+								}, {
+									"pattern": "^([a-fA-F0-9]{0,4}:){1,8}(:[a-fA-F0-9]{0,4}){0,8}([a-fA-F0-9]{0,4})?/[0-9]{1,3}$",
+									"title": "IPv6/CIDR",
+									"type": "string"
+								}]
+							},
+							"minItems": 1,
+							"type": "array"
+						}
+					},
+					"required": ["whitelist"],
+					"title": "whitelist"
+				}, {
+					"additionalProperties": false,
+					"properties": {
+						"blacklist": {
+							"items": {
+								"anyOf": [{
+									"format": "ipv4",
+									"title": "IPv4",
+									"type": "string"
+								}, {
+									"pattern": "^([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])/([12]?[0-9]|3[0-2])$",
+									"title": "IPv4/CIDR",
+									"type": "string"
+								}, {
+									"format": "ipv6",
+									"title": "IPv6",
+									"type": "string"
+								}, {
+									"pattern": "^([a-fA-F0-9]{0,4}:){1,8}(:[a-fA-F0-9]{0,4}){0,8}([a-fA-F0-9]{0,4})?/[0-9]{1,3}$",
+									"title": "IPv6/CIDR",
+									"type": "string"
+								}]
+							},
+							"minItems": 1,
+							"type": "array"
+						}
+					},
+					"required": ["blacklist"],
+					"title": "blacklist"
+				}],
+				"properties": {
+					"disable": {
+						"type": "boolean"
+					}
+				},
+				"type": "object"
+			},
+			"version": 0.1
+		},
+		"jwt-auth": {
+			"consumer_schema": {
+				"dependencies": {
+					"algorithm": {
+						"oneOf": [{
+							"properties": {
+								"algorithm": {
+									"default": "HS256",
+									"enum": ["HS256", "HS512"]
+								}
+							}
+						}, {
+							"properties": {
+								"algorithm": {
+									"enum": ["RS256"]
+								},
+								"private_key": {
+									"type": "string"
+								},
+								"public_key": {
+									"type": "string"
+								}
+							},
+							"required": ["private_key", "public_key"]
+						}]
+					}
+				},
+				"properties": {
+					"algorithm": {
+						"default": "HS256",
+						"enum": ["HS256", "HS512", "RS256"],
+						"type": "string"
+					},
+					"base64_secret": {
+						"default": false,
+						"type": "boolean"
+					},
+					"exp": {
+						"default": 86400,
+						"minimum": 1,
+						"type": "integer"
+					},
+					"key": {
+						"type": "string"
+					},
+					"secret": {
+						"type": "string"
+					}
+				},
+				"required": ["key"],
+				"type": "object"
+			},
+			"priority": 2510,
+			"schema": {
+				"additionalProperties": false,
+				"properties": {
+					"disable": {
+						"type": "boolean"
+					}
+				},
+				"type": "object"
+			},
+			"type": "auth",
+			"version": 0.1
+		},
+		"kafka-logger": {
+			"priority": 403,
+			"schema": {
+				"properties": {
+					"batch_max_size": {
+						"default": 1000,
+						"minimum": 1,
+						"type": "integer"
+					},
+					"broker_list": {
+						"type": "object"
+					},
+					"buffer_duration": {
+						"default": 60,
+						"minimum": 1,
+						"type": "integer"
+					},
+					"inactive_timeout": {
+						"default": 5,
+						"minimum": 1,
+						"type": "integer"
+					},
+					"include_req_body": {
+						"default": false,
+						"type": "boolean"
+					},
+					"kafka_topic": {
+						"type": "string"
+					},
+					"key": {
+						"type": "string"
+					},
+					"max_retry_count": {
+						"default": 0,
+						"minimum": 0,
+						"type": "integer"
+					},
+					"meta_format": {
+						"default": "default",
+						"enum": ["default", "origin"],
+						"type": "string"
+					},
+					"name": {
+						"default": "kafka logger",
+						"type": "string"
+					},
+					"retry_delay": {
+						"default": 1,
+						"minimum": 0,
+						"type": "integer"
+					},
+					"timeout": {
+						"default": 3,
+						"minimum": 1,
+						"type": "integer"
+					}
+				},
+				"required": ["broker_list", "kafka_topic"],
+				"type": "object"
+			},
+			"version": 0.1
+		},
+		"key-auth": {
+			"consumer_schema": {
+				"additionalProperties": false,
+				"properties": {
+					"key": {
+						"type": "string"
+					}
+				},
+				"required": ["key"],
+				"type": "object"
+			},
+			"priority": 2500,
+			"schema": {
+				"additionalProperties": false,
+				"properties": {
+					"disable": {
+						"type": "boolean"
+					}
+				},
+				"type": "object"
+			},
+			"type": "auth",
+			"version": 0.1
+		},
+		"limit-conn": {
+			"priority": 1003,
+			"schema": {
+				"properties": {
+					"burst": {
+						"minimum": 0,
+						"type": "integer"
+					},
+					"conn": {
+						"exclusiveMinimum": 0,
+						"type": "integer"
+					},
+					"default_conn_delay": {
+						"exclusiveMinimum": 0,
+						"type": "number"
+					},
+					"key": {
+						"enum": ["consumer_name", "http_x_forwarded_for", "http_x_real_ip", "remote_addr", "server_addr"],
+						"type": "string"
+					},
+					"rejected_code": {
+						"default": 503,
+						"minimum": 200,
+						"type": "integer"
+					}
+				},
+				"required": ["burst", "conn", "default_conn_delay", "key"],
+				"type": "object"
+			},
+			"version": 0.1
+		},
+		"limit-count": {
+			"priority": 1002,
+			"schema": {
+				"dependencies": {
+					"policy": {
+						"oneOf": [{
+							"properties": {
+								"policy": {
+									"enum": ["local"]
+								}
+							}
+						}, {
+							"properties": {
+								"policy": {
+									"enum": ["redis"]
+								},
+								"redis_host": {
+									"minLength": 2,
+									"type": "string"
+								},
+								"redis_password": {
+									"minLength": 0,
+									"type": "string"
+								},
+								"redis_port": {
+									"default": 6379,
+									"minimum": 1,
+									"type": "integer"
+								},
+								"redis_timeout": {
+									"default": 1000,
+									"minimum": 1,
+									"type": "integer"
+								}
+							},
+							"required": ["redis_host"]
+						}, {
+							"properties": {
+								"policy": {
+									"enum": ["redis-cluster"]
+								},
+								"redis_cluster_nodes": {
+									"items": {
+										"maxLength": 100,
+										"minLength": 2,
+										"type": "string"
+									},
+									"minItems": 2,
+									"type": "array"
+								},
+								"redis_password": {
+									"minLength": 0,
+									"type": "string"
+								},
+								"redis_timeout": {
+									"default": 1000,
+									"minimum": 1,
+									"type": "integer"
+								}
+							},
+							"required": ["redis_cluster_nodes"]
+						}]
+					}
+				},
+				"properties": {
+					"count": {
+						"minimum": 0,
+						"type": "integer"
+					},
+					"key": {
+						"default": "remote_addr",
+						"enum": ["consumer_name", "http_x_forwarded_for", "http_x_real_ip", "remote_addr", "server_addr", "service_id"],
+						"type": "string"
+					},
+					"policy": {
+						"default": "local",
+						"enum": ["local", "redis", "redis-cluster"],
+						"type": "string"
+					},
+					"rejected_code": {
+						"default": 503,
+						"maximum": 600,
+						"minimum": 200,
+						"type": "integer"
+					},
+					"time_window": {
+						"minimum": 0,
+						"type": "integer"
+					}
+				},
+				"required": ["count", "time_window"],
+				"type": "object"
+			},
+			"version": 0.4
+		},
+		"limit-req": {
+			"priority": 1001,
+			"schema": {
+				"properties": {
+					"burst": {
+						"minimum": 0,
+						"type": "number"
+					},
+					"key": {
+						"enum": ["consumer_name", "http_x_forwarded_for", "http_x_real_ip", "remote_addr", "server_addr"],
+						"type": "string"
+					},
+					"rate": {
+						"minimum": 0,
+						"type": "number"
+					},
+					"rejected_code": {
+						"default": 503,
+						"minimum": 200,
+						"type": "integer"
+					}
+				},
+				"required": ["burst", "key", "rate"],
+				"type": "object"
+			},
+			"version": 0.1
+		},
+		"mqtt-proxy": {
+			"priority": 1000,
+			"schema": {
+				"properties": {
+					"protocol_level": {
+						"type": "integer"
+					},
+					"protocol_name": {
+						"type": "string"
+					},
+					"upstream": {
+						"properties": {
+							"ip": {
+								"type": "string"
+							},
+							"port": {
+								"type": "number"
+							}
+						},
+						"type": "object"
+					}
+				},
+				"required": ["protocol_level", "protocol_name", "upstream"],
+				"type": "object"
+			},
+			"version": 0.1
+		},
+		"openid-connect": {
+			"priority": 2599,
+			"schema": {
+				"properties": {
+					"bearer_only": {
+						"default": false,
+						"type": "boolean"
+					},
+					"client_id": {
+						"type": "string"
+					},
+					"client_secret": {
+						"type": "string"
+					},
+					"discovery": {
+						"type": "string"
+					},
+					"introspection_endpoint": {
+						"type": "string"
+					},
+					"introspection_endpoint_auth_method": {
+						"default": "client_secret_basic",
+						"type": "string"
+					},
+					"logout_path": {
+						"default": "/logout",
+						"type": "string"
+					},
+					"public_key": {
+						"type": "string"
+					},
+					"realm": {
+						"default": "apisix",
+						"type": "string"
+					},
+					"redirect_uri": {
+						"description": "use ngx.var.request_uri if not configured",
+						"type": "string"
+					},
+					"scope": {
+						"default": "openid",
+						"type": "string"
+					},
+					"ssl_verify": {
+						"default": false,
+						"type": "boolean"
+					},
+					"timeout": {
+						"default": 3,
+						"description": "timeout in seconds",
+						"minimum": 1,
+						"type": "integer"
+					},
+					"token_signing_alg_values_expected": {
+						"type": "string"
+					}
+				},
+				"required": ["client_id", "client_secret", "discovery"],
+				"type": "object"
+			},
+			"version": 0.1
+		},
+		"prometheus": {
+			"priority": 500,
+			"schema": {
+				"additionalProperties": false,
+				"properties": {
+					"disable": {
+						"type": "boolean"
+					}
+				},
+				"type": "object"
+			},
+			"version": 0.2
+		},
+		"proxy-cache": {
+			"priority": 1009,
+			"schema": {
+				"properties": {
+					"cache_bypass": {
+						"items": {
+							"pattern": "(^[^\\$].+$|^\\$[0-9a-zA-Z_]+$)",
+							"type": "string"
+						},
+						"minItems": 1,
+						"type": "array"
+					},
+					"cache_http_status": {
+						"default": [200, 301, 404],
+						"items": {
+							"description": "http response status",
+							"maximum": 599,
+							"minimum": 200,
+							"type": "integer"
+						},
+						"minItems": 1,
+						"type": "array",
+						"uniqueItems": true
+					},
+					"cache_key": {
+						"default": ["$host", "$request_uri"],
+						"items": {
+							"description": "a key for caching",
+							"pattern": "(^[^\\$].+$|^\\$[0-9a-zA-Z_]+$)",
+							"type": "string"
+						},
+						"minItems": 1,
+						"type": "array"
+					},
+					"cache_method": {
+						"default": ["GET", "HEAD"],
+						"items": {
+							"description": "http method",
+							"enum": ["CONNECT", "DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT", "TRACE"],
+							"type": "string"
+						},
+						"minItems": 1,
+						"type": "array",
+						"uniqueItems": true
+					},
+					"cache_zone": {
+						"default": "disk_cache_one",
+						"maxLength": 100,
+						"minLength": 1,
+						"type": "string"
+					},
+					"hide_cache_headers": {
+						"default": false,
+						"type": "boolean"
+					},
+					"no_cache": {
+						"items": {
+							"pattern": "(^[^\\$].+$|^\\$[0-9a-zA-Z_]+$)",
+							"type": "string"
+						},
+						"minItems": 1,
+						"type": "array"
+					}
+				},
+				"type": "object"
+			},
+			"version": 0.1
+		},
+		"proxy-mirror": {
+			"priority": 1010,
+			"schema": {
+				"minProperties": 1,
+				"properties": {
+					"host": {
+						"pattern": "^http(s)?:\\/\\/[a-zA-Z0-9][-a-zA-Z0-9]{0,62}(\\.[a-zA-Z0-9][-a-zA-Z0-9]{0,62})+(:[0-9]{1,5})?$",
+						"type": "string"
+					}
+				},
+				"required": ["host"],
+				"type": "object"
+			},
+			"version": 0.1
+		},
+		"proxy-rewrite": {
+			"priority": 1008,
+			"schema": {
+				"additionalProperties": false,
+				"minProperties": 1,
+				"properties": {
+					"headers": {
+						"description": "new headers for request",
+						"minProperties": 1,
+						"type": "object"
+					},
+					"host": {
+						"description": "new host for upstream",
+						"pattern": "^[0-9a-zA-Z-.]+$",
+						"type": "string"
+					},
+					"regex_uri": {
+						"description": "new uri that substitute from client uri for upstream, lower priority than uri property",
+						"items": {
+							"description": "regex uri",
+							"type": "string"
+						},
+						"maxItems": 2,
+						"minItems": 2,
+						"type": "array"
+					},
+					"scheme": {
+						"description": "new scheme for upstream",
+						"enum": ["http", "https"],
+						"type": "string"
+					},
+					"uri": {
+						"description": "new uri for upstream",
+						"maxLength": 4096,
+						"minLength": 1,
+						"pattern": "^\\/.*",
+						"type": "string"
+					}
+				},
+				"type": "object"
+			},
+			"version": 0.1
+		},
+		"redirect": {
+			"priority": 900,
+			"schema": {
+				"oneOf": [{
+					"required": ["uri"]
+				}, {
+					"required": ["http_to_https"]
+				}],
+				"properties": {
+					"http_to_https": {
+						"type": "boolean"
+					},
+					"ret_code": {
+						"default": 302,
+						"minimum": 200,
+						"type": "integer"
+					},
+					"uri": {
+						"minLength": 2,
+						"pattern": "(\\\\\\$[0-9a-zA-Z_]+)|\\$\\{([0-9a-zA-Z_]+)\\}|\\$([0-9a-zA-Z_]+)|(\\$|[^$\\\\]+)",
+						"type": "string"
+					}
+				},
+				"type": "object"
+			},
+			"version": 0.1
+		},
+		"referer-restriction": {
+			"priority": 2990,
+			"schema": {
+				"additionalProperties": false,
+				"properties": {
+					"bypass_missing": {
+						"default": false,
+						"type": "boolean"
+					},
+					"whitelist": {
+						"items": {
+							"pattern": "^\\*?[0-9a-zA-Z-._]+$",
+							"type": "string"
+						},
+						"minItems": 1,
+						"type": "array"
+					}
+				},
+				"required": ["whitelist"],
+				"type": "object"
+			},
+			"version": 0.1
+		},
+		"request-id": {
+			"priority": 11010,
+			"schema": {
+				"properties": {
+					"header_name": {
+						"default": "X-Request-Id",
+						"type": "string"
+					},
+					"include_in_response": {
+						"default": true,
+						"type": "boolean"
+					}
+				},
+				"type": "object"
+			},
+			"version": 0.1
+		},
+		"request-validation": {
+			"priority": 2800,
+			"schema": {
+				"anyOf": [{
+					"properties": {
+						"body_schema": {
+							"type": "object"
+						}
+					},
+					"required": ["body_schema"],
+					"title": "Body schema"
+				}, {
+					"properties": {
+						"header_schema": {
+							"type": "object"
+						}
+					},
+					"required": ["header_schema"],
+					"title": "Header schema"
+				}],
+				"properties": {
+					"disable": {
+						"type": "boolean"
+					}
+				},
+				"type": "object"
+			},
+			"type": "validation",
+			"version": 0.1
+		},
+		"response-rewrite": {
+			"priority": 899,
+			"schema": {
+				"additionalProperties": false,
+				"minProperties": 1,
+				"properties": {
+					"body": {
+						"description": "new body for response",
+						"type": "string"
+					},
+					"body_base64": {
+						"default": false,
+						"description": "whether new body for response need base64 decode before return",
+						"type": "boolean"
+					},
+					"headers": {
+						"description": "new headers for response",
+						"minProperties": 1,
+						"type": "object"
+					},
+					"status_code": {
+						"description": "new status code for response",
+						"maximum": 598,
+						"minimum": 200,
+						"type": "integer"
+					}
+				},
+				"type": "object"
+			},
+			"version": 0.1
+		},
+		"serverless-post-function": {
+			"priority": -2000,
+			"schema": {
+				"properties": {
+					"functions": {
+						"items": {
+							"type": "string"
+						},
+						"minItems": 1,
+						"type": "array"
+					},
+					"phase": {
+						"default": "access",
+						"enum": ["access", "balancer", "body_filter", "header_filter", "log", "rewrite"],
+						"type": "string"
+					}
+				},
+				"required": ["functions"],
+				"type": "object"
+			},
+			"version": 0.1
+		},
+		"serverless-pre-function": {
+			"priority": 10000,
+			"schema": {
+				"properties": {
+					"functions": {
+						"items": {
+							"type": "string"
+						},
+						"minItems": 1,
+						"type": "array"
+					},
+					"phase": {
+						"default": "access",
+						"enum": ["access", "balancer", "body_filter", "header_filter", "log", "rewrite"],
+						"type": "string"
+					}
+				},
+				"required": ["functions"],
+				"type": "object"
+			},
+			"version": 0.1
+		},
+		"sls-logger": {
+			"priority": 406,
+			"schema": {
+				"properties": {
+					"access_key_id": {
+						"type": "string"
+					},
+					"access_key_secret": {
+						"type": "string"
+					},
+					"batch_max_size": {
+						"default": 1000,
+						"minimum": 1,
+						"type": "integer"
+					},
+					"buffer_duration": {
+						"default": 60,
+						"minimum": 1,
+						"type": "integer"
+					},
+					"host": {
+						"type": "string"
+					},
+					"inactive_timeout": {
+						"default": 5,
+						"minimum": 1,
+						"type": "integer"
+					},
+					"include_req_body": {
+						"default": false,
+						"type": "boolean"
+					},
+					"logstore": {
+						"type": "string"
+					},
+					"max_retry_count": {
+						"default": 0,
+						"minimum": 0,
+						"type": "integer"
+					},
+					"name": {
+						"default": "sls-logger",
+						"type": "string"
+					},
+					"port": {
+						"type": "integer"
+					},
+					"project": {
+						"type": "string"
+					},
+					"retry_delay": {
+						"default": 1,
+						"minimum": 0,
+						"type": "integer"
+					},
+					"timeout": {
+						"default": 5000,
+						"minimum": 1,
+						"type": "integer"
+					}
+				},
+				"required": ["access_key_id", "access_key_secret", "host", "logstore", "port", "project"],
+				"type": "object"
+			},
+			"version": 0.1
+		},
+		"syslog": {
+			"priority": 401,
+			"schema": {
+				"properties": {
+					"batch_max_size": {
+						"default": 1000,
+						"minimum": 1,
+						"type": "integer"
+					},
+					"buffer_duration": {
+						"default": 60,
+						"minimum": 1,
+						"type": "integer"
+					},
+					"drop_limit": {
+						"default": 1048576,
+						"type": "integer"
+					},
+					"flush_limit": {
+						"default": 4096,
+						"minimum": 1,
+						"type": "integer"
+					},
+					"host": {
+						"type": "string"
+					},
+					"include_req_body": {
+						"default": false,
+						"type": "boolean"
+					},
+					"max_retry_times": {
+						"default": 1,
+						"minimum": 1,
+						"type": "integer"
+					},
+					"name": {
+						"default": "sys logger",
+						"type": "string"
+					},
+					"pool_size": {
+						"default": 5,
+						"minimum": 5,
+						"type": "integer"
+					},
+					"port": {
+						"type": "integer"
+					},
+					"retry_interval": {
+						"default": 1,
+						"minimum": 0,
+						"type": "integer"
+					},
+					"sock_type": {
+						"default": "tcp",
+						"enum": ["tcp", "udp"],
+						"type": "string"
+					},
+					"timeout": {
+						"default": 3,
+						"minimum": 1,
+						"type": "integer"
+					},
+					"tls": {
+						"default": false,
+						"type": "boolean"
+					}
+				},
+				"required": ["host", "port"],
+				"type": "object"
+			},
+			"version": 0.1
+		},
+		"tcp-logger": {
+			"priority": 405,
+			"schema": {
+				"properties": {
+					"batch_max_size": {
+						"default": 1000,
+						"minimum": 1,
+						"type": "integer"
+					},
+					"buffer_duration": {
+						"default": 60,
+						"minimum": 1,
+						"type": "integer"
+					},
+					"host": {
+						"type": "string"
+					},
+					"inactive_timeout": {
+						"default": 5,
+						"minimum": 1,
+						"type": "integer"
+					},
+					"include_req_body": {
+						"default": false,
+						"type": "boolean"
+					},
+					"max_retry_count": {
+						"default": 0,
+						"minimum": 0,
+						"type": "integer"
+					},
+					"name": {
+						"default": "tcp logger",
+						"type": "string"
+					},
+					"port": {
+						"minimum": 0,
+						"type": "integer"
+					},
+					"retry_delay": {
+						"default": 1,
+						"minimum": 0,
+						"type": "integer"
+					},
+					"timeout": {
+						"default": 1000,
+						"minimum": 1,
+						"type": "integer"
+					},
+					"tls": {
+						"default": false,
+						"type": "boolean"
+					},
+					"tls_options": {
+						"type": "string"
+					}
+				},
+				"required": ["host", "port"],
+				"type": "object"
+			},
+			"version": 0.1
+		},
+		"traffic-split": {
+			"priority": 966,
+			"schema": {
+				"properties": {
+					"rules": {
+						"items": {
+							"properties": {
+								"match": {
+									"default": [{
+										"vars": [
+											[0, ">", "server_port"]
+										]
+									}],
+									"items": {
+										"properties": {
+											"vars": {
+												"items": {
+													"additionalItems": {
+														"anyOf": [{
+															"type": "string"
+														}, {
+															"type": "number"
+														}, {
+															"type": "boolean"
+														}, {
+															"items": {
+																"anyOf": [{
+																	"maxLength": 100,
+																	"minLength": 1,
+																	"type": "string"
+																}, {
+																	"type": "number"
+																}, {
+																	"type": "boolean"
+																}]
+															},
+															"type": "array",
+															"uniqueItems": true
+														}]
+													},
+													"items": [{
+														"maxLength": 100,
+														"minLength": 1,
+														"type": "string"
+													}, {
+														"maxLength": 2,
+														"minLength": 1,
+														"type": "string"
+													}],
+													"maxItems": 10,
+													"minItems": 0,
+													"type": "array"
+												},
+												"type": "array"
+											}
+										},
+										"type": "object"
+									},
+									"type": "array"
+								},
+								"weighted_upstreams": {
+									"default": [{
+										"weight": 1
+									}],
+									"items": {
+										"properties": {
+											"upstream": {
+												"additionalProperties": false,
+												"anyOf": [{
+													"required": ["nodes", "type"]
+												}, {
+													"required": ["service_name", "type"]
+												}],
+												"properties": {
+													"checks": {
+														"additionalProperties": false,
+														"anyOf": [{
+															"required": ["active"]
+														}, {
+															"required": ["active", "passive"]
+														}],
+														"properties": {
+															"active": {
+																"properties": {
+																	"concurrency": {
+																		"default": 10,
+																		"type": "integer"
+																	},
+																	"healthy": {
+																		"properties": {
+																			"http_statuses": {
+																				"default": [200, 302],
+																				"items": {
+																					"maximum": 599,
+																					"minimum": 200,
+																					"type": "integer"
+																				},
+																				"minItems": 1,
+																				"type": "array",
+																				"uniqueItems": true
+																			},
+																			"interval": {
+																				"default": 0,
+																				"minimum": 1,
+																				"type": "integer"
+																			},
+																			"successes": {
+																				"default": 2,
+																				"maximum": 254,
+																				"minimum": 1,
+																				"type": "integer"
+																			}
+																		},
+																		"type": "object"
+																	},
+																	"host": {
+																		"pattern": "^\\*?[0-9a-zA-Z-._]+$",
+																		"type": "string"
+																	},
+																	"http_path": {
+																		"default": "/",
+																		"type": "string"
+																	},
+																	"https_verify_certificate": {
+																		"default": true,
+																		"type": "boolean"
+																	},
+																	"port": {
+																		"maximum": 65535,
+																		"minimum": 1,
+																		"type": "integer"
+																	},
+																	"req_headers": {
+																		"items": {
+																			"type": "string",
+																			"uniqueItems": true
+																		},
+																		"minItems": 1,
+																		"type": "array"
+																	},
+																	"timeout": {
+																		"default": 1,
+																		"type": "number"
+																	},
+																	"type": {
+																		"default": "http",
+																		"enum": ["http", "https", "tcp"],
+																		"type": "string"
+																	},
+																	"unhealthy": {
+																		"properties": {
+																			"http_failures": {
+																				"default": 5,
+																				"maximum": 254,
+																				"minimum": 1,
+																				"type": "integer"
+																			},
+																			"http_statuses": {
+																				"default": [404, 429, 500, 501, 502, 503, 504, 505],
+																				"items": {
+																					"maximum": 599,
+																					"minimum": 200,
+																					"type": "integer"
+																				},
+																				"minItems": 1,
+																				"type": "array",
+																				"uniqueItems": true
+																			},
+																			"interval": {
+																				"default": 0,
+																				"minimum": 1,
+																				"type": "integer"
+																			},
+																			"tcp_failures": {
+																				"default": 2,
+																				"maximum": 254,
+																				"minimum": 1,
+																				"type": "integer"
+																			},
+																			"timeouts": {
+																				"default": 3,
+																				"maximum": 254,
+																				"minimum": 1,
+																				"type": "integer"
+																			}
+																		},
+																		"type": "object"
+																	}
+																},
+																"type": "object"
+															},
+															"passive": {
+																"properties": {
+																	"healthy": {
+																		"properties": {
+																			"http_statuses": {
+																				"default": [200, 201, 202, 203, 204, 205, 206, 207, 208, 226, 300, 301, 302, 303, 304, 305, 306, 307, 308],
+																				"items": {
+																					"maximum": 599,
+																					"minimum": 200,
+																					"type": "integer"
+																				},
+																				"minItems": 1,
+																				"type": "array",
+																				"uniqueItems": true
+																			},
+																			"successes": {
+																				"default": 5,
+																				"maximum": 254,
+																				"minimum": 1,
+																				"type": "integer"
+																			}
+																		},
+																		"type": "object"
+																	},
+																	"type": {
+																		"default": "http",
+																		"enum": ["http", "https", "tcp"],
+																		"type": "string"
+																	},
+																	"unhealthy": {
+																		"properties": {
+																			"http_failures": {
+																				"default": 5,
+																				"maximum": 254,
+																				"minimum": 1,
+																				"type": "integer"
+																			},
+																			"http_statuses": {
+																				"default": [429, 500, 503],
+																				"items": {
+																					"maximum": 599,
+																					"minimum": 200,
+																					"type": "integer"
+																				},
+																				"minItems": 1,
+																				"type": "array",
+																				"uniqueItems": true
+																			},
+																			"tcp_failures": {
+																				"default": 2,
+																				"maximum": 254,
+																				"minimum": 1,
+																				"type": "integer"
+																			},
+																			"timeouts": {
+																				"default": 7,
+																				"maximum": 254,
+																				"minimum": 1,
+																				"type": "integer"
+																			}
+																		},
+																		"type": "object"
+																	}
+																},
+																"type": "object"
+															}
+														},
+														"type": "object"
+													},
+													"create_time": {
+														"type": "integer"
+													},
+													"desc": {
+														"maxLength": 256,
+														"type": "string"
+													},
+													"discovery_type": {
+														"description": "discovery type",
+														"type": "string"
+													},
+													"enable_websocket": {
+														"description": "enable websocket for request",
+														"type": "boolean"
+													},
+													"hash_on": {
+														"default": "vars",
+														"enum": ["consumer", "cookie", "header", "vars"],
+														"type": "string"
+													},
+													"id": {
+														"anyOf": [{
+															"maxLength": 64,
+															"minLength": 1,
+															"pattern": "^[a-zA-Z0-9-_.]+$",
+															"type": "string"
+														}, {
+															"minimum": 1,
+															"type": "integer"
+														}]
+													},
+													"key": {
+														"description": "the key of chash for dynamic load balancing",
+														"type": "string"
+													},
+													"labels": {
+														"description": "key/value pairs to specify attributes",
+														"maxProperties": 16,
+														"patternProperties": {
+															".*": {
+																"description": "value of label",
+																"maxLength": 64,
+																"minLength": 1,
+																"pattern": "^[a-zA-Z0-9-_.]+$",
+																"type": "string"
+															}
+														},
+														"type": "object"
+													},
+													"name": {
+														"maxLength": 100,
+														"minLength": 1,
+														"type": "string"
+													},
+													"nodes": {
+														"anyOf": [{
+															"minProperties": 1,
+															"patternProperties": {
+																".*": {
+																	"description": "weight of node",
+																	"minimum": 0,
+																	"type": "integer"
+																}
+															},
+															"type": "object"
+														}, {
+															"items": {
+																"properties": {
+																	"host": {
+																		"pattern": "^\\*?[0-9a-zA-Z-._]+$",
+																		"type": "string"
+																	},
+																	"metadata": {
+																		"description": "metadata of node",
+																		"type": "object"
+																	},
+																	"port": {
+																		"description": "port of node",
+																		"minimum": 1,
+																		"type": "integer"
+																	},
+																	"weight": {
+																		"description": "weight of node",
+																		"minimum": 0,
+																		"type": "integer"
+																	}
+																},
+																"required": ["host", "port", "weight"],
+																"type": "object"
+															},
+															"type": "array"
+														}]
+													},
+													"pass_host": {
+														"default": "pass",
+														"description": "mod of host passing",
+														"enum": ["node", "pass", "rewrite"],
+														"type": "string"
+													},
+													"retries": {
+														"minimum": 0,
+														"type": "integer"
+													},
+													"service_name": {
+														"maxLength": 100,
+														"minLength": 1,
+														"type": "string"
+													},
+													"timeout": {
+														"properties": {
+															"connect": {
+																"minimum": 0,
+																"type": "number"
+															},
+															"read": {
+																"minimum": 0,
+																"type": "number"
+															},
+															"send": {
+																"minimum": 0,
+																"type": "number"
+															}
+														},
+														"required": ["connect", "read", "send"],
+														"type": "object"
+													},
+													"type": {
+														"description": "algorithms of load balancing",
+														"enum": ["chash", "ewma", "roundrobin"],
+														"type": "string"
+													},
+													"update_time": {
+														"type": "integer"
+													},
+													"upstream_host": {
+														"pattern": "^\\*?[0-9a-zA-Z-._]+$",
+														"type": "string"
+													}
+												},
+												"type": "object"
+											},
+											"upstream_id": {
+												"anyOf": [{
+													"maxLength": 64,
+													"minLength": 1,
+													"pattern": "^[a-zA-Z0-9-_.]+$",
+													"type": "string"
+												}, {
+													"minimum": 1,
+													"type": "integer"
+												}]
+											},
+											"weight": {
+												"default": 1,
+												"description": "used to split traffic between differentupstreams for plugin configuration",
+												"minimum": 0,
+												"type": "integer"
+											}
+										},
+										"type": "object"
+									},
+									"maxItems": 20,
+									"minItems": 1,
+									"type": "array"
+								}
+							},
+							"type": "object"
+						},
+						"type": "array"
+					}
+				},
+				"type": "object"
+			},
+			"version": 0.1
+		},
+		"udp-logger": {
+			"priority": 400,
+			"schema": {
+				"properties": {
+					"batch_max_size": {
+						"default": 1000,
+						"minimum": 1,
+						"type": "integer"
+					},
+					"buffer_duration": {
+						"default": 60,
+						"minimum": 1,
+						"type": "integer"
+					},
+					"host": {
+						"type": "string"
+					},
+					"inactive_timeout": {
+						"default": 5,
+						"minimum": 1,
+						"type": "integer"
+					},
+					"include_req_body": {
+						"default": false,
+						"type": "boolean"
+					},
+					"name": {
+						"default": "udp logger",
+						"type": "string"
+					},
+					"port": {
+						"minimum": 0,
+						"type": "integer"
+					},
+					"timeout": {
+						"default": 3,
+						"minimum": 1,
+						"type": "integer"
+					}
+				},
+				"required": ["host", "port"],
+				"type": "object"
+			},
+			"version": 0.1
+		},
+		"uri-blocker": {
+			"priority": 2900,
+			"schema": {
+				"properties": {
+					"block_rules": {
+						"items": {
+							"maxLength": 4096,
+							"minLength": 1,
+							"type": "string"
+						},
+						"type": "array",
+						"uniqueItems": true
+					},
+					"rejected_code": {
+						"default": 403,
+						"minimum": 200,
+						"type": "integer"
+					}
+				},
+				"required": ["block_rules"],
+				"type": "object"
+			},
+			"version": 0.1
+		},
+		"wolf-rbac": {
+			"priority": 2555,
+			"schema": {
+				"properties": {
+					"appid": {
+						"default": "unset",
+						"type": "string"
+					},
+					"header_prefix": {
+						"default": "X-",
+						"type": "string"
+					},
+					"server": {
+						"default": "http://127.0.0.1:10080",
+						"type": "string"
+					}
+				},
+				"type": "object"
+			},
+			"type": "auth",
+			"version": 0.1
+		},
+		"zipkin": {
+			"priority": 11011,
+			"schema": {
+				"properties": {
+					"endpoint": {
+						"type": "string"
+					},
+					"sample_ratio": {
+						"maximum": 1,
+						"minimum": 0.00001,
+						"type": "number"
+					},
+					"server_addr": {
+						"description": "default is $server_addr, you can specify your external ip address",
+						"pattern": "^[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}$",
+						"type": "string"
+					},
+					"service_name": {
+						"default": "APISIX",
+						"description": "service name for zipkin reporter",
+						"type": "string"
+					}
+				},
+				"required": ["endpoint", "sample_ratio"],
+				"type": "object"
+			},
+			"version": 0.1
+		}
+	}
 }

--- a/api/conf/schema.json
+++ b/api/conf/schema.json
@@ -1,4048 +1,4963 @@
 {
-	"main": {
-		"consumer": {
-			"additionalProperties": false,
-			"properties": {
-				"create_time": {
-					"type": "integer"
-				},
-				"desc": {
-					"maxLength": 256,
-					"type": "string"
-				},
-				"id": {
-					"anyOf": [{
-						"maxLength": 64,
-						"minLength": 1,
-						"pattern": "^[a-zA-Z0-9-_.]+$",
-						"type": "string"
-					}, {
-						"minimum": 1,
-						"type": "integer"
-					}]
-				},
-				"labels": {
-					"description": "key/value pairs to specify attributes",
-					"maxProperties": 16,
-					"patternProperties": {
-						".*": {
-							"description": "value of label",
-							"maxLength": 64,
-							"minLength": 1,
-							"pattern": "^[a-zA-Z0-9-_.]+$",
-							"type": "string"
-						}
-					},
-					"type": "object"
-				},
-				"plugins": {
-					"type": "object"
-				},
-				"update_time": {
-					"type": "integer"
-				},
-				"username": {
-					"maxLength": 32,
-					"minLength": 1,
-					"pattern": "^[a-zA-Z0-9_]+$",
-					"type": "string"
-				}
-			},
-			"required": ["username"],
-			"type": "object"
-		},
-		"global_rule": {
-			"additionalProperties": false,
-			"properties": {
-				"id": {
-					"anyOf": [{
-						"maxLength": 64,
-						"minLength": 1,
-						"pattern": "^[a-zA-Z0-9-_.]+$",
-						"type": "string"
-					}, {
-						"minimum": 1,
-						"type": "integer"
-					}]
-				},
-				"plugins": {
-					"type": "object"
-				}
-			},
-			"required": ["plugins"],
-			"type": "object"
-		},
-		"plugins": {
-			"items": {
-				"properties": {
-					"additionalProperties": false,
-					"name": {
-						"minLength": 1,
-						"type": "string"
-					},
-					"stream": {
-						"type": "boolean"
-					}
-				},
-				"required": ["name"],
-				"type": "object"
-			},
-			"type": "array"
-		},
-		"proto": {
-			"additionalProperties": false,
-			"properties": {
-				"content": {
-					"maxLength": 1048576,
-					"minLength": 1,
-					"type": "string"
-				}
-			},
-			"required": ["content"],
-			"type": "object"
-		},
-		"route": {
-			"additionalProperties": false,
-			"allOf": [{
-				"oneOf": [{
-					"required": ["uri"]
-				}, {
-					"required": ["uris"]
-				}]
-			}, {
-				"oneOf": [{
-					"not": {
-						"anyOf": [{
-							"required": ["host"]
-						}, {
-							"required": ["hosts"]
-						}]
-					}
-				}, {
-					"required": ["host"]
-				}, {
-					"required": ["hosts"]
-				}]
-			}, {
-				"oneOf": [{
-					"not": {
-						"anyOf": [{
-							"required": ["remote_addr"]
-						}, {
-							"required": ["remote_addrs"]
-						}]
-					}
-				}, {
-					"required": ["remote_addr"]
-				}, {
-					"required": ["remote_addrs"]
-				}]
-			}],
-			"anyOf": [{
-				"required": ["plugins", "uri"]
-			}, {
-				"required": ["upstream", "uri"]
-			}, {
-				"required": ["upstream_id", "uri"]
-			}, {
-				"required": ["service_id", "uri"]
-			}, {
-				"required": ["plugins", "uris"]
-			}, {
-				"required": ["upstream", "uris"]
-			}, {
-				"required": ["upstream_id", "uris"]
-			}, {
-				"required": ["service_id", "uris"]
-			}, {
-				"required": ["script", "uri"]
-			}, {
-				"required": ["script", "uris"]
-			}],
-			"not": {
-				"anyOf": [{
-					"required": ["plugins", "script"]
-				}]
-			},
-			"properties": {
-				"create_time": {
-					"type": "integer"
-				},
-				"desc": {
-					"maxLength": 256,
-					"type": "string"
-				},
-				"enable_websocket": {
-					"description": "enable websocket for request",
-					"type": "boolean"
-				},
-				"filter_func": {
-					"minLength": 10,
-					"pattern": "^function",
-					"type": "string"
-				},
-				"host": {
-					"pattern": "^\\*?[0-9a-zA-Z-._]+$",
-					"type": "string"
-				},
-				"hosts": {
-					"items": {
-						"pattern": "^\\*?[0-9a-zA-Z-._]+$",
-						"type": "string"
-					},
-					"minItems": 1,
-					"type": "array",
-					"uniqueItems": true
-				},
-				"id": {
-					"anyOf": [{
-						"maxLength": 64,
-						"minLength": 1,
-						"pattern": "^[a-zA-Z0-9-_.]+$",
-						"type": "string"
-					}, {
-						"minimum": 1,
-						"type": "integer"
-					}]
-				},
-				"labels": {
-					"description": "key/value pairs to specify attributes",
-					"maxProperties": 16,
-					"patternProperties": {
-						".*": {
-							"description": "value of label",
-							"maxLength": 64,
-							"minLength": 1,
-							"pattern": "^[a-zA-Z0-9-_.]+$",
-							"type": "string"
-						}
-					},
-					"type": "object"
-				},
-				"methods": {
-					"items": {
-						"description": "HTTP method",
-						"enum": ["CONNECT", "DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT", "TRACE"],
-						"type": "string"
-					},
-					"type": "array",
-					"uniqueItems": true
-				},
-				"name": {
-					"maxLength": 100,
-					"minLength": 1,
-					"type": "string"
-				},
-				"plugins": {
-					"type": "object"
-				},
-				"priority": {
-					"default": 0,
-					"type": "integer"
-				},
-				"remote_addr": {
-					"anyOf": [{
-						"format": "ipv4",
-						"title": "IPv4",
-						"type": "string"
-					}, {
-						"pattern": "^([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])/([12]?[0-9]|3[0-2])$",
-						"title": "IPv4/CIDR",
-						"type": "string"
-					}, {
-						"format": "ipv6",
-						"title": "IPv6",
-						"type": "string"
-					}, {
-						"pattern": "^([a-fA-F0-9]{0,4}:){1,8}(:[a-fA-F0-9]{0,4}){0,8}([a-fA-F0-9]{0,4})?/[0-9]{1,3}$",
-						"title": "IPv6/CIDR",
-						"type": "string"
-					}],
-					"description": "client IP",
-					"type": "string"
-				},
-				"remote_addrs": {
-					"items": {
-						"anyOf": [{
-							"format": "ipv4",
-							"title": "IPv4",
-							"type": "string"
-						}, {
-							"pattern": "^([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])/([12]?[0-9]|3[0-2])$",
-							"title": "IPv4/CIDR",
-							"type": "string"
-						}, {
-							"format": "ipv6",
-							"title": "IPv6",
-							"type": "string"
-						}, {
-							"pattern": "^([a-fA-F0-9]{0,4}:){1,8}(:[a-fA-F0-9]{0,4}){0,8}([a-fA-F0-9]{0,4})?/[0-9]{1,3}$",
-							"title": "IPv6/CIDR",
-							"type": "string"
-						}],
-						"description": "client IP",
-						"type": "string"
-					},
-					"minItems": 1,
-					"type": "array",
-					"uniqueItems": true
-				},
-				"script": {
-					"maxLength": 102400,
-					"minLength": 10,
-					"type": "string"
-				},
-				"script_id": {
-					"anyOf": [{
-						"maxLength": 64,
-						"minLength": 1,
-						"pattern": "^[a-zA-Z0-9-_.]+$",
-						"type": "string"
-					}, {
-						"minimum": 1,
-						"type": "integer"
-					}]
-				},
-				"service_id": {
-					"anyOf": [{
-						"maxLength": 64,
-						"minLength": 1,
-						"pattern": "^[a-zA-Z0-9-_.]+$",
-						"type": "string"
-					}, {
-						"minimum": 1,
-						"type": "integer"
-					}]
-				},
-				"service_protocol": {
-					"enum": ["grpc", "http"]
-				},
-				"status": {
-					"default": 1,
-					"description": "route status, 1 to enable, 0 to disable",
-					"enum": [0, 1],
-					"type": "integer"
-				},
-				"update_time": {
-					"type": "integer"
-				},
-				"upstream": {
-					"additionalProperties": false,
-					"anyOf": [{
-						"required": ["nodes", "type"]
-					}, {
-						"required": ["service_name", "type"]
-					}],
-					"properties": {
-						"checks": {
-							"additionalProperties": false,
-							"anyOf": [{
-								"required": ["active"]
-							}, {
-								"required": ["active", "passive"]
-							}],
-							"properties": {
-								"active": {
-									"properties": {
-										"concurrency": {
-											"default": 10,
-											"type": "integer"
-										},
-										"healthy": {
-											"properties": {
-												"http_statuses": {
-													"default": [200, 302],
-													"items": {
-														"maximum": 599,
-														"minimum": 200,
-														"type": "integer"
-													},
-													"minItems": 1,
-													"type": "array",
-													"uniqueItems": true
-												},
-												"interval": {
-													"default": 0,
-													"minimum": 1,
-													"type": "integer"
-												},
-												"successes": {
-													"default": 2,
-													"maximum": 254,
-													"minimum": 1,
-													"type": "integer"
-												}
-											},
-											"type": "object"
-										},
-										"host": {
-											"pattern": "^\\*?[0-9a-zA-Z-._]+$",
-											"type": "string"
-										},
-										"http_path": {
-											"default": "/",
-											"type": "string"
-										},
-										"https_verify_certificate": {
-											"default": true,
-											"type": "boolean"
-										},
-										"port": {
-											"maximum": 65535,
-											"minimum": 1,
-											"type": "integer"
-										},
-										"req_headers": {
-											"items": {
-												"type": "string",
-												"uniqueItems": true
-											},
-											"minItems": 1,
-											"type": "array"
-										},
-										"timeout": {
-											"default": 1,
-											"type": "number"
-										},
-										"type": {
-											"default": "http",
-											"enum": ["http", "https", "tcp"],
-											"type": "string"
-										},
-										"unhealthy": {
-											"properties": {
-												"http_failures": {
-													"default": 5,
-													"maximum": 254,
-													"minimum": 1,
-													"type": "integer"
-												},
-												"http_statuses": {
-													"default": [404, 429, 500, 501, 502, 503, 504, 505],
-													"items": {
-														"maximum": 599,
-														"minimum": 200,
-														"type": "integer"
-													},
-													"minItems": 1,
-													"type": "array",
-													"uniqueItems": true
-												},
-												"interval": {
-													"default": 0,
-													"minimum": 1,
-													"type": "integer"
-												},
-												"tcp_failures": {
-													"default": 2,
-													"maximum": 254,
-													"minimum": 1,
-													"type": "integer"
-												},
-												"timeouts": {
-													"default": 3,
-													"maximum": 254,
-													"minimum": 1,
-													"type": "integer"
-												}
-											},
-											"type": "object"
-										}
-									},
-									"type": "object"
-								},
-								"passive": {
-									"properties": {
-										"healthy": {
-											"properties": {
-												"http_statuses": {
-													"default": [200, 201, 202, 203, 204, 205, 206, 207, 208, 226, 300, 301, 302, 303, 304, 305, 306, 307, 308],
-													"items": {
-														"maximum": 599,
-														"minimum": 200,
-														"type": "integer"
-													},
-													"minItems": 1,
-													"type": "array",
-													"uniqueItems": true
-												},
-												"successes": {
-													"default": 5,
-													"maximum": 254,
-													"minimum": 1,
-													"type": "integer"
-												}
-											},
-											"type": "object"
-										},
-										"type": {
-											"default": "http",
-											"enum": ["http", "https", "tcp"],
-											"type": "string"
-										},
-										"unhealthy": {
-											"properties": {
-												"http_failures": {
-													"default": 5,
-													"maximum": 254,
-													"minimum": 1,
-													"type": "integer"
-												},
-												"http_statuses": {
-													"default": [429, 500, 503],
-													"items": {
-														"maximum": 599,
-														"minimum": 200,
-														"type": "integer"
-													},
-													"minItems": 1,
-													"type": "array",
-													"uniqueItems": true
-												},
-												"tcp_failures": {
-													"default": 2,
-													"maximum": 254,
-													"minimum": 1,
-													"type": "integer"
-												},
-												"timeouts": {
-													"default": 7,
-													"maximum": 254,
-													"minimum": 1,
-													"type": "integer"
-												}
-											},
-											"type": "object"
-										}
-									},
-									"type": "object"
-								}
-							},
-							"type": "object"
-						},
-						"create_time": {
-							"type": "integer"
-						},
-						"desc": {
-							"maxLength": 256,
-							"type": "string"
-						},
-						"discovery_type": {
-							"description": "discovery type",
-							"type": "string"
-						},
-						"enable_websocket": {
-							"description": "enable websocket for request",
-							"type": "boolean"
-						},
-						"hash_on": {
-							"default": "vars",
-							"enum": ["consumer", "cookie", "header", "vars"],
-							"type": "string"
-						},
-						"id": {
-							"anyOf": [{
-								"maxLength": 64,
-								"minLength": 1,
-								"pattern": "^[a-zA-Z0-9-_.]+$",
-								"type": "string"
-							}, {
-								"minimum": 1,
-								"type": "integer"
-							}]
-						},
-						"key": {
-							"description": "the key of chash for dynamic load balancing",
-							"type": "string"
-						},
-						"labels": {
-							"description": "key/value pairs to specify attributes",
-							"maxProperties": 16,
-							"patternProperties": {
-								".*": {
-									"description": "value of label",
-									"maxLength": 64,
-									"minLength": 1,
-									"pattern": "^[a-zA-Z0-9-_.]+$",
-									"type": "string"
-								}
-							},
-							"type": "object"
-						},
-						"name": {
-							"maxLength": 100,
-							"minLength": 1,
-							"type": "string"
-						},
-						"nodes": {
-							"anyOf": [{
-								"minProperties": 1,
-								"patternProperties": {
-									".*": {
-										"description": "weight of node",
-										"minimum": 0,
-										"type": "integer"
-									}
-								},
-								"type": "object"
-							}, {
-								"items": {
-									"properties": {
-										"host": {
-											"pattern": "^\\*?[0-9a-zA-Z-._]+$",
-											"type": "string"
-										},
-										"metadata": {
-											"description": "metadata of node",
-											"type": "object"
-										},
-										"port": {
-											"description": "port of node",
-											"minimum": 1,
-											"type": "integer"
-										},
-										"weight": {
-											"description": "weight of node",
-											"minimum": 0,
-											"type": "integer"
-										}
-									},
-									"required": ["host", "port", "weight"],
-									"type": "object"
-								},
-								"type": "array"
-							}]
-						},
-						"pass_host": {
-							"default": "pass",
-							"description": "mod of host passing",
-							"enum": ["node", "pass", "rewrite"],
-							"type": "string"
-						},
-						"retries": {
-							"minimum": 0,
-							"type": "integer"
-						},
-						"service_name": {
-							"maxLength": 100,
-							"minLength": 1,
-							"type": "string"
-						},
-						"timeout": {
-							"properties": {
-								"connect": {
-									"minimum": 0,
-									"type": "number"
-								},
-								"read": {
-									"minimum": 0,
-									"type": "number"
-								},
-								"send": {
-									"minimum": 0,
-									"type": "number"
-								}
-							},
-							"required": ["connect", "read", "send"],
-							"type": "object"
-						},
-						"type": {
-							"description": "algorithms of load balancing",
-							"enum": ["chash", "ewma", "roundrobin"],
-							"type": "string"
-						},
-						"update_time": {
-							"type": "integer"
-						},
-						"upstream_host": {
-							"pattern": "^\\*?[0-9a-zA-Z-._]+$",
-							"type": "string"
-						}
-					},
-					"type": "object"
-				},
-				"upstream_id": {
-					"anyOf": [{
-						"maxLength": 64,
-						"minLength": 1,
-						"pattern": "^[a-zA-Z0-9-_.]+$",
-						"type": "string"
-					}, {
-						"minimum": 1,
-						"type": "integer"
-					}]
-				},
-				"uri": {
-					"maxLength": 4096,
-					"minLength": 1,
-					"type": "string"
-				},
-				"uris": {
-					"items": {
-						"description": "HTTP uri",
-						"type": "string"
-					},
-					"minItems": 1,
-					"type": "array",
-					"uniqueItems": true
-				},
-				"vars": {
-					"items": {
-						"description": "Nginx builtin variable name and value",
-						"maxItems": 4,
-						"minItems": 2,
-						"type": "array"
-					},
-					"type": "array"
-				}
-			},
-			"type": "object"
-		},
-		"service": {
-			"additionalProperties": false,
-			"properties": {
-				"create_time": {
-					"type": "integer"
-				},
-				"desc": {
-					"maxLength": 256,
-					"type": "string"
-				},
-				"enable_websocket": {
-					"description": "enable websocket for request",
-					"type": "boolean"
-				},
-				"id": {
-					"anyOf": [{
-						"maxLength": 64,
-						"minLength": 1,
-						"pattern": "^[a-zA-Z0-9-_.]+$",
-						"type": "string"
-					}, {
-						"minimum": 1,
-						"type": "integer"
-					}]
-				},
-				"labels": {
-					"description": "key/value pairs to specify attributes",
-					"maxProperties": 16,
-					"patternProperties": {
-						".*": {
-							"description": "value of label",
-							"maxLength": 64,
-							"minLength": 1,
-							"pattern": "^[a-zA-Z0-9-_.]+$",
-							"type": "string"
-						}
-					},
-					"type": "object"
-				},
-				"name": {
-					"maxLength": 100,
-					"minLength": 1,
-					"type": "string"
-				},
-				"plugins": {
-					"type": "object"
-				},
-				"script": {
-					"maxLength": 102400,
-					"minLength": 10,
-					"type": "string"
-				},
-				"update_time": {
-					"type": "integer"
-				},
-				"upstream": {
-					"additionalProperties": false,
-					"anyOf": [{
-						"required": ["nodes", "type"]
-					}, {
-						"required": ["service_name", "type"]
-					}],
-					"properties": {
-						"checks": {
-							"additionalProperties": false,
-							"anyOf": [{
-								"required": ["active"]
-							}, {
-								"required": ["active", "passive"]
-							}],
-							"properties": {
-								"active": {
-									"properties": {
-										"concurrency": {
-											"default": 10,
-											"type": "integer"
-										},
-										"healthy": {
-											"properties": {
-												"http_statuses": {
-													"default": [200, 302],
-													"items": {
-														"maximum": 599,
-														"minimum": 200,
-														"type": "integer"
-													},
-													"minItems": 1,
-													"type": "array",
-													"uniqueItems": true
-												},
-												"interval": {
-													"default": 0,
-													"minimum": 1,
-													"type": "integer"
-												},
-												"successes": {
-													"default": 2,
-													"maximum": 254,
-													"minimum": 1,
-													"type": "integer"
-												}
-											},
-											"type": "object"
-										},
-										"host": {
-											"pattern": "^\\*?[0-9a-zA-Z-._]+$",
-											"type": "string"
-										},
-										"http_path": {
-											"default": "/",
-											"type": "string"
-										},
-										"https_verify_certificate": {
-											"default": true,
-											"type": "boolean"
-										},
-										"port": {
-											"maximum": 65535,
-											"minimum": 1,
-											"type": "integer"
-										},
-										"req_headers": {
-											"items": {
-												"type": "string",
-												"uniqueItems": true
-											},
-											"minItems": 1,
-											"type": "array"
-										},
-										"timeout": {
-											"default": 1,
-											"type": "number"
-										},
-										"type": {
-											"default": "http",
-											"enum": ["http", "https", "tcp"],
-											"type": "string"
-										},
-										"unhealthy": {
-											"properties": {
-												"http_failures": {
-													"default": 5,
-													"maximum": 254,
-													"minimum": 1,
-													"type": "integer"
-												},
-												"http_statuses": {
-													"default": [404, 429, 500, 501, 502, 503, 504, 505],
-													"items": {
-														"maximum": 599,
-														"minimum": 200,
-														"type": "integer"
-													},
-													"minItems": 1,
-													"type": "array",
-													"uniqueItems": true
-												},
-												"interval": {
-													"default": 0,
-													"minimum": 1,
-													"type": "integer"
-												},
-												"tcp_failures": {
-													"default": 2,
-													"maximum": 254,
-													"minimum": 1,
-													"type": "integer"
-												},
-												"timeouts": {
-													"default": 3,
-													"maximum": 254,
-													"minimum": 1,
-													"type": "integer"
-												}
-											},
-											"type": "object"
-										}
-									},
-									"type": "object"
-								},
-								"passive": {
-									"properties": {
-										"healthy": {
-											"properties": {
-												"http_statuses": {
-													"default": [200, 201, 202, 203, 204, 205, 206, 207, 208, 226, 300, 301, 302, 303, 304, 305, 306, 307, 308],
-													"items": {
-														"maximum": 599,
-														"minimum": 200,
-														"type": "integer"
-													},
-													"minItems": 1,
-													"type": "array",
-													"uniqueItems": true
-												},
-												"successes": {
-													"default": 5,
-													"maximum": 254,
-													"minimum": 1,
-													"type": "integer"
-												}
-											},
-											"type": "object"
-										},
-										"type": {
-											"default": "http",
-											"enum": ["http", "https", "tcp"],
-											"type": "string"
-										},
-										"unhealthy": {
-											"properties": {
-												"http_failures": {
-													"default": 5,
-													"maximum": 254,
-													"minimum": 1,
-													"type": "integer"
-												},
-												"http_statuses": {
-													"default": [429, 500, 503],
-													"items": {
-														"maximum": 599,
-														"minimum": 200,
-														"type": "integer"
-													},
-													"minItems": 1,
-													"type": "array",
-													"uniqueItems": true
-												},
-												"tcp_failures": {
-													"default": 2,
-													"maximum": 254,
-													"minimum": 1,
-													"type": "integer"
-												},
-												"timeouts": {
-													"default": 7,
-													"maximum": 254,
-													"minimum": 1,
-													"type": "integer"
-												}
-											},
-											"type": "object"
-										}
-									},
-									"type": "object"
-								}
-							},
-							"type": "object"
-						},
-						"create_time": {
-							"type": "integer"
-						},
-						"desc": {
-							"maxLength": 256,
-							"type": "string"
-						},
-						"discovery_type": {
-							"description": "discovery type",
-							"type": "string"
-						},
-						"enable_websocket": {
-							"description": "enable websocket for request",
-							"type": "boolean"
-						},
-						"hash_on": {
-							"default": "vars",
-							"enum": ["consumer", "cookie", "header", "vars"],
-							"type": "string"
-						},
-						"id": {
-							"anyOf": [{
-								"maxLength": 64,
-								"minLength": 1,
-								"pattern": "^[a-zA-Z0-9-_.]+$",
-								"type": "string"
-							}, {
-								"minimum": 1,
-								"type": "integer"
-							}]
-						},
-						"key": {
-							"description": "the key of chash for dynamic load balancing",
-							"type": "string"
-						},
-						"labels": {
-							"description": "key/value pairs to specify attributes",
-							"maxProperties": 16,
-							"patternProperties": {
-								".*": {
-									"description": "value of label",
-									"maxLength": 64,
-									"minLength": 1,
-									"pattern": "^[a-zA-Z0-9-_.]+$",
-									"type": "string"
-								}
-							},
-							"type": "object"
-						},
-						"name": {
-							"maxLength": 100,
-							"minLength": 1,
-							"type": "string"
-						},
-						"nodes": {
-							"anyOf": [{
-								"minProperties": 1,
-								"patternProperties": {
-									".*": {
-										"description": "weight of node",
-										"minimum": 0,
-										"type": "integer"
-									}
-								},
-								"type": "object"
-							}, {
-								"items": {
-									"properties": {
-										"host": {
-											"pattern": "^\\*?[0-9a-zA-Z-._]+$",
-											"type": "string"
-										},
-										"metadata": {
-											"description": "metadata of node",
-											"type": "object"
-										},
-										"port": {
-											"description": "port of node",
-											"minimum": 1,
-											"type": "integer"
-										},
-										"weight": {
-											"description": "weight of node",
-											"minimum": 0,
-											"type": "integer"
-										}
-									},
-									"required": ["host", "port", "weight"],
-									"type": "object"
-								},
-								"type": "array"
-							}]
-						},
-						"pass_host": {
-							"default": "pass",
-							"description": "mod of host passing",
-							"enum": ["node", "pass", "rewrite"],
-							"type": "string"
-						},
-						"retries": {
-							"minimum": 0,
-							"type": "integer"
-						},
-						"service_name": {
-							"maxLength": 100,
-							"minLength": 1,
-							"type": "string"
-						},
-						"timeout": {
-							"properties": {
-								"connect": {
-									"minimum": 0,
-									"type": "number"
-								},
-								"read": {
-									"minimum": 0,
-									"type": "number"
-								},
-								"send": {
-									"minimum": 0,
-									"type": "number"
-								}
-							},
-							"required": ["connect", "read", "send"],
-							"type": "object"
-						},
-						"type": {
-							"description": "algorithms of load balancing",
-							"enum": ["chash", "ewma", "roundrobin"],
-							"type": "string"
-						},
-						"update_time": {
-							"type": "integer"
-						},
-						"upstream_host": {
-							"pattern": "^\\*?[0-9a-zA-Z-._]+$",
-							"type": "string"
-						}
-					},
-					"type": "object"
-				},
-				"upstream_id": {
-					"anyOf": [{
-						"maxLength": 64,
-						"minLength": 1,
-						"pattern": "^[a-zA-Z0-9-_.]+$",
-						"type": "string"
-					}, {
-						"minimum": 1,
-						"type": "integer"
-					}]
-				}
-			},
-			"type": "object"
-		},
-		"ssl": {
-			"additionalProperties": false,
-			"oneOf": [{
-				"required": ["cert", "key", "sni"]
-			}, {
-				"required": ["cert", "key", "snis"]
-			}],
-			"properties": {
-				"cert": {
-					"maxLength": 65536,
-					"minLength": 128,
-					"type": "string"
-				},
-				"certs": {
-					"items": {
-						"maxLength": 65536,
-						"minLength": 128,
-						"type": "string"
-					},
-					"type": "array"
-				},
-				"create_time": {
-					"type": "integer"
-				},
-				"exptime": {
-					"minimum": 1588262400,
-					"type": "integer"
-				},
-				"id": {
-					"anyOf": [{
-						"maxLength": 64,
-						"minLength": 1,
-						"pattern": "^[a-zA-Z0-9-_.]+$",
-						"type": "string"
-					}, {
-						"minimum": 1,
-						"type": "integer"
-					}]
-				},
-				"key": {
-					"maxLength": 65536,
-					"minLength": 128,
-					"type": "string"
-				},
-				"keys": {
-					"items": {
-						"maxLength": 65536,
-						"minLength": 128,
-						"type": "string"
-					},
-					"type": "array"
-				},
-				"labels": {
-					"description": "key/value pairs to specify attributes",
-					"maxProperties": 16,
-					"patternProperties": {
-						".*": {
-							"description": "value of label",
-							"maxLength": 64,
-							"minLength": 1,
-							"pattern": "^[a-zA-Z0-9-_.]+$",
-							"type": "string"
-						}
-					},
-					"type": "object"
-				},
-				"sni": {
-					"pattern": "^\\*?[0-9a-zA-Z-.]+$",
-					"type": "string"
-				},
-				"snis": {
-					"items": {
-						"pattern": "^\\*?[0-9a-zA-Z-.]+$",
-						"type": "string"
-					},
-					"minItems": 1,
-					"type": "array"
-				},
-				"status": {
-					"default": 1,
-					"description": "ssl status, 1 to enable, 0 to disable",
-					"enum": [0, 1],
-					"type": "integer"
-				},
-				"update_time": {
-					"type": "integer"
-				},
-				"validity_end": {
-					"type": "integer"
-				},
-				"validity_start": {
-					"type": "integer"
-				}
-			},
-			"type": "object"
-		},
-		"stream_route": {
-			"properties": {
-				"id": {
-					"anyOf": [{
-						"maxLength": 64,
-						"minLength": 1,
-						"pattern": "^[a-zA-Z0-9-_.]+$",
-						"type": "string"
-					}, {
-						"minimum": 1,
-						"type": "integer"
-					}]
-				},
-				"plugins": {
-					"type": "object"
-				},
-				"remote_addr": {
-					"anyOf": [{
-						"format": "ipv4",
-						"title": "IPv4",
-						"type": "string"
-					}, {
-						"pattern": "^([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])/([12]?[0-9]|3[0-2])$",
-						"title": "IPv4/CIDR",
-						"type": "string"
-					}, {
-						"format": "ipv6",
-						"title": "IPv6",
-						"type": "string"
-					}, {
-						"pattern": "^([a-fA-F0-9]{0,4}:){1,8}(:[a-fA-F0-9]{0,4}){0,8}([a-fA-F0-9]{0,4})?/[0-9]{1,3}$",
-						"title": "IPv6/CIDR",
-						"type": "string"
-					}],
-					"description": "client IP",
-					"type": "string"
-				},
-				"server_addr": {
-					"anyOf": [{
-						"format": "ipv4",
-						"title": "IPv4",
-						"type": "string"
-					}, {
-						"pattern": "^([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])/([12]?[0-9]|3[0-2])$",
-						"title": "IPv4/CIDR",
-						"type": "string"
-					}, {
-						"format": "ipv6",
-						"title": "IPv6",
-						"type": "string"
-					}, {
-						"pattern": "^([a-fA-F0-9]{0,4}:){1,8}(:[a-fA-F0-9]{0,4}){0,8}([a-fA-F0-9]{0,4})?/[0-9]{1,3}$",
-						"title": "IPv6/CIDR",
-						"type": "string"
-					}],
-					"description": "server IP",
-					"type": "string"
-				},
-				"server_port": {
-					"description": "server port",
-					"type": "integer"
-				},
-				"upstream": {
-					"additionalProperties": false,
-					"anyOf": [{
-						"required": ["nodes", "type"]
-					}, {
-						"required": ["service_name", "type"]
-					}],
-					"properties": {
-						"checks": {
-							"additionalProperties": false,
-							"anyOf": [{
-								"required": ["active"]
-							}, {
-								"required": ["active", "passive"]
-							}],
-							"properties": {
-								"active": {
-									"properties": {
-										"concurrency": {
-											"default": 10,
-											"type": "integer"
-										},
-										"healthy": {
-											"properties": {
-												"http_statuses": {
-													"default": [200, 302],
-													"items": {
-														"maximum": 599,
-														"minimum": 200,
-														"type": "integer"
-													},
-													"minItems": 1,
-													"type": "array",
-													"uniqueItems": true
-												},
-												"interval": {
-													"default": 0,
-													"minimum": 1,
-													"type": "integer"
-												},
-												"successes": {
-													"default": 2,
-													"maximum": 254,
-													"minimum": 1,
-													"type": "integer"
-												}
-											},
-											"type": "object"
-										},
-										"host": {
-											"pattern": "^\\*?[0-9a-zA-Z-._]+$",
-											"type": "string"
-										},
-										"http_path": {
-											"default": "/",
-											"type": "string"
-										},
-										"https_verify_certificate": {
-											"default": true,
-											"type": "boolean"
-										},
-										"port": {
-											"maximum": 65535,
-											"minimum": 1,
-											"type": "integer"
-										},
-										"req_headers": {
-											"items": {
-												"type": "string",
-												"uniqueItems": true
-											},
-											"minItems": 1,
-											"type": "array"
-										},
-										"timeout": {
-											"default": 1,
-											"type": "number"
-										},
-										"type": {
-											"default": "http",
-											"enum": ["http", "https", "tcp"],
-											"type": "string"
-										},
-										"unhealthy": {
-											"properties": {
-												"http_failures": {
-													"default": 5,
-													"maximum": 254,
-													"minimum": 1,
-													"type": "integer"
-												},
-												"http_statuses": {
-													"default": [404, 429, 500, 501, 502, 503, 504, 505],
-													"items": {
-														"maximum": 599,
-														"minimum": 200,
-														"type": "integer"
-													},
-													"minItems": 1,
-													"type": "array",
-													"uniqueItems": true
-												},
-												"interval": {
-													"default": 0,
-													"minimum": 1,
-													"type": "integer"
-												},
-												"tcp_failures": {
-													"default": 2,
-													"maximum": 254,
-													"minimum": 1,
-													"type": "integer"
-												},
-												"timeouts": {
-													"default": 3,
-													"maximum": 254,
-													"minimum": 1,
-													"type": "integer"
-												}
-											},
-											"type": "object"
-										}
-									},
-									"type": "object"
-								},
-								"passive": {
-									"properties": {
-										"healthy": {
-											"properties": {
-												"http_statuses": {
-													"default": [200, 201, 202, 203, 204, 205, 206, 207, 208, 226, 300, 301, 302, 303, 304, 305, 306, 307, 308],
-													"items": {
-														"maximum": 599,
-														"minimum": 200,
-														"type": "integer"
-													},
-													"minItems": 1,
-													"type": "array",
-													"uniqueItems": true
-												},
-												"successes": {
-													"default": 5,
-													"maximum": 254,
-													"minimum": 1,
-													"type": "integer"
-												}
-											},
-											"type": "object"
-										},
-										"type": {
-											"default": "http",
-											"enum": ["http", "https", "tcp"],
-											"type": "string"
-										},
-										"unhealthy": {
-											"properties": {
-												"http_failures": {
-													"default": 5,
-													"maximum": 254,
-													"minimum": 1,
-													"type": "integer"
-												},
-												"http_statuses": {
-													"default": [429, 500, 503],
-													"items": {
-														"maximum": 599,
-														"minimum": 200,
-														"type": "integer"
-													},
-													"minItems": 1,
-													"type": "array",
-													"uniqueItems": true
-												},
-												"tcp_failures": {
-													"default": 2,
-													"maximum": 254,
-													"minimum": 1,
-													"type": "integer"
-												},
-												"timeouts": {
-													"default": 7,
-													"maximum": 254,
-													"minimum": 1,
-													"type": "integer"
-												}
-											},
-											"type": "object"
-										}
-									},
-									"type": "object"
-								}
-							},
-							"type": "object"
-						},
-						"create_time": {
-							"type": "integer"
-						},
-						"desc": {
-							"maxLength": 256,
-							"type": "string"
-						},
-						"discovery_type": {
-							"description": "discovery type",
-							"type": "string"
-						},
-						"enable_websocket": {
-							"description": "enable websocket for request",
-							"type": "boolean"
-						},
-						"hash_on": {
-							"default": "vars",
-							"enum": ["consumer", "cookie", "header", "vars"],
-							"type": "string"
-						},
-						"id": {
-							"anyOf": [{
-								"maxLength": 64,
-								"minLength": 1,
-								"pattern": "^[a-zA-Z0-9-_.]+$",
-								"type": "string"
-							}, {
-								"minimum": 1,
-								"type": "integer"
-							}]
-						},
-						"key": {
-							"description": "the key of chash for dynamic load balancing",
-							"type": "string"
-						},
-						"labels": {
-							"description": "key/value pairs to specify attributes",
-							"maxProperties": 16,
-							"patternProperties": {
-								".*": {
-									"description": "value of label",
-									"maxLength": 64,
-									"minLength": 1,
-									"pattern": "^[a-zA-Z0-9-_.]+$",
-									"type": "string"
-								}
-							},
-							"type": "object"
-						},
-						"name": {
-							"maxLength": 100,
-							"minLength": 1,
-							"type": "string"
-						},
-						"nodes": {
-							"anyOf": [{
-								"minProperties": 1,
-								"patternProperties": {
-									".*": {
-										"description": "weight of node",
-										"minimum": 0,
-										"type": "integer"
-									}
-								},
-								"type": "object"
-							}, {
-								"items": {
-									"properties": {
-										"host": {
-											"pattern": "^\\*?[0-9a-zA-Z-._]+$",
-											"type": "string"
-										},
-										"metadata": {
-											"description": "metadata of node",
-											"type": "object"
-										},
-										"port": {
-											"description": "port of node",
-											"minimum": 1,
-											"type": "integer"
-										},
-										"weight": {
-											"description": "weight of node",
-											"minimum": 0,
-											"type": "integer"
-										}
-									},
-									"required": ["host", "port", "weight"],
-									"type": "object"
-								},
-								"type": "array"
-							}]
-						},
-						"pass_host": {
-							"default": "pass",
-							"description": "mod of host passing",
-							"enum": ["node", "pass", "rewrite"],
-							"type": "string"
-						},
-						"retries": {
-							"minimum": 0,
-							"type": "integer"
-						},
-						"service_name": {
-							"maxLength": 100,
-							"minLength": 1,
-							"type": "string"
-						},
-						"timeout": {
-							"properties": {
-								"connect": {
-									"minimum": 0,
-									"type": "number"
-								},
-								"read": {
-									"minimum": 0,
-									"type": "number"
-								},
-								"send": {
-									"minimum": 0,
-									"type": "number"
-								}
-							},
-							"required": ["connect", "read", "send"],
-							"type": "object"
-						},
-						"type": {
-							"description": "algorithms of load balancing",
-							"enum": ["chash", "ewma", "roundrobin"],
-							"type": "string"
-						},
-						"update_time": {
-							"type": "integer"
-						},
-						"upstream_host": {
-							"pattern": "^\\*?[0-9a-zA-Z-._]+$",
-							"type": "string"
-						}
-					},
-					"type": "object"
-				},
-				"upstream_id": {
-					"anyOf": [{
-						"maxLength": 64,
-						"minLength": 1,
-						"pattern": "^[a-zA-Z0-9-_.]+$",
-						"type": "string"
-					}, {
-						"minimum": 1,
-						"type": "integer"
-					}]
-				}
-			},
-			"type": "object"
-		},
-		"upstream": {
-			"additionalProperties": false,
-			"anyOf": [{
-				"required": ["nodes", "type"]
-			}, {
-				"required": ["service_name", "type"]
-			}],
-			"properties": {
-				"checks": {
-					"additionalProperties": false,
-					"anyOf": [{
-						"required": ["active"]
-					}, {
-						"required": ["active", "passive"]
-					}],
-					"properties": {
-						"active": {
-							"properties": {
-								"concurrency": {
-									"default": 10,
-									"type": "integer"
-								},
-								"healthy": {
-									"properties": {
-										"http_statuses": {
-											"default": [200, 302],
-											"items": {
-												"maximum": 599,
-												"minimum": 200,
-												"type": "integer"
-											},
-											"minItems": 1,
-											"type": "array",
-											"uniqueItems": true
-										},
-										"interval": {
-											"default": 0,
-											"minimum": 1,
-											"type": "integer"
-										},
-										"successes": {
-											"default": 2,
-											"maximum": 254,
-											"minimum": 1,
-											"type": "integer"
-										}
-									},
-									"type": "object"
-								},
-								"host": {
-									"pattern": "^\\*?[0-9a-zA-Z-._]+$",
-									"type": "string"
-								},
-								"http_path": {
-									"default": "/",
-									"type": "string"
-								},
-								"https_verify_certificate": {
-									"default": true,
-									"type": "boolean"
-								},
-								"port": {
-									"maximum": 65535,
-									"minimum": 1,
-									"type": "integer"
-								},
-								"req_headers": {
-									"items": {
-										"type": "string",
-										"uniqueItems": true
-									},
-									"minItems": 1,
-									"type": "array"
-								},
-								"timeout": {
-									"default": 1,
-									"type": "number"
-								},
-								"type": {
-									"default": "http",
-									"enum": ["http", "https", "tcp"],
-									"type": "string"
-								},
-								"unhealthy": {
-									"properties": {
-										"http_failures": {
-											"default": 5,
-											"maximum": 254,
-											"minimum": 1,
-											"type": "integer"
-										},
-										"http_statuses": {
-											"default": [404, 429, 500, 501, 502, 503, 504, 505],
-											"items": {
-												"maximum": 599,
-												"minimum": 200,
-												"type": "integer"
-											},
-											"minItems": 1,
-											"type": "array",
-											"uniqueItems": true
-										},
-										"interval": {
-											"default": 0,
-											"minimum": 1,
-											"type": "integer"
-										},
-										"tcp_failures": {
-											"default": 2,
-											"maximum": 254,
-											"minimum": 1,
-											"type": "integer"
-										},
-										"timeouts": {
-											"default": 3,
-											"maximum": 254,
-											"minimum": 1,
-											"type": "integer"
-										}
-									},
-									"type": "object"
-								}
-							},
-							"type": "object"
-						},
-						"passive": {
-							"properties": {
-								"healthy": {
-									"properties": {
-										"http_statuses": {
-											"default": [200, 201, 202, 203, 204, 205, 206, 207, 208, 226, 300, 301, 302, 303, 304, 305, 306, 307, 308],
-											"items": {
-												"maximum": 599,
-												"minimum": 200,
-												"type": "integer"
-											},
-											"minItems": 1,
-											"type": "array",
-											"uniqueItems": true
-										},
-										"successes": {
-											"default": 5,
-											"maximum": 254,
-											"minimum": 1,
-											"type": "integer"
-										}
-									},
-									"type": "object"
-								},
-								"type": {
-									"default": "http",
-									"enum": ["http", "https", "tcp"],
-									"type": "string"
-								},
-								"unhealthy": {
-									"properties": {
-										"http_failures": {
-											"default": 5,
-											"maximum": 254,
-											"minimum": 1,
-											"type": "integer"
-										},
-										"http_statuses": {
-											"default": [429, 500, 503],
-											"items": {
-												"maximum": 599,
-												"minimum": 200,
-												"type": "integer"
-											},
-											"minItems": 1,
-											"type": "array",
-											"uniqueItems": true
-										},
-										"tcp_failures": {
-											"default": 2,
-											"maximum": 254,
-											"minimum": 1,
-											"type": "integer"
-										},
-										"timeouts": {
-											"default": 7,
-											"maximum": 254,
-											"minimum": 1,
-											"type": "integer"
-										}
-									},
-									"type": "object"
-								}
-							},
-							"type": "object"
-						}
-					},
-					"type": "object"
-				},
-				"create_time": {
-					"type": "integer"
-				},
-				"desc": {
-					"maxLength": 256,
-					"type": "string"
-				},
-				"discovery_type": {
-					"description": "discovery type",
-					"type": "string"
-				},
-				"enable_websocket": {
-					"description": "enable websocket for request",
-					"type": "boolean"
-				},
-				"hash_on": {
-					"default": "vars",
-					"enum": ["consumer", "cookie", "header", "vars"],
-					"type": "string"
-				},
-				"id": {
-					"anyOf": [{
-						"maxLength": 64,
-						"minLength": 1,
-						"pattern": "^[a-zA-Z0-9-_.]+$",
-						"type": "string"
-					}, {
-						"minimum": 1,
-						"type": "integer"
-					}]
-				},
-				"key": {
-					"description": "the key of chash for dynamic load balancing",
-					"type": "string"
-				},
-				"labels": {
-					"description": "key/value pairs to specify attributes",
-					"maxProperties": 16,
-					"patternProperties": {
-						".*": {
-							"description": "value of label",
-							"maxLength": 64,
-							"minLength": 1,
-							"pattern": "^[a-zA-Z0-9-_.]+$",
-							"type": "string"
-						}
-					},
-					"type": "object"
-				},
-				"name": {
-					"maxLength": 100,
-					"minLength": 1,
-					"type": "string"
-				},
-				"nodes": {
-					"anyOf": [{
-						"minProperties": 1,
-						"patternProperties": {
-							".*": {
-								"description": "weight of node",
-								"minimum": 0,
-								"type": "integer"
-							}
-						},
-						"type": "object"
-					}, {
-						"items": {
-							"properties": {
-								"host": {
-									"pattern": "^\\*?[0-9a-zA-Z-._]+$",
-									"type": "string"
-								},
-								"metadata": {
-									"description": "metadata of node",
-									"type": "object"
-								},
-								"port": {
-									"description": "port of node",
-									"minimum": 1,
-									"type": "integer"
-								},
-								"weight": {
-									"description": "weight of node",
-									"minimum": 0,
-									"type": "integer"
-								}
-							},
-							"required": ["host", "port", "weight"],
-							"type": "object"
-						},
-						"type": "array"
-					}]
-				},
-				"pass_host": {
-					"default": "pass",
-					"description": "mod of host passing",
-					"enum": ["node", "pass", "rewrite"],
-					"type": "string"
-				},
-				"retries": {
-					"minimum": 0,
-					"type": "integer"
-				},
-				"service_name": {
-					"maxLength": 100,
-					"minLength": 1,
-					"type": "string"
-				},
-				"timeout": {
-					"properties": {
-						"connect": {
-							"minimum": 0,
-							"type": "number"
-						},
-						"read": {
-							"minimum": 0,
-							"type": "number"
-						},
-						"send": {
-							"minimum": 0,
-							"type": "number"
-						}
-					},
-					"required": ["connect", "read", "send"],
-					"type": "object"
-				},
-				"type": {
-					"description": "algorithms of load balancing",
-					"enum": ["chash", "ewma", "roundrobin"],
-					"type": "string"
-				},
-				"update_time": {
-					"type": "integer"
-				},
-				"upstream_host": {
-					"pattern": "^\\*?[0-9a-zA-Z-._]+$",
-					"type": "string"
-				}
-			},
-			"type": "object"
-		},
-		"upstream_hash_header_schema": {
-			"pattern": "^[a-zA-Z0-9-_]+$",
-			"type": "string"
-		},
-		"upstream_hash_vars_schema": {
-			"pattern": "^((uri|server_name|server_addr|request_uri|remote_port|remote_addr|query_string|host|hostname)|arg_[0-9a-zA-z_-]+)$",
-			"type": "string"
-		}
-	},
-	"plugins": {
-		"api-breaker": {
-			"priority": 1005,
-			"schema": {
-				"properties": {
-					"break_response_code": {
-						"maximum": 599,
-						"minimum": 200,
-						"type": "integer"
-					},
-					"healthy": {
-						"default": {
-							"http_statuses": [200],
-							"successes": 3
-						},
-						"properties": {
-							"http_statuses": {
-								"default": [200],
-								"items": {
-									"maximum": 499,
-									"minimum": 200,
-									"type": "integer"
-								},
-								"minItems": 1,
-								"type": "array",
-								"uniqueItems": true
-							},
-							"successes": {
-								"default": 3,
-								"minimum": 1,
-								"type": "integer"
-							}
-						},
-						"type": "object"
-					},
-					"max_breaker_sec": {
-						"default": 300,
-						"minimum": 3,
-						"type": "integer"
-					},
-					"unhealthy": {
-						"default": {
-							"failures": 3,
-							"http_statuses": [500]
-						},
-						"properties": {
-							"failures": {
-								"default": 3,
-								"minimum": 1,
-								"type": "integer"
-							},
-							"http_statuses": {
-								"default": [500],
-								"items": {
-									"maximum": 599,
-									"minimum": 500,
-									"type": "integer"
-								},
-								"minItems": 1,
-								"type": "array",
-								"uniqueItems": true
-							}
-						},
-						"type": "object"
-					}
-				},
-				"required": ["break_response_code"],
-				"type": "object"
-			},
-			"version": 0.1
-		},
-		"authz-keycloak": {
-			"priority": 2000,
-			"schema": {
-				"properties": {
-					"audience": {
-						"maxLength": 100,
-						"minLength": 1,
-						"type": "string"
-					},
-					"grant_type": {
-						"default": "urn:ietf:params:oauth:grant-type:uma-ticket",
-						"enum": ["urn:ietf:params:oauth:grant-type:uma-ticket"],
-						"maxLength": 100,
-						"minLength": 1,
-						"type": "string"
-					},
-					"keepalive": {
-						"default": true,
-						"type": "boolean"
-					},
-					"keepalive_pool": {
-						"default": 5,
-						"minimum": 1,
-						"type": "integer"
-					},
-					"keepalive_timeout": {
-						"default": 60000,
-						"minimum": 1000,
-						"type": "integer"
-					},
-					"permissions": {
-						"items": {
-							"maxLength": 100,
-							"minLength": 1,
-							"type": "string"
-						},
-						"type": "array",
-						"uniqueItems": true
-					},
-					"policy_enforcement_mode": {
-						"default": "ENFORCING",
-						"enum": ["ENFORCING", "PERMISSIVE"],
-						"type": "string"
-					},
-					"ssl_verify": {
-						"default": true,
-						"type": "boolean"
-					},
-					"timeout": {
-						"default": 3000,
-						"minimum": 1000,
-						"type": "integer"
-					},
-					"token_endpoint": {
-						"maxLength": 4096,
-						"minLength": 1,
-						"type": "string"
-					}
-				},
-				"required": ["token_endpoint"],
-				"type": "object"
-			},
-			"version": 0.1
-		},
-		"basic-auth": {
-			"consumer_schema": {
-				"additionalProperties": false,
-				"properties": {
-					"password": {
-						"type": "string"
-					},
-					"username": {
-						"type": "string"
-					}
-				},
-				"required": ["password", "username"],
-				"title": "work with consumer object",
-				"type": "object"
-			},
-			"priority": 2520,
-			"schema": {
-				"additionalProperties": false,
-				"properties": {
-					"disable": {
-						"type": "boolean"
-					}
-				},
-				"title": "work with route or service object",
-				"type": "object"
-			},
-			"type": "auth",
-			"version": 0.1
-		},
-		"batch-requests": {
-			"metadata_schema": {
-				"additionalProperties": false,
-				"properties": {
-					"max_body_size": {
-						"default": 1048576,
-						"description": "max pipeline body size in bytes",
-						"exclusiveMinimum": 0,
-						"type": "integer"
-					}
-				},
-				"type": "object"
-			},
-			"priority": 4010,
-			"schema": {
-				"additionalProperties": false,
-				"properties": {
-					"disable": {
-						"type": "boolean"
-					}
-				},
-				"type": "object"
-			},
-			"version": 0.1
-		},
-		"consumer-restriction": {
-			"priority": 2400,
-			"schema": {
-				"oneOf": [{
-					"properties": {
-						"blacklist": {
-							"items": {
-								"type": "string"
-							},
-							"minItems": 1,
-							"type": "array"
-						},
-						"rejected_code": {
-							"default": 403,
-							"minimum": 200,
-							"type": "integer"
-						},
-						"type": {
-							"default": "consumer_name",
-							"enum": ["consumer_name", "service_id"],
-							"type": "string"
-						}
-					},
-					"required": ["blacklist"],
-					"title": "blacklist"
-				}, {
-					"properties": {
-						"rejected_code": {
-							"default": 403,
-							"minimum": 200,
-							"type": "integer"
-						},
-						"type": {
-							"default": "consumer_name",
-							"enum": ["consumer_name", "service_id"],
-							"type": "string"
-						},
-						"whitelist": {
-							"items": {
-								"type": "string"
-							},
-							"minItems": 1,
-							"type": "array"
-						}
-					},
-					"required": ["whitelist"],
-					"title": "whitelist"
-				}],
-				"properties": {
-					"disable": {
-						"type": "boolean"
-					}
-				},
-				"type": "object"
-			},
-			"version": 0.1
-		},
-		"cors": {
-			"priority": 4000,
-			"schema": {
-				"properties": {
-					"allow_credential": {
-						"default": false,
-						"description": "allow client append credential. according to CORS specification,if you set this option to 'true', you can not use '*' for other options.",
-						"type": "boolean"
-					},
-					"allow_headers": {
-						"default": "*",
-						"description": "you can use '*' to allow all header when no credentials,'**' to allow forcefully(it will bring some security risks, be carefully),multiple header use ',' to split. default: *.",
-						"type": "string"
-					},
-					"allow_methods": {
-						"default": "*",
-						"description": "you can use '*' to allow all methods when no credentials and '**','**' to allow forcefully(it will bring some security risks, be carefully),multiple method use ',' to split. default: *.",
-						"type": "string"
-					},
-					"allow_origins": {
-						"default": "*",
-						"description": "you can use '*' to allow all origins when no credentials,'**' to allow forcefully(it will bring some security risks, be carefully),multiple origin use ',' to split. default: *.",
-						"type": "string"
-					},
-					"expose_headers": {
-						"default": "*",
-						"description": "you can use '*' to expose all header when no credentials,multiple header use ',' to split. default: *.",
-						"type": "string"
-					},
-					"max_age": {
-						"default": 5,
-						"description": "maximum number of seconds the results can be cached.-1 mean no cached,the max value is depend on browser,more detail plz check MDN. default: 5.",
-						"type": "integer"
-					}
-				},
-				"type": "object"
-			},
-			"version": 0.1
-		},
-		"echo": {
-			"priority": 412,
-			"schema": {
-				"additionalProperties": false,
-				"anyOf": [{
-					"required": ["before_body"]
-				}, {
-					"required": ["body"]
-				}, {
-					"required": ["after_body"]
-				}],
-				"minProperties": 1,
-				"properties": {
-					"after_body": {
-						"description": "body after the modification of filter phase.",
-						"type": "string"
-					},
-					"auth_value": {
-						"description": "auth value",
-						"type": "string"
-					},
-					"before_body": {
-						"description": "body before the filter phase.",
-						"type": "string"
-					},
-					"body": {
-						"description": "body to replace upstream response.",
-						"type": "string"
-					},
-					"headers": {
-						"description": "new headers for response",
-						"minProperties": 1,
-						"type": "object"
-					}
-				},
-				"type": "object"
-			},
-			"version": 0.1
-		},
-		"fault-injection": {
-			"priority": 11000,
-			"schema": {
-				"minProperties": 1,
-				"properties": {
-					"abort": {
-						"properties": {
-							"body": {
-								"minLength": 0,
-								"type": "string"
-							},
-							"http_status": {
-								"minimum": 200,
-								"type": "integer"
-							},
-							"percentage": {
-								"maximum": 100,
-								"minimum": 0,
-								"type": "integer"
-							}
-						},
-						"required": ["http_status"],
-						"type": "object"
-					},
-					"delay": {
-						"properties": {
-							"duration": {
-								"minimum": 0,
-								"type": "number"
-							},
-							"percentage": {
-								"maximum": 100,
-								"minimum": 0,
-								"type": "integer"
-							}
-						},
-						"required": ["duration"],
-						"type": "object"
-					}
-				},
-				"type": "object"
-			},
-			"version": 0.1
-		},
-		"grpc-transcode": {
-			"priority": 506,
-			"schema": {
-				"additionalProperties": true,
-				"properties": {
-					"deadline": {
-						"default": 0,
-						"description": "deadline for grpc, millisecond",
-						"type": "number"
-					},
-					"method": {
-						"description": "the method name in the grpc service.",
-						"type": "string"
-					},
-					"pb_option": {
-						"items": {
-							"anyOf": [{
-								"description": "enum as result",
-								"enum": ["int64_as_hexstring", "int64_as_number", "int64_as_string"],
-								"type": "string"
-							}, {
-								"description": "int64 as result",
-								"enum": ["enum_as_value", "ienum_as_name"],
-								"type": "string"
-							}, {
-								"description": "default values option",
-								"enum": ["auto_default_values", "no_default_values", "use_default_metatable", "use_default_values"],
-								"type": "string"
-							}, {
-								"description": "hooks option",
-								"enum": ["disable_hooks", "enable_hooks"],
-								"type": "string"
-							}],
-							"type": "string"
-						},
-						"minItems": 1,
-						"type": "array"
-					},
-					"proto_id": {
-						"anyOf": [{
-							"maxLength": 64,
-							"minLength": 1,
-							"pattern": "^[a-zA-Z0-9-_.]+$",
-							"type": "string"
-						}, {
-							"minimum": 1,
-							"type": "integer"
-						}]
-					},
-					"service": {
-						"description": "the grpc service name",
-						"type": "string"
-					}
-				},
-				"required": ["method", "proto_id", "service"],
-				"type": "object"
-			},
-			"version": 0.1
-		},
-		"hmac-auth": {
-			"consumer_schema": {
-				"additionalProperties": false,
-				"properties": {
-					"access_key": {
-						"maxLength": 256,
-						"minLength": 1,
-						"type": "string"
-					},
-					"algorithm": {
-						"default": "hmac-sha256",
-						"enum": ["hmac-sha1", "hmac-sha256", "hmac-sha512"],
-						"type": "string"
-					},
-					"clock_skew": {
-						"default": 0,
-						"type": "integer"
-					},
-					"encode_uri_params": {
-						"default": true,
-						"title": "Whether to escape the uri parameter",
-						"type": "boolean"
-					},
-					"keep_headers": {
-						"default": false,
-						"title": "whether to keep the http request header",
-						"type": "boolean"
-					},
-					"secret_key": {
-						"maxLength": 256,
-						"minLength": 1,
-						"type": "string"
-					},
-					"signed_headers": {
-						"items": {
-							"maxLength": 50,
-							"minLength": 1,
-							"type": "string"
-						},
-						"type": "array"
-					}
-				},
-				"required": ["access_key", "secret_key"],
-				"title": "work with consumer object",
-				"type": "object"
-			},
-			"priority": 2530,
-			"schema": {
-				"additionalProperties": false,
-				"properties": {
-					"disable": {
-						"type": "boolean"
-					}
-				},
-				"title": "work with route or service object",
-				"type": "object"
-			},
-			"type": "auth",
-			"version": 0.1
-		},
-		"http-logger": {
-			"metadata_schema": {
-				"additionalProperties": false,
-				"properties": {
-					"log_format": {
-						"default": {
-							"@timestamp": "$time_iso8601",
-							"client_ip": "$remote_addr",
-							"host": "$host"
-						},
-						"type": "object"
-					}
-				},
-				"type": "object"
-			},
-			"priority": 410,
-			"schema": {
-				"properties": {
-					"auth_header": {
-						"default": "",
-						"type": "string"
-					},
-					"batch_max_size": {
-						"default": 1000,
-						"minimum": 1,
-						"type": "integer"
-					},
-					"buffer_duration": {
-						"default": 60,
-						"minimum": 1,
-						"type": "integer"
-					},
-					"concat_method": {
-						"default": "json",
-						"enum": ["json", "new_line"],
-						"type": "string"
-					},
-					"inactive_timeout": {
-						"default": 5,
-						"minimum": 1,
-						"type": "integer"
-					},
-					"include_req_body": {
-						"default": false,
-						"type": "boolean"
-					},
-					"max_retry_count": {
-						"default": 0,
-						"minimum": 0,
-						"type": "integer"
-					},
-					"name": {
-						"default": "http logger",
-						"type": "string"
-					},
-					"retry_delay": {
-						"default": 1,
-						"minimum": 0,
-						"type": "integer"
-					},
-					"timeout": {
-						"default": 3,
-						"minimum": 1,
-						"type": "integer"
-					},
-					"uri": {
-						"pattern": "^[^\\/]+:\\/\\/([\\da-zA-Z.-]+|\\[[\\da-fA-F:]+\\])(:\\d+)?",
-						"type": "string"
-					}
-				},
-				"required": ["uri"],
-				"type": "object"
-			},
-			"version": 0.1
-		},
-		"ip-restriction": {
-			"priority": 3000,
-			"schema": {
-				"oneOf": [{
-					"additionalProperties": false,
-					"properties": {
-						"whitelist": {
-							"items": {
-								"anyOf": [{
-									"format": "ipv4",
-									"title": "IPv4",
-									"type": "string"
-								}, {
-									"pattern": "^([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])/([12]?[0-9]|3[0-2])$",
-									"title": "IPv4/CIDR",
-									"type": "string"
-								}, {
-									"format": "ipv6",
-									"title": "IPv6",
-									"type": "string"
-								}, {
-									"pattern": "^([a-fA-F0-9]{0,4}:){1,8}(:[a-fA-F0-9]{0,4}){0,8}([a-fA-F0-9]{0,4})?/[0-9]{1,3}$",
-									"title": "IPv6/CIDR",
-									"type": "string"
-								}]
-							},
-							"minItems": 1,
-							"type": "array"
-						}
-					},
-					"required": ["whitelist"],
-					"title": "whitelist"
-				}, {
-					"additionalProperties": false,
-					"properties": {
-						"blacklist": {
-							"items": {
-								"anyOf": [{
-									"format": "ipv4",
-									"title": "IPv4",
-									"type": "string"
-								}, {
-									"pattern": "^([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])/([12]?[0-9]|3[0-2])$",
-									"title": "IPv4/CIDR",
-									"type": "string"
-								}, {
-									"format": "ipv6",
-									"title": "IPv6",
-									"type": "string"
-								}, {
-									"pattern": "^([a-fA-F0-9]{0,4}:){1,8}(:[a-fA-F0-9]{0,4}){0,8}([a-fA-F0-9]{0,4})?/[0-9]{1,3}$",
-									"title": "IPv6/CIDR",
-									"type": "string"
-								}]
-							},
-							"minItems": 1,
-							"type": "array"
-						}
-					},
-					"required": ["blacklist"],
-					"title": "blacklist"
-				}],
-				"properties": {
-					"disable": {
-						"type": "boolean"
-					}
-				},
-				"type": "object"
-			},
-			"version": 0.1
-		},
-		"jwt-auth": {
-			"consumer_schema": {
-				"dependencies": {
-					"algorithm": {
-						"oneOf": [{
-							"properties": {
-								"algorithm": {
-									"default": "HS256",
-									"enum": ["HS256", "HS512"]
-								}
-							}
-						}, {
-							"properties": {
-								"algorithm": {
-									"enum": ["RS256"]
-								},
-								"private_key": {
-									"type": "string"
-								},
-								"public_key": {
-									"type": "string"
-								}
-							},
-							"required": ["private_key", "public_key"]
-						}]
-					}
-				},
-				"properties": {
-					"algorithm": {
-						"default": "HS256",
-						"enum": ["HS256", "HS512", "RS256"],
-						"type": "string"
-					},
-					"base64_secret": {
-						"default": false,
-						"type": "boolean"
-					},
-					"exp": {
-						"default": 86400,
-						"minimum": 1,
-						"type": "integer"
-					},
-					"key": {
-						"type": "string"
-					},
-					"secret": {
-						"type": "string"
-					}
-				},
-				"required": ["key"],
-				"type": "object"
-			},
-			"priority": 2510,
-			"schema": {
-				"additionalProperties": false,
-				"properties": {
-					"disable": {
-						"type": "boolean"
-					}
-				},
-				"type": "object"
-			},
-			"type": "auth",
-			"version": 0.1
-		},
-		"kafka-logger": {
-			"priority": 403,
-			"schema": {
-				"properties": {
-					"batch_max_size": {
-						"default": 1000,
-						"minimum": 1,
-						"type": "integer"
-					},
-					"broker_list": {
-						"type": "object"
-					},
-					"buffer_duration": {
-						"default": 60,
-						"minimum": 1,
-						"type": "integer"
-					},
-					"inactive_timeout": {
-						"default": 5,
-						"minimum": 1,
-						"type": "integer"
-					},
-					"include_req_body": {
-						"default": false,
-						"type": "boolean"
-					},
-					"kafka_topic": {
-						"type": "string"
-					},
-					"key": {
-						"type": "string"
-					},
-					"max_retry_count": {
-						"default": 0,
-						"minimum": 0,
-						"type": "integer"
-					},
-					"meta_format": {
-						"default": "default",
-						"enum": ["default", "origin"],
-						"type": "string"
-					},
-					"name": {
-						"default": "kafka logger",
-						"type": "string"
-					},
-					"retry_delay": {
-						"default": 1,
-						"minimum": 0,
-						"type": "integer"
-					},
-					"timeout": {
-						"default": 3,
-						"minimum": 1,
-						"type": "integer"
-					}
-				},
-				"required": ["broker_list", "kafka_topic"],
-				"type": "object"
-			},
-			"version": 0.1
-		},
-		"key-auth": {
-			"consumer_schema": {
-				"additionalProperties": false,
-				"properties": {
-					"key": {
-						"type": "string"
-					}
-				},
-				"required": ["key"],
-				"type": "object"
-			},
-			"priority": 2500,
-			"schema": {
-				"additionalProperties": false,
-				"properties": {
-					"disable": {
-						"type": "boolean"
-					}
-				},
-				"type": "object"
-			},
-			"type": "auth",
-			"version": 0.1
-		},
-		"limit-conn": {
-			"priority": 1003,
-			"schema": {
-				"properties": {
-					"burst": {
-						"minimum": 0,
-						"type": "integer"
-					},
-					"conn": {
-						"exclusiveMinimum": 0,
-						"type": "integer"
-					},
-					"default_conn_delay": {
-						"exclusiveMinimum": 0,
-						"type": "number"
-					},
-					"key": {
-						"enum": ["consumer_name", "http_x_forwarded_for", "http_x_real_ip", "remote_addr", "server_addr"],
-						"type": "string"
-					},
-					"rejected_code": {
-						"default": 503,
-						"minimum": 200,
-						"type": "integer"
-					}
-				},
-				"required": ["burst", "conn", "default_conn_delay", "key"],
-				"type": "object"
-			},
-			"version": 0.1
-		},
-		"limit-count": {
-			"priority": 1002,
-			"schema": {
-				"dependencies": {
-					"policy": {
-						"oneOf": [{
-							"properties": {
-								"policy": {
-									"enum": ["local"]
-								}
-							}
-						}, {
-							"properties": {
-								"policy": {
-									"enum": ["redis"]
-								},
-								"redis_host": {
-									"minLength": 2,
-									"type": "string"
-								},
-								"redis_password": {
-									"minLength": 0,
-									"type": "string"
-								},
-								"redis_port": {
-									"default": 6379,
-									"minimum": 1,
-									"type": "integer"
-								},
-								"redis_timeout": {
-									"default": 1000,
-									"minimum": 1,
-									"type": "integer"
-								}
-							},
-							"required": ["redis_host"]
-						}, {
-							"properties": {
-								"policy": {
-									"enum": ["redis-cluster"]
-								},
-								"redis_cluster_nodes": {
-									"items": {
-										"maxLength": 100,
-										"minLength": 2,
-										"type": "string"
-									},
-									"minItems": 2,
-									"type": "array"
-								},
-								"redis_password": {
-									"minLength": 0,
-									"type": "string"
-								},
-								"redis_timeout": {
-									"default": 1000,
-									"minimum": 1,
-									"type": "integer"
-								}
-							},
-							"required": ["redis_cluster_nodes"]
-						}]
-					}
-				},
-				"properties": {
-					"count": {
-						"minimum": 0,
-						"type": "integer"
-					},
-					"key": {
-						"default": "remote_addr",
-						"enum": ["consumer_name", "http_x_forwarded_for", "http_x_real_ip", "remote_addr", "server_addr", "service_id"],
-						"type": "string"
-					},
-					"policy": {
-						"default": "local",
-						"enum": ["local", "redis", "redis-cluster"],
-						"type": "string"
-					},
-					"rejected_code": {
-						"default": 503,
-						"maximum": 600,
-						"minimum": 200,
-						"type": "integer"
-					},
-					"time_window": {
-						"minimum": 0,
-						"type": "integer"
-					}
-				},
-				"required": ["count", "time_window"],
-				"type": "object"
-			},
-			"version": 0.4
-		},
-		"limit-req": {
-			"priority": 1001,
-			"schema": {
-				"properties": {
-					"burst": {
-						"minimum": 0,
-						"type": "number"
-					},
-					"key": {
-						"enum": ["consumer_name", "http_x_forwarded_for", "http_x_real_ip", "remote_addr", "server_addr"],
-						"type": "string"
-					},
-					"rate": {
-						"minimum": 0,
-						"type": "number"
-					},
-					"rejected_code": {
-						"default": 503,
-						"minimum": 200,
-						"type": "integer"
-					}
-				},
-				"required": ["burst", "key", "rate"],
-				"type": "object"
-			},
-			"version": 0.1
-		},
-		"mqtt-proxy": {
-			"priority": 1000,
-			"schema": {
-				"properties": {
-					"protocol_level": {
-						"type": "integer"
-					},
-					"protocol_name": {
-						"type": "string"
-					},
-					"upstream": {
-						"properties": {
-							"ip": {
-								"type": "string"
-							},
-							"port": {
-								"type": "number"
-							}
-						},
-						"type": "object"
-					}
-				},
-				"required": ["protocol_level", "protocol_name", "upstream"],
-				"type": "object"
-			},
-			"version": 0.1
-		},
-		"openid-connect": {
-			"priority": 2599,
-			"schema": {
-				"properties": {
-					"bearer_only": {
-						"default": false,
-						"type": "boolean"
-					},
-					"client_id": {
-						"type": "string"
-					},
-					"client_secret": {
-						"type": "string"
-					},
-					"discovery": {
-						"type": "string"
-					},
-					"introspection_endpoint": {
-						"type": "string"
-					},
-					"introspection_endpoint_auth_method": {
-						"default": "client_secret_basic",
-						"type": "string"
-					},
-					"logout_path": {
-						"default": "/logout",
-						"type": "string"
-					},
-					"public_key": {
-						"type": "string"
-					},
-					"realm": {
-						"default": "apisix",
-						"type": "string"
-					},
-					"redirect_uri": {
-						"description": "use ngx.var.request_uri if not configured",
-						"type": "string"
-					},
-					"scope": {
-						"default": "openid",
-						"type": "string"
-					},
-					"ssl_verify": {
-						"default": false,
-						"type": "boolean"
-					},
-					"timeout": {
-						"default": 3,
-						"description": "timeout in seconds",
-						"minimum": 1,
-						"type": "integer"
-					},
-					"token_signing_alg_values_expected": {
-						"type": "string"
-					}
-				},
-				"required": ["client_id", "client_secret", "discovery"],
-				"type": "object"
-			},
-			"version": 0.1
-		},
-		"prometheus": {
-			"priority": 500,
-			"schema": {
-				"additionalProperties": false,
-				"properties": {
-					"disable": {
-						"type": "boolean"
-					}
-				},
-				"type": "object"
-			},
-			"version": 0.2
-		},
-		"proxy-cache": {
-			"priority": 1009,
-			"schema": {
-				"properties": {
-					"cache_bypass": {
-						"items": {
-							"pattern": "(^[^\\$].+$|^\\$[0-9a-zA-Z_]+$)",
-							"type": "string"
-						},
-						"minItems": 1,
-						"type": "array"
-					},
-					"cache_http_status": {
-						"default": [200, 301, 404],
-						"items": {
-							"description": "http response status",
-							"maximum": 599,
-							"minimum": 200,
-							"type": "integer"
-						},
-						"minItems": 1,
-						"type": "array",
-						"uniqueItems": true
-					},
-					"cache_key": {
-						"default": ["$host", "$request_uri"],
-						"items": {
-							"description": "a key for caching",
-							"pattern": "(^[^\\$].+$|^\\$[0-9a-zA-Z_]+$)",
-							"type": "string"
-						},
-						"minItems": 1,
-						"type": "array"
-					},
-					"cache_method": {
-						"default": ["GET", "HEAD"],
-						"items": {
-							"description": "http method",
-							"enum": ["CONNECT", "DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT", "TRACE"],
-							"type": "string"
-						},
-						"minItems": 1,
-						"type": "array",
-						"uniqueItems": true
-					},
-					"cache_zone": {
-						"default": "disk_cache_one",
-						"maxLength": 100,
-						"minLength": 1,
-						"type": "string"
-					},
-					"hide_cache_headers": {
-						"default": false,
-						"type": "boolean"
-					},
-					"no_cache": {
-						"items": {
-							"pattern": "(^[^\\$].+$|^\\$[0-9a-zA-Z_]+$)",
-							"type": "string"
-						},
-						"minItems": 1,
-						"type": "array"
-					}
-				},
-				"type": "object"
-			},
-			"version": 0.1
-		},
-		"proxy-mirror": {
-			"priority": 1010,
-			"schema": {
-				"minProperties": 1,
-				"properties": {
-					"host": {
-						"pattern": "^http(s)?:\\/\\/[a-zA-Z0-9][-a-zA-Z0-9]{0,62}(\\.[a-zA-Z0-9][-a-zA-Z0-9]{0,62})+(:[0-9]{1,5})?$",
-						"type": "string"
-					}
-				},
-				"required": ["host"],
-				"type": "object"
-			},
-			"version": 0.1
-		},
-		"proxy-rewrite": {
-			"priority": 1008,
-			"schema": {
-				"additionalProperties": false,
-				"minProperties": 1,
-				"properties": {
-					"headers": {
-						"description": "new headers for request",
-						"minProperties": 1,
-						"type": "object"
-					},
-					"host": {
-						"description": "new host for upstream",
-						"pattern": "^[0-9a-zA-Z-.]+$",
-						"type": "string"
-					},
-					"regex_uri": {
-						"description": "new uri that substitute from client uri for upstream, lower priority than uri property",
-						"items": {
-							"description": "regex uri",
-							"type": "string"
-						},
-						"maxItems": 2,
-						"minItems": 2,
-						"type": "array"
-					},
-					"scheme": {
-						"description": "new scheme for upstream",
-						"enum": ["http", "https"],
-						"type": "string"
-					},
-					"uri": {
-						"description": "new uri for upstream",
-						"maxLength": 4096,
-						"minLength": 1,
-						"pattern": "^\\/.*",
-						"type": "string"
-					}
-				},
-				"type": "object"
-			},
-			"version": 0.1
-		},
-		"redirect": {
-			"priority": 900,
-			"schema": {
-				"oneOf": [{
-					"required": ["uri"]
-				}, {
-					"required": ["http_to_https"]
-				}],
-				"properties": {
-					"http_to_https": {
-						"type": "boolean"
-					},
-					"ret_code": {
-						"default": 302,
-						"minimum": 200,
-						"type": "integer"
-					},
-					"uri": {
-						"minLength": 2,
-						"pattern": "(\\\\\\$[0-9a-zA-Z_]+)|\\$\\{([0-9a-zA-Z_]+)\\}|\\$([0-9a-zA-Z_]+)|(\\$|[^$\\\\]+)",
-						"type": "string"
-					}
-				},
-				"type": "object"
-			},
-			"version": 0.1
-		},
-		"referer-restriction": {
-			"priority": 2990,
-			"schema": {
-				"additionalProperties": false,
-				"properties": {
-					"bypass_missing": {
-						"default": false,
-						"type": "boolean"
-					},
-					"whitelist": {
-						"items": {
-							"pattern": "^\\*?[0-9a-zA-Z-._]+$",
-							"type": "string"
-						},
-						"minItems": 1,
-						"type": "array"
-					}
-				},
-				"required": ["whitelist"],
-				"type": "object"
-			},
-			"version": 0.1
-		},
-		"request-id": {
-			"priority": 11010,
-			"schema": {
-				"properties": {
-					"header_name": {
-						"default": "X-Request-Id",
-						"type": "string"
-					},
-					"include_in_response": {
-						"default": true,
-						"type": "boolean"
-					}
-				},
-				"type": "object"
-			},
-			"version": 0.1
-		},
-		"request-validation": {
-			"priority": 2800,
-			"schema": {
-				"anyOf": [{
-					"properties": {
-						"body_schema": {
-							"type": "object"
-						}
-					},
-					"required": ["body_schema"],
-					"title": "Body schema"
-				}, {
-					"properties": {
-						"header_schema": {
-							"type": "object"
-						}
-					},
-					"required": ["header_schema"],
-					"title": "Header schema"
-				}],
-				"properties": {
-					"disable": {
-						"type": "boolean"
-					}
-				},
-				"type": "object"
-			},
-			"type": "validation",
-			"version": 0.1
-		},
-		"response-rewrite": {
-			"priority": 899,
-			"schema": {
-				"additionalProperties": false,
-				"minProperties": 1,
-				"properties": {
-					"body": {
-						"description": "new body for response",
-						"type": "string"
-					},
-					"body_base64": {
-						"default": false,
-						"description": "whether new body for response need base64 decode before return",
-						"type": "boolean"
-					},
-					"headers": {
-						"description": "new headers for response",
-						"minProperties": 1,
-						"type": "object"
-					},
-					"status_code": {
-						"description": "new status code for response",
-						"maximum": 598,
-						"minimum": 200,
-						"type": "integer"
-					}
-				},
-				"type": "object"
-			},
-			"version": 0.1
-		},
-		"serverless-post-function": {
-			"priority": -2000,
-			"schema": {
-				"properties": {
-					"functions": {
-						"items": {
-							"type": "string"
-						},
-						"minItems": 1,
-						"type": "array"
-					},
-					"phase": {
-						"default": "access",
-						"enum": ["access", "balancer", "body_filter", "header_filter", "log", "rewrite"],
-						"type": "string"
-					}
-				},
-				"required": ["functions"],
-				"type": "object"
-			},
-			"version": 0.1
-		},
-		"serverless-pre-function": {
-			"priority": 10000,
-			"schema": {
-				"properties": {
-					"functions": {
-						"items": {
-							"type": "string"
-						},
-						"minItems": 1,
-						"type": "array"
-					},
-					"phase": {
-						"default": "access",
-						"enum": ["access", "balancer", "body_filter", "header_filter", "log", "rewrite"],
-						"type": "string"
-					}
-				},
-				"required": ["functions"],
-				"type": "object"
-			},
-			"version": 0.1
-		},
-		"sls-logger": {
-			"priority": 406,
-			"schema": {
-				"properties": {
-					"access_key_id": {
-						"type": "string"
-					},
-					"access_key_secret": {
-						"type": "string"
-					},
-					"batch_max_size": {
-						"default": 1000,
-						"minimum": 1,
-						"type": "integer"
-					},
-					"buffer_duration": {
-						"default": 60,
-						"minimum": 1,
-						"type": "integer"
-					},
-					"host": {
-						"type": "string"
-					},
-					"inactive_timeout": {
-						"default": 5,
-						"minimum": 1,
-						"type": "integer"
-					},
-					"include_req_body": {
-						"default": false,
-						"type": "boolean"
-					},
-					"logstore": {
-						"type": "string"
-					},
-					"max_retry_count": {
-						"default": 0,
-						"minimum": 0,
-						"type": "integer"
-					},
-					"name": {
-						"default": "sls-logger",
-						"type": "string"
-					},
-					"port": {
-						"type": "integer"
-					},
-					"project": {
-						"type": "string"
-					},
-					"retry_delay": {
-						"default": 1,
-						"minimum": 0,
-						"type": "integer"
-					},
-					"timeout": {
-						"default": 5000,
-						"minimum": 1,
-						"type": "integer"
-					}
-				},
-				"required": ["access_key_id", "access_key_secret", "host", "logstore", "port", "project"],
-				"type": "object"
-			},
-			"version": 0.1
-		},
-		"syslog": {
-			"priority": 401,
-			"schema": {
-				"properties": {
-					"batch_max_size": {
-						"default": 1000,
-						"minimum": 1,
-						"type": "integer"
-					},
-					"buffer_duration": {
-						"default": 60,
-						"minimum": 1,
-						"type": "integer"
-					},
-					"drop_limit": {
-						"default": 1048576,
-						"type": "integer"
-					},
-					"flush_limit": {
-						"default": 4096,
-						"minimum": 1,
-						"type": "integer"
-					},
-					"host": {
-						"type": "string"
-					},
-					"include_req_body": {
-						"default": false,
-						"type": "boolean"
-					},
-					"max_retry_times": {
-						"default": 1,
-						"minimum": 1,
-						"type": "integer"
-					},
-					"name": {
-						"default": "sys logger",
-						"type": "string"
-					},
-					"pool_size": {
-						"default": 5,
-						"minimum": 5,
-						"type": "integer"
-					},
-					"port": {
-						"type": "integer"
-					},
-					"retry_interval": {
-						"default": 1,
-						"minimum": 0,
-						"type": "integer"
-					},
-					"sock_type": {
-						"default": "tcp",
-						"enum": ["tcp", "udp"],
-						"type": "string"
-					},
-					"timeout": {
-						"default": 3,
-						"minimum": 1,
-						"type": "integer"
-					},
-					"tls": {
-						"default": false,
-						"type": "boolean"
-					}
-				},
-				"required": ["host", "port"],
-				"type": "object"
-			},
-			"version": 0.1
-		},
-		"tcp-logger": {
-			"priority": 405,
-			"schema": {
-				"properties": {
-					"batch_max_size": {
-						"default": 1000,
-						"minimum": 1,
-						"type": "integer"
-					},
-					"buffer_duration": {
-						"default": 60,
-						"minimum": 1,
-						"type": "integer"
-					},
-					"host": {
-						"type": "string"
-					},
-					"inactive_timeout": {
-						"default": 5,
-						"minimum": 1,
-						"type": "integer"
-					},
-					"include_req_body": {
-						"default": false,
-						"type": "boolean"
-					},
-					"max_retry_count": {
-						"default": 0,
-						"minimum": 0,
-						"type": "integer"
-					},
-					"name": {
-						"default": "tcp logger",
-						"type": "string"
-					},
-					"port": {
-						"minimum": 0,
-						"type": "integer"
-					},
-					"retry_delay": {
-						"default": 1,
-						"minimum": 0,
-						"type": "integer"
-					},
-					"timeout": {
-						"default": 1000,
-						"minimum": 1,
-						"type": "integer"
-					},
-					"tls": {
-						"default": false,
-						"type": "boolean"
-					},
-					"tls_options": {
-						"type": "string"
-					}
-				},
-				"required": ["host", "port"],
-				"type": "object"
-			},
-			"version": 0.1
-		},
-		"traffic-split": {
-			"priority": 966,
-			"schema": {
-				"properties": {
-					"rules": {
-						"items": {
-							"properties": {
-								"match": {
-									"default": [{
-										"vars": [
-											[0, ">", "server_port"]
-										]
-									}],
-									"items": {
-										"properties": {
-											"vars": {
-												"items": {
-													"additionalItems": {
-														"anyOf": [{
-															"type": "string"
-														}, {
-															"type": "number"
-														}, {
-															"type": "boolean"
-														}, {
-															"items": {
-																"anyOf": [{
-																	"maxLength": 100,
-																	"minLength": 1,
-																	"type": "string"
-																}, {
-																	"type": "number"
-																}, {
-																	"type": "boolean"
-																}]
-															},
-															"type": "array",
-															"uniqueItems": true
-														}]
-													},
-													"items": [{
-														"maxLength": 100,
-														"minLength": 1,
-														"type": "string"
-													}, {
-														"maxLength": 2,
-														"minLength": 1,
-														"type": "string"
-													}],
-													"maxItems": 10,
-													"minItems": 0,
-													"type": "array"
-												},
-												"type": "array"
-											}
-										},
-										"type": "object"
-									},
-									"type": "array"
-								},
-								"weighted_upstreams": {
-									"default": [{
-										"weight": 1
-									}],
-									"items": {
-										"properties": {
-											"upstream": {
-												"additionalProperties": false,
-												"anyOf": [{
-													"required": ["nodes", "type"]
-												}, {
-													"required": ["service_name", "type"]
-												}],
-												"properties": {
-													"checks": {
-														"additionalProperties": false,
-														"anyOf": [{
-															"required": ["active"]
-														}, {
-															"required": ["active", "passive"]
-														}],
-														"properties": {
-															"active": {
-																"properties": {
-																	"concurrency": {
-																		"default": 10,
-																		"type": "integer"
-																	},
-																	"healthy": {
-																		"properties": {
-																			"http_statuses": {
-																				"default": [200, 302],
-																				"items": {
-																					"maximum": 599,
-																					"minimum": 200,
-																					"type": "integer"
-																				},
-																				"minItems": 1,
-																				"type": "array",
-																				"uniqueItems": true
-																			},
-																			"interval": {
-																				"default": 0,
-																				"minimum": 1,
-																				"type": "integer"
-																			},
-																			"successes": {
-																				"default": 2,
-																				"maximum": 254,
-																				"minimum": 1,
-																				"type": "integer"
-																			}
-																		},
-																		"type": "object"
-																	},
-																	"host": {
-																		"pattern": "^\\*?[0-9a-zA-Z-._]+$",
-																		"type": "string"
-																	},
-																	"http_path": {
-																		"default": "/",
-																		"type": "string"
-																	},
-																	"https_verify_certificate": {
-																		"default": true,
-																		"type": "boolean"
-																	},
-																	"port": {
-																		"maximum": 65535,
-																		"minimum": 1,
-																		"type": "integer"
-																	},
-																	"req_headers": {
-																		"items": {
-																			"type": "string",
-																			"uniqueItems": true
-																		},
-																		"minItems": 1,
-																		"type": "array"
-																	},
-																	"timeout": {
-																		"default": 1,
-																		"type": "number"
-																	},
-																	"type": {
-																		"default": "http",
-																		"enum": ["http", "https", "tcp"],
-																		"type": "string"
-																	},
-																	"unhealthy": {
-																		"properties": {
-																			"http_failures": {
-																				"default": 5,
-																				"maximum": 254,
-																				"minimum": 1,
-																				"type": "integer"
-																			},
-																			"http_statuses": {
-																				"default": [404, 429, 500, 501, 502, 503, 504, 505],
-																				"items": {
-																					"maximum": 599,
-																					"minimum": 200,
-																					"type": "integer"
-																				},
-																				"minItems": 1,
-																				"type": "array",
-																				"uniqueItems": true
-																			},
-																			"interval": {
-																				"default": 0,
-																				"minimum": 1,
-																				"type": "integer"
-																			},
-																			"tcp_failures": {
-																				"default": 2,
-																				"maximum": 254,
-																				"minimum": 1,
-																				"type": "integer"
-																			},
-																			"timeouts": {
-																				"default": 3,
-																				"maximum": 254,
-																				"minimum": 1,
-																				"type": "integer"
-																			}
-																		},
-																		"type": "object"
-																	}
-																},
-																"type": "object"
-															},
-															"passive": {
-																"properties": {
-																	"healthy": {
-																		"properties": {
-																			"http_statuses": {
-																				"default": [200, 201, 202, 203, 204, 205, 206, 207, 208, 226, 300, 301, 302, 303, 304, 305, 306, 307, 308],
-																				"items": {
-																					"maximum": 599,
-																					"minimum": 200,
-																					"type": "integer"
-																				},
-																				"minItems": 1,
-																				"type": "array",
-																				"uniqueItems": true
-																			},
-																			"successes": {
-																				"default": 5,
-																				"maximum": 254,
-																				"minimum": 1,
-																				"type": "integer"
-																			}
-																		},
-																		"type": "object"
-																	},
-																	"type": {
-																		"default": "http",
-																		"enum": ["http", "https", "tcp"],
-																		"type": "string"
-																	},
-																	"unhealthy": {
-																		"properties": {
-																			"http_failures": {
-																				"default": 5,
-																				"maximum": 254,
-																				"minimum": 1,
-																				"type": "integer"
-																			},
-																			"http_statuses": {
-																				"default": [429, 500, 503],
-																				"items": {
-																					"maximum": 599,
-																					"minimum": 200,
-																					"type": "integer"
-																				},
-																				"minItems": 1,
-																				"type": "array",
-																				"uniqueItems": true
-																			},
-																			"tcp_failures": {
-																				"default": 2,
-																				"maximum": 254,
-																				"minimum": 1,
-																				"type": "integer"
-																			},
-																			"timeouts": {
-																				"default": 7,
-																				"maximum": 254,
-																				"minimum": 1,
-																				"type": "integer"
-																			}
-																		},
-																		"type": "object"
-																	}
-																},
-																"type": "object"
-															}
-														},
-														"type": "object"
-													},
-													"create_time": {
-														"type": "integer"
-													},
-													"desc": {
-														"maxLength": 256,
-														"type": "string"
-													},
-													"discovery_type": {
-														"description": "discovery type",
-														"type": "string"
-													},
-													"enable_websocket": {
-														"description": "enable websocket for request",
-														"type": "boolean"
-													},
-													"hash_on": {
-														"default": "vars",
-														"enum": ["consumer", "cookie", "header", "vars"],
-														"type": "string"
-													},
-													"id": {
-														"anyOf": [{
-															"maxLength": 64,
-															"minLength": 1,
-															"pattern": "^[a-zA-Z0-9-_.]+$",
-															"type": "string"
-														}, {
-															"minimum": 1,
-															"type": "integer"
-														}]
-													},
-													"key": {
-														"description": "the key of chash for dynamic load balancing",
-														"type": "string"
-													},
-													"labels": {
-														"description": "key/value pairs to specify attributes",
-														"maxProperties": 16,
-														"patternProperties": {
-															".*": {
-																"description": "value of label",
-																"maxLength": 64,
-																"minLength": 1,
-																"pattern": "^[a-zA-Z0-9-_.]+$",
-																"type": "string"
-															}
-														},
-														"type": "object"
-													},
-													"name": {
-														"maxLength": 100,
-														"minLength": 1,
-														"type": "string"
-													},
-													"nodes": {
-														"anyOf": [{
-															"minProperties": 1,
-															"patternProperties": {
-																".*": {
-																	"description": "weight of node",
-																	"minimum": 0,
-																	"type": "integer"
-																}
-															},
-															"type": "object"
-														}, {
-															"items": {
-																"properties": {
-																	"host": {
-																		"pattern": "^\\*?[0-9a-zA-Z-._]+$",
-																		"type": "string"
-																	},
-																	"metadata": {
-																		"description": "metadata of node",
-																		"type": "object"
-																	},
-																	"port": {
-																		"description": "port of node",
-																		"minimum": 1,
-																		"type": "integer"
-																	},
-																	"weight": {
-																		"description": "weight of node",
-																		"minimum": 0,
-																		"type": "integer"
-																	}
-																},
-																"required": ["host", "port", "weight"],
-																"type": "object"
-															},
-															"type": "array"
-														}]
-													},
-													"pass_host": {
-														"default": "pass",
-														"description": "mod of host passing",
-														"enum": ["node", "pass", "rewrite"],
-														"type": "string"
-													},
-													"retries": {
-														"minimum": 0,
-														"type": "integer"
-													},
-													"service_name": {
-														"maxLength": 100,
-														"minLength": 1,
-														"type": "string"
-													},
-													"timeout": {
-														"properties": {
-															"connect": {
-																"minimum": 0,
-																"type": "number"
-															},
-															"read": {
-																"minimum": 0,
-																"type": "number"
-															},
-															"send": {
-																"minimum": 0,
-																"type": "number"
-															}
-														},
-														"required": ["connect", "read", "send"],
-														"type": "object"
-													},
-													"type": {
-														"description": "algorithms of load balancing",
-														"enum": ["chash", "ewma", "roundrobin"],
-														"type": "string"
-													},
-													"update_time": {
-														"type": "integer"
-													},
-													"upstream_host": {
-														"pattern": "^\\*?[0-9a-zA-Z-._]+$",
-														"type": "string"
-													}
-												},
-												"type": "object"
-											},
-											"upstream_id": {
-												"anyOf": [{
-													"maxLength": 64,
-													"minLength": 1,
-													"pattern": "^[a-zA-Z0-9-_.]+$",
-													"type": "string"
-												}, {
-													"minimum": 1,
-													"type": "integer"
-												}]
-											},
-											"weight": {
-												"default": 1,
-												"description": "used to split traffic between differentupstreams for plugin configuration",
-												"minimum": 0,
-												"type": "integer"
-											}
-										},
-										"type": "object"
-									},
-									"maxItems": 20,
-									"minItems": 1,
-									"type": "array"
-								}
-							},
-							"type": "object"
-						},
-						"type": "array"
-					}
-				},
-				"type": "object"
-			},
-			"version": 0.1
-		},
-		"udp-logger": {
-			"priority": 400,
-			"schema": {
-				"properties": {
-					"batch_max_size": {
-						"default": 1000,
-						"minimum": 1,
-						"type": "integer"
-					},
-					"buffer_duration": {
-						"default": 60,
-						"minimum": 1,
-						"type": "integer"
-					},
-					"host": {
-						"type": "string"
-					},
-					"inactive_timeout": {
-						"default": 5,
-						"minimum": 1,
-						"type": "integer"
-					},
-					"include_req_body": {
-						"default": false,
-						"type": "boolean"
-					},
-					"name": {
-						"default": "udp logger",
-						"type": "string"
-					},
-					"port": {
-						"minimum": 0,
-						"type": "integer"
-					},
-					"timeout": {
-						"default": 3,
-						"minimum": 1,
-						"type": "integer"
-					}
-				},
-				"required": ["host", "port"],
-				"type": "object"
-			},
-			"version": 0.1
-		},
-		"uri-blocker": {
-			"priority": 2900,
-			"schema": {
-				"properties": {
-					"block_rules": {
-						"items": {
-							"maxLength": 4096,
-							"minLength": 1,
-							"type": "string"
-						},
-						"type": "array",
-						"uniqueItems": true
-					},
-					"rejected_code": {
-						"default": 403,
-						"minimum": 200,
-						"type": "integer"
-					}
-				},
-				"required": ["block_rules"],
-				"type": "object"
-			},
-			"version": 0.1
-		},
-		"wolf-rbac": {
-			"priority": 2555,
-			"schema": {
-				"properties": {
-					"appid": {
-						"default": "unset",
-						"type": "string"
-					},
-					"header_prefix": {
-						"default": "X-",
-						"type": "string"
-					},
-					"server": {
-						"default": "http://127.0.0.1:10080",
-						"type": "string"
-					}
-				},
-				"type": "object"
-			},
-			"type": "auth",
-			"version": 0.1
-		},
-		"zipkin": {
-			"priority": 11011,
-			"schema": {
-				"properties": {
-					"endpoint": {
-						"type": "string"
-					},
-					"sample_ratio": {
-						"maximum": 1,
-						"minimum": 0.00001,
-						"type": "number"
-					},
-					"server_addr": {
-						"description": "default is $server_addr, you can specify your external ip address",
-						"pattern": "^[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}$",
-						"type": "string"
-					},
-					"service_name": {
-						"default": "APISIX",
-						"description": "service name for zipkin reporter",
-						"type": "string"
-					}
-				},
-				"required": ["endpoint", "sample_ratio"],
-				"type": "object"
-			},
-			"version": 0.1
-		}
-	}
+    "main": {
+        "consumer": {
+            "additionalProperties": false,
+            "properties": {
+                "create_time": {
+                    "type": "integer"
+                },
+                "desc": {
+                    "maxLength": 256,
+                    "type": "string"
+                },
+                "id": {
+                    "anyOf": [
+                        {
+                            "maxLength": 64,
+                            "minLength": 1,
+                            "pattern": "^[a-zA-Z0-9-_.]+$",
+                            "type": "string"
+                        },
+                        {
+                            "minimum": 1,
+                            "type": "integer"
+                        }
+                    ]
+                },
+                "labels": {
+                    "description": "key/value pairs to specify attributes",
+                    "maxProperties": 16,
+                    "patternProperties": {
+                        ".*": {
+                            "description": "value of label",
+                            "maxLength": 64,
+                            "minLength": 1,
+                            "pattern": "^[a-zA-Z0-9-_.]+$",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "plugins": {
+                    "type": "object"
+                },
+                "update_time": {
+                    "type": "integer"
+                },
+                "username": {
+                    "maxLength": 32,
+                    "minLength": 1,
+                    "pattern": "^[a-zA-Z0-9_]+$",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "username"
+            ],
+            "type": "object"
+        },
+        "global_rule": {
+            "additionalProperties": false,
+            "properties": {
+                "create_time": {
+                    "type": "integer"
+                },
+                "id": {
+                    "anyOf": [
+                        {
+                            "maxLength": 64,
+                            "minLength": 1,
+                            "pattern": "^[a-zA-Z0-9-_.]+$",
+                            "type": "string"
+                        },
+                        {
+                            "minimum": 1,
+                            "type": "integer"
+                        }
+                    ]
+                },
+                "plugins": {
+                    "type": "object"
+                },
+                "update_time": {
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "plugins"
+            ],
+            "type": "object"
+        },
+        "plugins": {
+            "items": {
+                "properties": {
+                    "additionalProperties": false,
+                    "name": {
+                        "minLength": 1,
+                        "type": "string"
+                    },
+                    "stream": {
+                        "type": "boolean"
+                    }
+                },
+                "required": [
+                    "name"
+                ],
+                "type": "object"
+            },
+            "type": "array"
+        },
+        "proto": {
+            "additionalProperties": false,
+            "properties": {
+                "content": {
+                    "maxLength": 1048576,
+                    "minLength": 1,
+                    "type": "string"
+                }
+            },
+            "required": [
+                "content"
+            ],
+            "type": "object"
+        },
+        "route": {
+            "additionalProperties": false,
+            "allOf": [
+                {
+                    "oneOf": [
+                        {
+                            "required": [
+                                "uri"
+                            ]
+                        },
+                        {
+                            "required": [
+                                "uris"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "oneOf": [
+                        {
+                            "not": {
+                                "anyOf": [
+                                    {
+                                        "required": [
+                                            "host"
+                                        ]
+                                    },
+                                    {
+                                        "required": [
+                                            "hosts"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "required": [
+                                "host"
+                            ]
+                        },
+                        {
+                            "required": [
+                                "hosts"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "oneOf": [
+                        {
+                            "not": {
+                                "anyOf": [
+                                    {
+                                        "required": [
+                                            "remote_addr"
+                                        ]
+                                    },
+                                    {
+                                        "required": [
+                                            "remote_addrs"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "required": [
+                                "remote_addr"
+                            ]
+                        },
+                        {
+                            "required": [
+                                "remote_addrs"
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "anyOf": [
+                {
+                    "required": [
+                        "plugins",
+                        "uri"
+                    ]
+                },
+                {
+                    "required": [
+                        "upstream",
+                        "uri"
+                    ]
+                },
+                {
+                    "required": [
+                        "upstream_id",
+                        "uri"
+                    ]
+                },
+                {
+                    "required": [
+                        "service_id",
+                        "uri"
+                    ]
+                },
+                {
+                    "required": [
+                        "plugins",
+                        "uris"
+                    ]
+                },
+                {
+                    "required": [
+                        "upstream",
+                        "uris"
+                    ]
+                },
+                {
+                    "required": [
+                        "upstream_id",
+                        "uris"
+                    ]
+                },
+                {
+                    "required": [
+                        "service_id",
+                        "uris"
+                    ]
+                },
+                {
+                    "required": [
+                        "script",
+                        "uri"
+                    ]
+                },
+                {
+                    "required": [
+                        "script",
+                        "uris"
+                    ]
+                }
+            ],
+            "not": {
+                "anyOf": [
+                    {
+                        "required": [
+                            "plugins",
+                            "script"
+                        ]
+                    }
+                ]
+            },
+            "properties": {
+                "create_time": {
+                    "type": "integer"
+                },
+                "desc": {
+                    "maxLength": 256,
+                    "type": "string"
+                },
+                "enable_websocket": {
+                    "description": "enable websocket for request",
+                    "type": "boolean"
+                },
+                "filter_func": {
+                    "minLength": 10,
+                    "pattern": "^function",
+                    "type": "string"
+                },
+                "host": {
+                    "pattern": "^\\*?[0-9a-zA-Z-._]+$",
+                    "type": "string"
+                },
+                "hosts": {
+                    "items": {
+                        "pattern": "^\\*?[0-9a-zA-Z-._]+$",
+                        "type": "string"
+                    },
+                    "minItems": 1,
+                    "type": "array",
+                    "uniqueItems": true
+                },
+                "id": {
+                    "anyOf": [
+                        {
+                            "maxLength": 64,
+                            "minLength": 1,
+                            "pattern": "^[a-zA-Z0-9-_.]+$",
+                            "type": "string"
+                        },
+                        {
+                            "minimum": 1,
+                            "type": "integer"
+                        }
+                    ]
+                },
+                "labels": {
+                    "description": "key/value pairs to specify attributes",
+                    "maxProperties": 16,
+                    "patternProperties": {
+                        ".*": {
+                            "description": "value of label",
+                            "maxLength": 64,
+                            "minLength": 1,
+                            "pattern": "^[a-zA-Z0-9-_.]+$",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "methods": {
+                    "items": {
+                        "description": "HTTP method",
+                        "enum": [
+                            "CONNECT",
+                            "DELETE",
+                            "GET",
+                            "HEAD",
+                            "OPTIONS",
+                            "PATCH",
+                            "POST",
+                            "PUT",
+                            "TRACE"
+                        ],
+                        "type": "string"
+                    },
+                    "type": "array",
+                    "uniqueItems": true
+                },
+                "name": {
+                    "maxLength": 100,
+                    "minLength": 1,
+                    "type": "string"
+                },
+                "plugins": {
+                    "type": "object"
+                },
+                "priority": {
+                    "default": 0,
+                    "type": "integer"
+                },
+                "remote_addr": {
+                    "anyOf": [
+                        {
+                            "format": "ipv4",
+                            "title": "IPv4",
+                            "type": "string"
+                        },
+                        {
+                            "pattern": "^([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])/([12]?[0-9]|3[0-2])$",
+                            "title": "IPv4/CIDR",
+                            "type": "string"
+                        },
+                        {
+                            "format": "ipv6",
+                            "title": "IPv6",
+                            "type": "string"
+                        },
+                        {
+                            "pattern": "^([a-fA-F0-9]{0,4}:){1,8}(:[a-fA-F0-9]{0,4}){0,8}([a-fA-F0-9]{0,4})?/[0-9]{1,3}$",
+                            "title": "IPv6/CIDR",
+                            "type": "string"
+                        }
+                    ],
+                    "description": "client IP",
+                    "type": "string"
+                },
+                "remote_addrs": {
+                    "items": {
+                        "anyOf": [
+                            {
+                                "format": "ipv4",
+                                "title": "IPv4",
+                                "type": "string"
+                            },
+                            {
+                                "pattern": "^([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])/([12]?[0-9]|3[0-2])$",
+                                "title": "IPv4/CIDR",
+                                "type": "string"
+                            },
+                            {
+                                "format": "ipv6",
+                                "title": "IPv6",
+                                "type": "string"
+                            },
+                            {
+                                "pattern": "^([a-fA-F0-9]{0,4}:){1,8}(:[a-fA-F0-9]{0,4}){0,8}([a-fA-F0-9]{0,4})?/[0-9]{1,3}$",
+                                "title": "IPv6/CIDR",
+                                "type": "string"
+                            }
+                        ],
+                        "description": "client IP",
+                        "type": "string"
+                    },
+                    "minItems": 1,
+                    "type": "array",
+                    "uniqueItems": true
+                },
+                "script": {
+                    "maxLength": 102400,
+                    "minLength": 10,
+                    "type": "string"
+                },
+                "script_id": {
+                    "anyOf": [
+                        {
+                            "maxLength": 64,
+                            "minLength": 1,
+                            "pattern": "^[a-zA-Z0-9-_.]+$",
+                            "type": "string"
+                        },
+                        {
+                            "minimum": 1,
+                            "type": "integer"
+                        }
+                    ]
+                },
+                "service_id": {
+                    "anyOf": [
+                        {
+                            "maxLength": 64,
+                            "minLength": 1,
+                            "pattern": "^[a-zA-Z0-9-_.]+$",
+                            "type": "string"
+                        },
+                        {
+                            "minimum": 1,
+                            "type": "integer"
+                        }
+                    ]
+                },
+                "service_protocol": {
+                    "enum": [
+                        "grpc",
+                        "http"
+                    ]
+                },
+                "status": {
+                    "default": 1,
+                    "description": "route status, 1 to enable, 0 to disable",
+                    "enum": [
+                        0,
+                        1
+                    ],
+                    "type": "integer"
+                },
+                "update_time": {
+                    "type": "integer"
+                },
+                "upstream": {
+                    "additionalProperties": false,
+                    "anyOf": [
+                        {
+                            "required": [
+                                "nodes",
+                                "type"
+                            ]
+                        },
+                        {
+                            "required": [
+                                "service_name",
+                                "type"
+                            ]
+                        }
+                    ],
+                    "properties": {
+                        "checks": {
+                            "additionalProperties": false,
+                            "anyOf": [
+                                {
+                                    "required": [
+                                        "active"
+                                    ]
+                                },
+                                {
+                                    "required": [
+                                        "active",
+                                        "passive"
+                                    ]
+                                }
+                            ],
+                            "properties": {
+                                "active": {
+                                    "properties": {
+                                        "concurrency": {
+                                            "default": 10,
+                                            "type": "integer"
+                                        },
+                                        "healthy": {
+                                            "properties": {
+                                                "http_statuses": {
+                                                    "default": [
+                                                        200,
+                                                        302
+                                                    ],
+                                                    "items": {
+                                                        "maximum": 599,
+                                                        "minimum": 200,
+                                                        "type": "integer"
+                                                    },
+                                                    "minItems": 1,
+                                                    "type": "array",
+                                                    "uniqueItems": true
+                                                },
+                                                "interval": {
+                                                    "default": 0,
+                                                    "minimum": 1,
+                                                    "type": "integer"
+                                                },
+                                                "successes": {
+                                                    "default": 2,
+                                                    "maximum": 254,
+                                                    "minimum": 1,
+                                                    "type": "integer"
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "host": {
+                                            "pattern": "^\\*?[0-9a-zA-Z-._]+$",
+                                            "type": "string"
+                                        },
+                                        "http_path": {
+                                            "default": "/",
+                                            "type": "string"
+                                        },
+                                        "https_verify_certificate": {
+                                            "default": true,
+                                            "type": "boolean"
+                                        },
+                                        "port": {
+                                            "maximum": 65535,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                        },
+                                        "req_headers": {
+                                            "items": {
+                                                "type": "string",
+                                                "uniqueItems": true
+                                            },
+                                            "minItems": 1,
+                                            "type": "array"
+                                        },
+                                        "timeout": {
+                                            "default": 1,
+                                            "type": "number"
+                                        },
+                                        "type": {
+                                            "default": "http",
+                                            "enum": [
+                                                "http",
+                                                "https",
+                                                "tcp"
+                                            ],
+                                            "type": "string"
+                                        },
+                                        "unhealthy": {
+                                            "properties": {
+                                                "http_failures": {
+                                                    "default": 5,
+                                                    "maximum": 254,
+                                                    "minimum": 1,
+                                                    "type": "integer"
+                                                },
+                                                "http_statuses": {
+                                                    "default": [
+                                                        404,
+                                                        429,
+                                                        500,
+                                                        501,
+                                                        502,
+                                                        503,
+                                                        504,
+                                                        505
+                                                    ],
+                                                    "items": {
+                                                        "maximum": 599,
+                                                        "minimum": 200,
+                                                        "type": "integer"
+                                                    },
+                                                    "minItems": 1,
+                                                    "type": "array",
+                                                    "uniqueItems": true
+                                                },
+                                                "interval": {
+                                                    "default": 0,
+                                                    "minimum": 1,
+                                                    "type": "integer"
+                                                },
+                                                "tcp_failures": {
+                                                    "default": 2,
+                                                    "maximum": 254,
+                                                    "minimum": 1,
+                                                    "type": "integer"
+                                                },
+                                                "timeouts": {
+                                                    "default": 3,
+                                                    "maximum": 254,
+                                                    "minimum": 1,
+                                                    "type": "integer"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                "passive": {
+                                    "properties": {
+                                        "healthy": {
+                                            "properties": {
+                                                "http_statuses": {
+                                                    "default": [
+                                                        200,
+                                                        201,
+                                                        202,
+                                                        203,
+                                                        204,
+                                                        205,
+                                                        206,
+                                                        207,
+                                                        208,
+                                                        226,
+                                                        300,
+                                                        301,
+                                                        302,
+                                                        303,
+                                                        304,
+                                                        305,
+                                                        306,
+                                                        307,
+                                                        308
+                                                    ],
+                                                    "items": {
+                                                        "maximum": 599,
+                                                        "minimum": 200,
+                                                        "type": "integer"
+                                                    },
+                                                    "minItems": 1,
+                                                    "type": "array",
+                                                    "uniqueItems": true
+                                                },
+                                                "successes": {
+                                                    "default": 5,
+                                                    "maximum": 254,
+                                                    "minimum": 1,
+                                                    "type": "integer"
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "type": {
+                                            "default": "http",
+                                            "enum": [
+                                                "http",
+                                                "https",
+                                                "tcp"
+                                            ],
+                                            "type": "string"
+                                        },
+                                        "unhealthy": {
+                                            "properties": {
+                                                "http_failures": {
+                                                    "default": 5,
+                                                    "maximum": 254,
+                                                    "minimum": 1,
+                                                    "type": "integer"
+                                                },
+                                                "http_statuses": {
+                                                    "default": [
+                                                        429,
+                                                        500,
+                                                        503
+                                                    ],
+                                                    "items": {
+                                                        "maximum": 599,
+                                                        "minimum": 200,
+                                                        "type": "integer"
+                                                    },
+                                                    "minItems": 1,
+                                                    "type": "array",
+                                                    "uniqueItems": true
+                                                },
+                                                "tcp_failures": {
+                                                    "default": 2,
+                                                    "maximum": 254,
+                                                    "minimum": 1,
+                                                    "type": "integer"
+                                                },
+                                                "timeouts": {
+                                                    "default": 7,
+                                                    "maximum": 254,
+                                                    "minimum": 1,
+                                                    "type": "integer"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "create_time": {
+                            "type": "integer"
+                        },
+                        "desc": {
+                            "maxLength": 256,
+                            "type": "string"
+                        },
+                        "discovery_type": {
+                            "description": "discovery type",
+                            "type": "string"
+                        },
+                        "enable_websocket": {
+                            "description": "enable websocket for request",
+                            "type": "boolean"
+                        },
+                        "hash_on": {
+                            "default": "vars",
+                            "enum": [
+                                "consumer",
+                                "cookie",
+                                "header",
+                                "vars"
+                            ],
+                            "type": "string"
+                        },
+                        "id": {
+                            "anyOf": [
+                                {
+                                    "maxLength": 64,
+                                    "minLength": 1,
+                                    "pattern": "^[a-zA-Z0-9-_.]+$",
+                                    "type": "string"
+                                },
+                                {
+                                    "minimum": 1,
+                                    "type": "integer"
+                                }
+                            ]
+                        },
+                        "key": {
+                            "description": "the key of chash for dynamic load balancing",
+                            "type": "string"
+                        },
+                        "labels": {
+                            "description": "key/value pairs to specify attributes",
+                            "maxProperties": 16,
+                            "patternProperties": {
+                                ".*": {
+                                    "description": "value of label",
+                                    "maxLength": 64,
+                                    "minLength": 1,
+                                    "pattern": "^[a-zA-Z0-9-_.]+$",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "name": {
+                            "maxLength": 100,
+                            "minLength": 1,
+                            "type": "string"
+                        },
+                        "nodes": {
+                            "anyOf": [
+                                {
+                                    "minProperties": 1,
+                                    "patternProperties": {
+                                        ".*": {
+                                            "description": "weight of node",
+                                            "minimum": 0,
+                                            "type": "integer"
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "items": {
+                                        "properties": {
+                                            "host": {
+                                                "pattern": "^\\*?[0-9a-zA-Z-._]+$",
+                                                "type": "string"
+                                            },
+                                            "metadata": {
+                                                "description": "metadata of node",
+                                                "type": "object"
+                                            },
+                                            "port": {
+                                                "description": "port of node",
+                                                "minimum": 1,
+                                                "type": "integer"
+                                            },
+                                            "weight": {
+                                                "description": "weight of node",
+                                                "minimum": 0,
+                                                "type": "integer"
+                                            }
+                                        },
+                                        "required": [
+                                            "host",
+                                            "port",
+                                            "weight"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "type": "array"
+                                }
+                            ]
+                        },
+                        "pass_host": {
+                            "default": "pass",
+                            "description": "mod of host passing",
+                            "enum": [
+                                "node",
+                                "pass",
+                                "rewrite"
+                            ],
+                            "type": "string"
+                        },
+                        "retries": {
+                            "minimum": 0,
+                            "type": "integer"
+                        },
+                        "service_name": {
+                            "maxLength": 100,
+                            "minLength": 1,
+                            "type": "string"
+                        },
+                        "timeout": {
+                            "properties": {
+                                "connect": {
+                                    "minimum": 0,
+                                    "type": "number"
+                                },
+                                "read": {
+                                    "minimum": 0,
+                                    "type": "number"
+                                },
+                                "send": {
+                                    "minimum": 0,
+                                    "type": "number"
+                                }
+                            },
+                            "required": [
+                                "connect",
+                                "read",
+                                "send"
+                            ],
+                            "type": "object"
+                        },
+                        "type": {
+                            "description": "algorithms of load balancing",
+                            "enum": [
+                                "chash",
+                                "ewma",
+                                "roundrobin"
+                            ],
+                            "type": "string"
+                        },
+                        "update_time": {
+                            "type": "integer"
+                        },
+                        "upstream_host": {
+                            "pattern": "^\\*?[0-9a-zA-Z-._]+$",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "upstream_id": {
+                    "anyOf": [
+                        {
+                            "maxLength": 64,
+                            "minLength": 1,
+                            "pattern": "^[a-zA-Z0-9-_.]+$",
+                            "type": "string"
+                        },
+                        {
+                            "minimum": 1,
+                            "type": "integer"
+                        }
+                    ]
+                },
+                "uri": {
+                    "maxLength": 4096,
+                    "minLength": 1,
+                    "type": "string"
+                },
+                "uris": {
+                    "items": {
+                        "description": "HTTP uri",
+                        "type": "string"
+                    },
+                    "minItems": 1,
+                    "type": "array",
+                    "uniqueItems": true
+                },
+                "vars": {
+                    "items": {
+                        "description": "Nginx builtin variable name and value",
+                        "maxItems": 4,
+                        "minItems": 2,
+                        "type": "array"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "service": {
+            "additionalProperties": false,
+            "properties": {
+                "create_time": {
+                    "type": "integer"
+                },
+                "desc": {
+                    "maxLength": 256,
+                    "type": "string"
+                },
+                "enable_websocket": {
+                    "description": "enable websocket for request",
+                    "type": "boolean"
+                },
+                "id": {
+                    "anyOf": [
+                        {
+                            "maxLength": 64,
+                            "minLength": 1,
+                            "pattern": "^[a-zA-Z0-9-_.]+$",
+                            "type": "string"
+                        },
+                        {
+                            "minimum": 1,
+                            "type": "integer"
+                        }
+                    ]
+                },
+                "labels": {
+                    "description": "key/value pairs to specify attributes",
+                    "maxProperties": 16,
+                    "patternProperties": {
+                        ".*": {
+                            "description": "value of label",
+                            "maxLength": 64,
+                            "minLength": 1,
+                            "pattern": "^[a-zA-Z0-9-_.]+$",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "name": {
+                    "maxLength": 100,
+                    "minLength": 1,
+                    "type": "string"
+                },
+                "plugins": {
+                    "type": "object"
+                },
+                "script": {
+                    "maxLength": 102400,
+                    "minLength": 10,
+                    "type": "string"
+                },
+                "update_time": {
+                    "type": "integer"
+                },
+                "upstream": {
+                    "additionalProperties": false,
+                    "anyOf": [
+                        {
+                            "required": [
+                                "nodes",
+                                "type"
+                            ]
+                        },
+                        {
+                            "required": [
+                                "service_name",
+                                "type"
+                            ]
+                        }
+                    ],
+                    "properties": {
+                        "checks": {
+                            "additionalProperties": false,
+                            "anyOf": [
+                                {
+                                    "required": [
+                                        "active"
+                                    ]
+                                },
+                                {
+                                    "required": [
+                                        "active",
+                                        "passive"
+                                    ]
+                                }
+                            ],
+                            "properties": {
+                                "active": {
+                                    "properties": {
+                                        "concurrency": {
+                                            "default": 10,
+                                            "type": "integer"
+                                        },
+                                        "healthy": {
+                                            "properties": {
+                                                "http_statuses": {
+                                                    "default": [
+                                                        200,
+                                                        302
+                                                    ],
+                                                    "items": {
+                                                        "maximum": 599,
+                                                        "minimum": 200,
+                                                        "type": "integer"
+                                                    },
+                                                    "minItems": 1,
+                                                    "type": "array",
+                                                    "uniqueItems": true
+                                                },
+                                                "interval": {
+                                                    "default": 0,
+                                                    "minimum": 1,
+                                                    "type": "integer"
+                                                },
+                                                "successes": {
+                                                    "default": 2,
+                                                    "maximum": 254,
+                                                    "minimum": 1,
+                                                    "type": "integer"
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "host": {
+                                            "pattern": "^\\*?[0-9a-zA-Z-._]+$",
+                                            "type": "string"
+                                        },
+                                        "http_path": {
+                                            "default": "/",
+                                            "type": "string"
+                                        },
+                                        "https_verify_certificate": {
+                                            "default": true,
+                                            "type": "boolean"
+                                        },
+                                        "port": {
+                                            "maximum": 65535,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                        },
+                                        "req_headers": {
+                                            "items": {
+                                                "type": "string",
+                                                "uniqueItems": true
+                                            },
+                                            "minItems": 1,
+                                            "type": "array"
+                                        },
+                                        "timeout": {
+                                            "default": 1,
+                                            "type": "number"
+                                        },
+                                        "type": {
+                                            "default": "http",
+                                            "enum": [
+                                                "http",
+                                                "https",
+                                                "tcp"
+                                            ],
+                                            "type": "string"
+                                        },
+                                        "unhealthy": {
+                                            "properties": {
+                                                "http_failures": {
+                                                    "default": 5,
+                                                    "maximum": 254,
+                                                    "minimum": 1,
+                                                    "type": "integer"
+                                                },
+                                                "http_statuses": {
+                                                    "default": [
+                                                        404,
+                                                        429,
+                                                        500,
+                                                        501,
+                                                        502,
+                                                        503,
+                                                        504,
+                                                        505
+                                                    ],
+                                                    "items": {
+                                                        "maximum": 599,
+                                                        "minimum": 200,
+                                                        "type": "integer"
+                                                    },
+                                                    "minItems": 1,
+                                                    "type": "array",
+                                                    "uniqueItems": true
+                                                },
+                                                "interval": {
+                                                    "default": 0,
+                                                    "minimum": 1,
+                                                    "type": "integer"
+                                                },
+                                                "tcp_failures": {
+                                                    "default": 2,
+                                                    "maximum": 254,
+                                                    "minimum": 1,
+                                                    "type": "integer"
+                                                },
+                                                "timeouts": {
+                                                    "default": 3,
+                                                    "maximum": 254,
+                                                    "minimum": 1,
+                                                    "type": "integer"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                "passive": {
+                                    "properties": {
+                                        "healthy": {
+                                            "properties": {
+                                                "http_statuses": {
+                                                    "default": [
+                                                        200,
+                                                        201,
+                                                        202,
+                                                        203,
+                                                        204,
+                                                        205,
+                                                        206,
+                                                        207,
+                                                        208,
+                                                        226,
+                                                        300,
+                                                        301,
+                                                        302,
+                                                        303,
+                                                        304,
+                                                        305,
+                                                        306,
+                                                        307,
+                                                        308
+                                                    ],
+                                                    "items": {
+                                                        "maximum": 599,
+                                                        "minimum": 200,
+                                                        "type": "integer"
+                                                    },
+                                                    "minItems": 1,
+                                                    "type": "array",
+                                                    "uniqueItems": true
+                                                },
+                                                "successes": {
+                                                    "default": 5,
+                                                    "maximum": 254,
+                                                    "minimum": 1,
+                                                    "type": "integer"
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "type": {
+                                            "default": "http",
+                                            "enum": [
+                                                "http",
+                                                "https",
+                                                "tcp"
+                                            ],
+                                            "type": "string"
+                                        },
+                                        "unhealthy": {
+                                            "properties": {
+                                                "http_failures": {
+                                                    "default": 5,
+                                                    "maximum": 254,
+                                                    "minimum": 1,
+                                                    "type": "integer"
+                                                },
+                                                "http_statuses": {
+                                                    "default": [
+                                                        429,
+                                                        500,
+                                                        503
+                                                    ],
+                                                    "items": {
+                                                        "maximum": 599,
+                                                        "minimum": 200,
+                                                        "type": "integer"
+                                                    },
+                                                    "minItems": 1,
+                                                    "type": "array",
+                                                    "uniqueItems": true
+                                                },
+                                                "tcp_failures": {
+                                                    "default": 2,
+                                                    "maximum": 254,
+                                                    "minimum": 1,
+                                                    "type": "integer"
+                                                },
+                                                "timeouts": {
+                                                    "default": 7,
+                                                    "maximum": 254,
+                                                    "minimum": 1,
+                                                    "type": "integer"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "create_time": {
+                            "type": "integer"
+                        },
+                        "desc": {
+                            "maxLength": 256,
+                            "type": "string"
+                        },
+                        "discovery_type": {
+                            "description": "discovery type",
+                            "type": "string"
+                        },
+                        "enable_websocket": {
+                            "description": "enable websocket for request",
+                            "type": "boolean"
+                        },
+                        "hash_on": {
+                            "default": "vars",
+                            "enum": [
+                                "consumer",
+                                "cookie",
+                                "header",
+                                "vars"
+                            ],
+                            "type": "string"
+                        },
+                        "id": {
+                            "anyOf": [
+                                {
+                                    "maxLength": 64,
+                                    "minLength": 1,
+                                    "pattern": "^[a-zA-Z0-9-_.]+$",
+                                    "type": "string"
+                                },
+                                {
+                                    "minimum": 1,
+                                    "type": "integer"
+                                }
+                            ]
+                        },
+                        "key": {
+                            "description": "the key of chash for dynamic load balancing",
+                            "type": "string"
+                        },
+                        "labels": {
+                            "description": "key/value pairs to specify attributes",
+                            "maxProperties": 16,
+                            "patternProperties": {
+                                ".*": {
+                                    "description": "value of label",
+                                    "maxLength": 64,
+                                    "minLength": 1,
+                                    "pattern": "^[a-zA-Z0-9-_.]+$",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "name": {
+                            "maxLength": 100,
+                            "minLength": 1,
+                            "type": "string"
+                        },
+                        "nodes": {
+                            "anyOf": [
+                                {
+                                    "minProperties": 1,
+                                    "patternProperties": {
+                                        ".*": {
+                                            "description": "weight of node",
+                                            "minimum": 0,
+                                            "type": "integer"
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "items": {
+                                        "properties": {
+                                            "host": {
+                                                "pattern": "^\\*?[0-9a-zA-Z-._]+$",
+                                                "type": "string"
+                                            },
+                                            "metadata": {
+                                                "description": "metadata of node",
+                                                "type": "object"
+                                            },
+                                            "port": {
+                                                "description": "port of node",
+                                                "minimum": 1,
+                                                "type": "integer"
+                                            },
+                                            "weight": {
+                                                "description": "weight of node",
+                                                "minimum": 0,
+                                                "type": "integer"
+                                            }
+                                        },
+                                        "required": [
+                                            "host",
+                                            "port",
+                                            "weight"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "type": "array"
+                                }
+                            ]
+                        },
+                        "pass_host": {
+                            "default": "pass",
+                            "description": "mod of host passing",
+                            "enum": [
+                                "node",
+                                "pass",
+                                "rewrite"
+                            ],
+                            "type": "string"
+                        },
+                        "retries": {
+                            "minimum": 0,
+                            "type": "integer"
+                        },
+                        "service_name": {
+                            "maxLength": 100,
+                            "minLength": 1,
+                            "type": "string"
+                        },
+                        "timeout": {
+                            "properties": {
+                                "connect": {
+                                    "minimum": 0,
+                                    "type": "number"
+                                },
+                                "read": {
+                                    "minimum": 0,
+                                    "type": "number"
+                                },
+                                "send": {
+                                    "minimum": 0,
+                                    "type": "number"
+                                }
+                            },
+                            "required": [
+                                "connect",
+                                "read",
+                                "send"
+                            ],
+                            "type": "object"
+                        },
+                        "type": {
+                            "description": "algorithms of load balancing",
+                            "enum": [
+                                "chash",
+                                "ewma",
+                                "roundrobin"
+                            ],
+                            "type": "string"
+                        },
+                        "update_time": {
+                            "type": "integer"
+                        },
+                        "upstream_host": {
+                            "pattern": "^\\*?[0-9a-zA-Z-._]+$",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "upstream_id": {
+                    "anyOf": [
+                        {
+                            "maxLength": 64,
+                            "minLength": 1,
+                            "pattern": "^[a-zA-Z0-9-_.]+$",
+                            "type": "string"
+                        },
+                        {
+                            "minimum": 1,
+                            "type": "integer"
+                        }
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "ssl": {
+            "additionalProperties": false,
+            "oneOf": [
+                {
+                    "required": [
+                        "cert",
+                        "key",
+                        "sni"
+                    ]
+                },
+                {
+                    "required": [
+                        "cert",
+                        "key",
+                        "snis"
+                    ]
+                }
+            ],
+            "properties": {
+                "cert": {
+                    "maxLength": 65536,
+                    "minLength": 128,
+                    "type": "string"
+                },
+                "certs": {
+                    "items": {
+                        "maxLength": 65536,
+                        "minLength": 128,
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "create_time": {
+                    "type": "integer"
+                },
+                "exptime": {
+                    "minimum": 1588262400,
+                    "type": "integer"
+                },
+                "id": {
+                    "anyOf": [
+                        {
+                            "maxLength": 64,
+                            "minLength": 1,
+                            "pattern": "^[a-zA-Z0-9-_.]+$",
+                            "type": "string"
+                        },
+                        {
+                            "minimum": 1,
+                            "type": "integer"
+                        }
+                    ]
+                },
+                "key": {
+                    "maxLength": 65536,
+                    "minLength": 128,
+                    "type": "string"
+                },
+                "keys": {
+                    "items": {
+                        "maxLength": 65536,
+                        "minLength": 128,
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "labels": {
+                    "description": "key/value pairs to specify attributes",
+                    "maxProperties": 16,
+                    "patternProperties": {
+                        ".*": {
+                            "description": "value of label",
+                            "maxLength": 64,
+                            "minLength": 1,
+                            "pattern": "^[a-zA-Z0-9-_.]+$",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "sni": {
+                    "pattern": "^\\*?[0-9a-zA-Z-.]+$",
+                    "type": "string"
+                },
+                "snis": {
+                    "items": {
+                        "pattern": "^\\*?[0-9a-zA-Z-.]+$",
+                        "type": "string"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                },
+                "status": {
+                    "default": 1,
+                    "description": "ssl status, 1 to enable, 0 to disable",
+                    "enum": [
+                        0,
+                        1
+                    ],
+                    "type": "integer"
+                },
+                "update_time": {
+                    "type": "integer"
+                },
+                "validity_end": {
+                    "type": "integer"
+                },
+                "validity_start": {
+                    "type": "integer"
+                }
+            },
+            "type": "object"
+        },
+        "stream_route": {
+            "properties": {
+                "id": {
+                    "anyOf": [
+                        {
+                            "maxLength": 64,
+                            "minLength": 1,
+                            "pattern": "^[a-zA-Z0-9-_.]+$",
+                            "type": "string"
+                        },
+                        {
+                            "minimum": 1,
+                            "type": "integer"
+                        }
+                    ]
+                },
+                "plugins": {
+                    "type": "object"
+                },
+                "remote_addr": {
+                    "anyOf": [
+                        {
+                            "format": "ipv4",
+                            "title": "IPv4",
+                            "type": "string"
+                        },
+                        {
+                            "pattern": "^([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])/([12]?[0-9]|3[0-2])$",
+                            "title": "IPv4/CIDR",
+                            "type": "string"
+                        },
+                        {
+                            "format": "ipv6",
+                            "title": "IPv6",
+                            "type": "string"
+                        },
+                        {
+                            "pattern": "^([a-fA-F0-9]{0,4}:){1,8}(:[a-fA-F0-9]{0,4}){0,8}([a-fA-F0-9]{0,4})?/[0-9]{1,3}$",
+                            "title": "IPv6/CIDR",
+                            "type": "string"
+                        }
+                    ],
+                    "description": "client IP",
+                    "type": "string"
+                },
+                "server_addr": {
+                    "anyOf": [
+                        {
+                            "format": "ipv4",
+                            "title": "IPv4",
+                            "type": "string"
+                        },
+                        {
+                            "pattern": "^([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])/([12]?[0-9]|3[0-2])$",
+                            "title": "IPv4/CIDR",
+                            "type": "string"
+                        },
+                        {
+                            "format": "ipv6",
+                            "title": "IPv6",
+                            "type": "string"
+                        },
+                        {
+                            "pattern": "^([a-fA-F0-9]{0,4}:){1,8}(:[a-fA-F0-9]{0,4}){0,8}([a-fA-F0-9]{0,4})?/[0-9]{1,3}$",
+                            "title": "IPv6/CIDR",
+                            "type": "string"
+                        }
+                    ],
+                    "description": "server IP",
+                    "type": "string"
+                },
+                "server_port": {
+                    "description": "server port",
+                    "type": "integer"
+                },
+                "upstream": {
+                    "additionalProperties": false,
+                    "anyOf": [
+                        {
+                            "required": [
+                                "nodes",
+                                "type"
+                            ]
+                        },
+                        {
+                            "required": [
+                                "service_name",
+                                "type"
+                            ]
+                        }
+                    ],
+                    "properties": {
+                        "checks": {
+                            "additionalProperties": false,
+                            "anyOf": [
+                                {
+                                    "required": [
+                                        "active"
+                                    ]
+                                },
+                                {
+                                    "required": [
+                                        "active",
+                                        "passive"
+                                    ]
+                                }
+                            ],
+                            "properties": {
+                                "active": {
+                                    "properties": {
+                                        "concurrency": {
+                                            "default": 10,
+                                            "type": "integer"
+                                        },
+                                        "healthy": {
+                                            "properties": {
+                                                "http_statuses": {
+                                                    "default": [
+                                                        200,
+                                                        302
+                                                    ],
+                                                    "items": {
+                                                        "maximum": 599,
+                                                        "minimum": 200,
+                                                        "type": "integer"
+                                                    },
+                                                    "minItems": 1,
+                                                    "type": "array",
+                                                    "uniqueItems": true
+                                                },
+                                                "interval": {
+                                                    "default": 0,
+                                                    "minimum": 1,
+                                                    "type": "integer"
+                                                },
+                                                "successes": {
+                                                    "default": 2,
+                                                    "maximum": 254,
+                                                    "minimum": 1,
+                                                    "type": "integer"
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "host": {
+                                            "pattern": "^\\*?[0-9a-zA-Z-._]+$",
+                                            "type": "string"
+                                        },
+                                        "http_path": {
+                                            "default": "/",
+                                            "type": "string"
+                                        },
+                                        "https_verify_certificate": {
+                                            "default": true,
+                                            "type": "boolean"
+                                        },
+                                        "port": {
+                                            "maximum": 65535,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                        },
+                                        "req_headers": {
+                                            "items": {
+                                                "type": "string",
+                                                "uniqueItems": true
+                                            },
+                                            "minItems": 1,
+                                            "type": "array"
+                                        },
+                                        "timeout": {
+                                            "default": 1,
+                                            "type": "number"
+                                        },
+                                        "type": {
+                                            "default": "http",
+                                            "enum": [
+                                                "http",
+                                                "https",
+                                                "tcp"
+                                            ],
+                                            "type": "string"
+                                        },
+                                        "unhealthy": {
+                                            "properties": {
+                                                "http_failures": {
+                                                    "default": 5,
+                                                    "maximum": 254,
+                                                    "minimum": 1,
+                                                    "type": "integer"
+                                                },
+                                                "http_statuses": {
+                                                    "default": [
+                                                        404,
+                                                        429,
+                                                        500,
+                                                        501,
+                                                        502,
+                                                        503,
+                                                        504,
+                                                        505
+                                                    ],
+                                                    "items": {
+                                                        "maximum": 599,
+                                                        "minimum": 200,
+                                                        "type": "integer"
+                                                    },
+                                                    "minItems": 1,
+                                                    "type": "array",
+                                                    "uniqueItems": true
+                                                },
+                                                "interval": {
+                                                    "default": 0,
+                                                    "minimum": 1,
+                                                    "type": "integer"
+                                                },
+                                                "tcp_failures": {
+                                                    "default": 2,
+                                                    "maximum": 254,
+                                                    "minimum": 1,
+                                                    "type": "integer"
+                                                },
+                                                "timeouts": {
+                                                    "default": 3,
+                                                    "maximum": 254,
+                                                    "minimum": 1,
+                                                    "type": "integer"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                "passive": {
+                                    "properties": {
+                                        "healthy": {
+                                            "properties": {
+                                                "http_statuses": {
+                                                    "default": [
+                                                        200,
+                                                        201,
+                                                        202,
+                                                        203,
+                                                        204,
+                                                        205,
+                                                        206,
+                                                        207,
+                                                        208,
+                                                        226,
+                                                        300,
+                                                        301,
+                                                        302,
+                                                        303,
+                                                        304,
+                                                        305,
+                                                        306,
+                                                        307,
+                                                        308
+                                                    ],
+                                                    "items": {
+                                                        "maximum": 599,
+                                                        "minimum": 200,
+                                                        "type": "integer"
+                                                    },
+                                                    "minItems": 1,
+                                                    "type": "array",
+                                                    "uniqueItems": true
+                                                },
+                                                "successes": {
+                                                    "default": 5,
+                                                    "maximum": 254,
+                                                    "minimum": 1,
+                                                    "type": "integer"
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "type": {
+                                            "default": "http",
+                                            "enum": [
+                                                "http",
+                                                "https",
+                                                "tcp"
+                                            ],
+                                            "type": "string"
+                                        },
+                                        "unhealthy": {
+                                            "properties": {
+                                                "http_failures": {
+                                                    "default": 5,
+                                                    "maximum": 254,
+                                                    "minimum": 1,
+                                                    "type": "integer"
+                                                },
+                                                "http_statuses": {
+                                                    "default": [
+                                                        429,
+                                                        500,
+                                                        503
+                                                    ],
+                                                    "items": {
+                                                        "maximum": 599,
+                                                        "minimum": 200,
+                                                        "type": "integer"
+                                                    },
+                                                    "minItems": 1,
+                                                    "type": "array",
+                                                    "uniqueItems": true
+                                                },
+                                                "tcp_failures": {
+                                                    "default": 2,
+                                                    "maximum": 254,
+                                                    "minimum": 1,
+                                                    "type": "integer"
+                                                },
+                                                "timeouts": {
+                                                    "default": 7,
+                                                    "maximum": 254,
+                                                    "minimum": 1,
+                                                    "type": "integer"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "create_time": {
+                            "type": "integer"
+                        },
+                        "desc": {
+                            "maxLength": 256,
+                            "type": "string"
+                        },
+                        "discovery_type": {
+                            "description": "discovery type",
+                            "type": "string"
+                        },
+                        "enable_websocket": {
+                            "description": "enable websocket for request",
+                            "type": "boolean"
+                        },
+                        "hash_on": {
+                            "default": "vars",
+                            "enum": [
+                                "consumer",
+                                "cookie",
+                                "header",
+                                "vars"
+                            ],
+                            "type": "string"
+                        },
+                        "id": {
+                            "anyOf": [
+                                {
+                                    "maxLength": 64,
+                                    "minLength": 1,
+                                    "pattern": "^[a-zA-Z0-9-_.]+$",
+                                    "type": "string"
+                                },
+                                {
+                                    "minimum": 1,
+                                    "type": "integer"
+                                }
+                            ]
+                        },
+                        "key": {
+                            "description": "the key of chash for dynamic load balancing",
+                            "type": "string"
+                        },
+                        "labels": {
+                            "description": "key/value pairs to specify attributes",
+                            "maxProperties": 16,
+                            "patternProperties": {
+                                ".*": {
+                                    "description": "value of label",
+                                    "maxLength": 64,
+                                    "minLength": 1,
+                                    "pattern": "^[a-zA-Z0-9-_.]+$",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "name": {
+                            "maxLength": 100,
+                            "minLength": 1,
+                            "type": "string"
+                        },
+                        "nodes": {
+                            "anyOf": [
+                                {
+                                    "minProperties": 1,
+                                    "patternProperties": {
+                                        ".*": {
+                                            "description": "weight of node",
+                                            "minimum": 0,
+                                            "type": "integer"
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "items": {
+                                        "properties": {
+                                            "host": {
+                                                "pattern": "^\\*?[0-9a-zA-Z-._]+$",
+                                                "type": "string"
+                                            },
+                                            "metadata": {
+                                                "description": "metadata of node",
+                                                "type": "object"
+                                            },
+                                            "port": {
+                                                "description": "port of node",
+                                                "minimum": 1,
+                                                "type": "integer"
+                                            },
+                                            "weight": {
+                                                "description": "weight of node",
+                                                "minimum": 0,
+                                                "type": "integer"
+                                            }
+                                        },
+                                        "required": [
+                                            "host",
+                                            "port",
+                                            "weight"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "type": "array"
+                                }
+                            ]
+                        },
+                        "pass_host": {
+                            "default": "pass",
+                            "description": "mod of host passing",
+                            "enum": [
+                                "node",
+                                "pass",
+                                "rewrite"
+                            ],
+                            "type": "string"
+                        },
+                        "retries": {
+                            "minimum": 0,
+                            "type": "integer"
+                        },
+                        "service_name": {
+                            "maxLength": 100,
+                            "minLength": 1,
+                            "type": "string"
+                        },
+                        "timeout": {
+                            "properties": {
+                                "connect": {
+                                    "minimum": 0,
+                                    "type": "number"
+                                },
+                                "read": {
+                                    "minimum": 0,
+                                    "type": "number"
+                                },
+                                "send": {
+                                    "minimum": 0,
+                                    "type": "number"
+                                }
+                            },
+                            "required": [
+                                "connect",
+                                "read",
+                                "send"
+                            ],
+                            "type": "object"
+                        },
+                        "type": {
+                            "description": "algorithms of load balancing",
+                            "enum": [
+                                "chash",
+                                "ewma",
+                                "roundrobin"
+                            ],
+                            "type": "string"
+                        },
+                        "update_time": {
+                            "type": "integer"
+                        },
+                        "upstream_host": {
+                            "pattern": "^\\*?[0-9a-zA-Z-._]+$",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "upstream_id": {
+                    "anyOf": [
+                        {
+                            "maxLength": 64,
+                            "minLength": 1,
+                            "pattern": "^[a-zA-Z0-9-_.]+$",
+                            "type": "string"
+                        },
+                        {
+                            "minimum": 1,
+                            "type": "integer"
+                        }
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "upstream": {
+            "additionalProperties": false,
+            "anyOf": [
+                {
+                    "required": [
+                        "nodes",
+                        "type"
+                    ]
+                },
+                {
+                    "required": [
+                        "service_name",
+                        "type"
+                    ]
+                }
+            ],
+            "properties": {
+                "checks": {
+                    "additionalProperties": false,
+                    "anyOf": [
+                        {
+                            "required": [
+                                "active"
+                            ]
+                        },
+                        {
+                            "required": [
+                                "active",
+                                "passive"
+                            ]
+                        }
+                    ],
+                    "properties": {
+                        "active": {
+                            "properties": {
+                                "concurrency": {
+                                    "default": 10,
+                                    "type": "integer"
+                                },
+                                "healthy": {
+                                    "properties": {
+                                        "http_statuses": {
+                                            "default": [
+                                                200,
+                                                302
+                                            ],
+                                            "items": {
+                                                "maximum": 599,
+                                                "minimum": 200,
+                                                "type": "integer"
+                                            },
+                                            "minItems": 1,
+                                            "type": "array",
+                                            "uniqueItems": true
+                                        },
+                                        "interval": {
+                                            "default": 0,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                        },
+                                        "successes": {
+                                            "default": 2,
+                                            "maximum": 254,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                "host": {
+                                    "pattern": "^\\*?[0-9a-zA-Z-._]+$",
+                                    "type": "string"
+                                },
+                                "http_path": {
+                                    "default": "/",
+                                    "type": "string"
+                                },
+                                "https_verify_certificate": {
+                                    "default": true,
+                                    "type": "boolean"
+                                },
+                                "port": {
+                                    "maximum": 65535,
+                                    "minimum": 1,
+                                    "type": "integer"
+                                },
+                                "req_headers": {
+                                    "items": {
+                                        "type": "string",
+                                        "uniqueItems": true
+                                    },
+                                    "minItems": 1,
+                                    "type": "array"
+                                },
+                                "timeout": {
+                                    "default": 1,
+                                    "type": "number"
+                                },
+                                "type": {
+                                    "default": "http",
+                                    "enum": [
+                                        "http",
+                                        "https",
+                                        "tcp"
+                                    ],
+                                    "type": "string"
+                                },
+                                "unhealthy": {
+                                    "properties": {
+                                        "http_failures": {
+                                            "default": 5,
+                                            "maximum": 254,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                        },
+                                        "http_statuses": {
+                                            "default": [
+                                                404,
+                                                429,
+                                                500,
+                                                501,
+                                                502,
+                                                503,
+                                                504,
+                                                505
+                                            ],
+                                            "items": {
+                                                "maximum": 599,
+                                                "minimum": 200,
+                                                "type": "integer"
+                                            },
+                                            "minItems": 1,
+                                            "type": "array",
+                                            "uniqueItems": true
+                                        },
+                                        "interval": {
+                                            "default": 0,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                        },
+                                        "tcp_failures": {
+                                            "default": 2,
+                                            "maximum": 254,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                        },
+                                        "timeouts": {
+                                            "default": 3,
+                                            "maximum": 254,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "passive": {
+                            "properties": {
+                                "healthy": {
+                                    "properties": {
+                                        "http_statuses": {
+                                            "default": [
+                                                200,
+                                                201,
+                                                202,
+                                                203,
+                                                204,
+                                                205,
+                                                206,
+                                                207,
+                                                208,
+                                                226,
+                                                300,
+                                                301,
+                                                302,
+                                                303,
+                                                304,
+                                                305,
+                                                306,
+                                                307,
+                                                308
+                                            ],
+                                            "items": {
+                                                "maximum": 599,
+                                                "minimum": 200,
+                                                "type": "integer"
+                                            },
+                                            "minItems": 1,
+                                            "type": "array",
+                                            "uniqueItems": true
+                                        },
+                                        "successes": {
+                                            "default": 5,
+                                            "maximum": 254,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                "type": {
+                                    "default": "http",
+                                    "enum": [
+                                        "http",
+                                        "https",
+                                        "tcp"
+                                    ],
+                                    "type": "string"
+                                },
+                                "unhealthy": {
+                                    "properties": {
+                                        "http_failures": {
+                                            "default": 5,
+                                            "maximum": 254,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                        },
+                                        "http_statuses": {
+                                            "default": [
+                                                429,
+                                                500,
+                                                503
+                                            ],
+                                            "items": {
+                                                "maximum": 599,
+                                                "minimum": 200,
+                                                "type": "integer"
+                                            },
+                                            "minItems": 1,
+                                            "type": "array",
+                                            "uniqueItems": true
+                                        },
+                                        "tcp_failures": {
+                                            "default": 2,
+                                            "maximum": 254,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                        },
+                                        "timeouts": {
+                                            "default": 7,
+                                            "maximum": 254,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
+                },
+                "create_time": {
+                    "type": "integer"
+                },
+                "desc": {
+                    "maxLength": 256,
+                    "type": "string"
+                },
+                "discovery_type": {
+                    "description": "discovery type",
+                    "type": "string"
+                },
+                "enable_websocket": {
+                    "description": "enable websocket for request",
+                    "type": "boolean"
+                },
+                "hash_on": {
+                    "default": "vars",
+                    "enum": [
+                        "consumer",
+                        "cookie",
+                        "header",
+                        "vars"
+                    ],
+                    "type": "string"
+                },
+                "id": {
+                    "anyOf": [
+                        {
+                            "maxLength": 64,
+                            "minLength": 1,
+                            "pattern": "^[a-zA-Z0-9-_.]+$",
+                            "type": "string"
+                        },
+                        {
+                            "minimum": 1,
+                            "type": "integer"
+                        }
+                    ]
+                },
+                "key": {
+                    "description": "the key of chash for dynamic load balancing",
+                    "type": "string"
+                },
+                "labels": {
+                    "description": "key/value pairs to specify attributes",
+                    "maxProperties": 16,
+                    "patternProperties": {
+                        ".*": {
+                            "description": "value of label",
+                            "maxLength": 64,
+                            "minLength": 1,
+                            "pattern": "^[a-zA-Z0-9-_.]+$",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "name": {
+                    "maxLength": 100,
+                    "minLength": 1,
+                    "type": "string"
+                },
+                "nodes": {
+                    "anyOf": [
+                        {
+                            "minProperties": 1,
+                            "patternProperties": {
+                                ".*": {
+                                    "description": "weight of node",
+                                    "minimum": 0,
+                                    "type": "integer"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        {
+                            "items": {
+                                "properties": {
+                                    "host": {
+                                        "pattern": "^\\*?[0-9a-zA-Z-._]+$",
+                                        "type": "string"
+                                    },
+                                    "metadata": {
+                                        "description": "metadata of node",
+                                        "type": "object"
+                                    },
+                                    "port": {
+                                        "description": "port of node",
+                                        "minimum": 1,
+                                        "type": "integer"
+                                    },
+                                    "weight": {
+                                        "description": "weight of node",
+                                        "minimum": 0,
+                                        "type": "integer"
+                                    }
+                                },
+                                "required": [
+                                    "host",
+                                    "port",
+                                    "weight"
+                                ],
+                                "type": "object"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "pass_host": {
+                    "default": "pass",
+                    "description": "mod of host passing",
+                    "enum": [
+                        "node",
+                        "pass",
+                        "rewrite"
+                    ],
+                    "type": "string"
+                },
+                "retries": {
+                    "minimum": 0,
+                    "type": "integer"
+                },
+                "service_name": {
+                    "maxLength": 100,
+                    "minLength": 1,
+                    "type": "string"
+                },
+                "timeout": {
+                    "properties": {
+                        "connect": {
+                            "minimum": 0,
+                            "type": "number"
+                        },
+                        "read": {
+                            "minimum": 0,
+                            "type": "number"
+                        },
+                        "send": {
+                            "minimum": 0,
+                            "type": "number"
+                        }
+                    },
+                    "required": [
+                        "connect",
+                        "read",
+                        "send"
+                    ],
+                    "type": "object"
+                },
+                "type": {
+                    "description": "algorithms of load balancing",
+                    "enum": [
+                        "chash",
+                        "ewma",
+                        "roundrobin"
+                    ],
+                    "type": "string"
+                },
+                "update_time": {
+                    "type": "integer"
+                },
+                "upstream_host": {
+                    "pattern": "^\\*?[0-9a-zA-Z-._]+$",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "upstream_hash_header_schema": {
+            "pattern": "^[a-zA-Z0-9-_]+$",
+            "type": "string"
+        },
+        "upstream_hash_vars_schema": {
+            "pattern": "^((uri|server_name|server_addr|request_uri|remote_port|remote_addr|query_string|host|hostname)|arg_[0-9a-zA-z_-]+)$",
+            "type": "string"
+        }
+    },
+    "plugins": {
+        "api-breaker": {
+            "priority": 1005,
+            "schema": {
+                "properties": {
+                    "break_response_code": {
+                        "maximum": 599,
+                        "minimum": 200,
+                        "type": "integer"
+                    },
+                    "healthy": {
+                        "default": {
+                            "http_statuses": [
+                                200
+                            ],
+                            "successes": 3
+                        },
+                        "properties": {
+                            "http_statuses": {
+                                "default": [
+                                    200
+                                ],
+                                "items": {
+                                    "maximum": 499,
+                                    "minimum": 200,
+                                    "type": "integer"
+                                },
+                                "minItems": 1,
+                                "type": "array",
+                                "uniqueItems": true
+                            },
+                            "successes": {
+                                "default": 3,
+                                "minimum": 1,
+                                "type": "integer"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "max_breaker_sec": {
+                        "default": 300,
+                        "minimum": 3,
+                        "type": "integer"
+                    },
+                    "unhealthy": {
+                        "default": {
+                            "failures": 3,
+                            "http_statuses": [
+                                500
+                            ]
+                        },
+                        "properties": {
+                            "failures": {
+                                "default": 3,
+                                "minimum": 1,
+                                "type": "integer"
+                            },
+                            "http_statuses": {
+                                "default": [
+                                    500
+                                ],
+                                "items": {
+                                    "maximum": 599,
+                                    "minimum": 500,
+                                    "type": "integer"
+                                },
+                                "minItems": 1,
+                                "type": "array",
+                                "uniqueItems": true
+                            }
+                        },
+                        "type": "object"
+                    }
+                },
+                "required": [
+                    "break_response_code"
+                ],
+                "type": "object"
+            },
+            "version": 0.1
+        },
+        "authz-keycloak": {
+            "priority": 2000,
+            "schema": {
+                "properties": {
+                    "audience": {
+                        "maxLength": 100,
+                        "minLength": 1,
+                        "type": "string"
+                    },
+                    "grant_type": {
+                        "default": "urn:ietf:params:oauth:grant-type:uma-ticket",
+                        "enum": [
+                            "urn:ietf:params:oauth:grant-type:uma-ticket"
+                        ],
+                        "maxLength": 100,
+                        "minLength": 1,
+                        "type": "string"
+                    },
+                    "keepalive": {
+                        "default": true,
+                        "type": "boolean"
+                    },
+                    "keepalive_pool": {
+                        "default": 5,
+                        "minimum": 1,
+                        "type": "integer"
+                    },
+                    "keepalive_timeout": {
+                        "default": 60000,
+                        "minimum": 1000,
+                        "type": "integer"
+                    },
+                    "permissions": {
+                        "items": {
+                            "maxLength": 100,
+                            "minLength": 1,
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "uniqueItems": true
+                    },
+                    "policy_enforcement_mode": {
+                        "default": "ENFORCING",
+                        "enum": [
+                            "ENFORCING",
+                            "PERMISSIVE"
+                        ],
+                        "type": "string"
+                    },
+                    "ssl_verify": {
+                        "default": true,
+                        "type": "boolean"
+                    },
+                    "timeout": {
+                        "default": 3000,
+                        "minimum": 1000,
+                        "type": "integer"
+                    },
+                    "token_endpoint": {
+                        "maxLength": 4096,
+                        "minLength": 1,
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "token_endpoint"
+                ],
+                "type": "object"
+            },
+            "version": 0.1
+        },
+        "basic-auth": {
+            "consumer_schema": {
+                "additionalProperties": false,
+                "properties": {
+                    "password": {
+                        "type": "string"
+                    },
+                    "username": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "password",
+                    "username"
+                ],
+                "title": "work with consumer object",
+                "type": "object"
+            },
+            "priority": 2520,
+            "schema": {
+                "additionalProperties": false,
+                "properties": {
+                    "disable": {
+                        "type": "boolean"
+                    }
+                },
+                "title": "work with route or service object",
+                "type": "object"
+            },
+            "type": "auth",
+            "version": 0.1
+        },
+        "batch-requests": {
+            "metadata_schema": {
+                "additionalProperties": false,
+                "properties": {
+                    "max_body_size": {
+                        "default": 1048576,
+                        "description": "max pipeline body size in bytes",
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                    }
+                },
+                "type": "object"
+            },
+            "priority": 4010,
+            "schema": {
+                "additionalProperties": false,
+                "properties": {
+                    "disable": {
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "version": 0.1
+        },
+        "consumer-restriction": {
+            "priority": 2400,
+            "schema": {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "blacklist": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "minItems": 1,
+                                "type": "array"
+                            },
+                            "rejected_code": {
+                                "default": 403,
+                                "minimum": 200,
+                                "type": "integer"
+                            },
+                            "type": {
+                                "default": "consumer_name",
+                                "enum": [
+                                    "consumer_name",
+                                    "service_id"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "blacklist"
+                        ],
+                        "title": "blacklist"
+                    },
+                    {
+                        "properties": {
+                            "rejected_code": {
+                                "default": 403,
+                                "minimum": 200,
+                                "type": "integer"
+                            },
+                            "type": {
+                                "default": "consumer_name",
+                                "enum": [
+                                    "consumer_name",
+                                    "service_id"
+                                ],
+                                "type": "string"
+                            },
+                            "whitelist": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "minItems": 1,
+                                "type": "array"
+                            }
+                        },
+                        "required": [
+                            "whitelist"
+                        ],
+                        "title": "whitelist"
+                    }
+                ],
+                "properties": {
+                    "disable": {
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "version": 0.1
+        },
+        "cors": {
+            "priority": 4000,
+            "schema": {
+                "properties": {
+                    "allow_credential": {
+                        "default": false,
+                        "description": "allow client append credential. according to CORS specification,if you set this option to 'true', you can not use '*' for other options.",
+                        "type": "boolean"
+                    },
+                    "allow_headers": {
+                        "default": "*",
+                        "description": "you can use '*' to allow all header when no credentials,'**' to allow forcefully(it will bring some security risks, be carefully),multiple header use ',' to split. default: *.",
+                        "type": "string"
+                    },
+                    "allow_methods": {
+                        "default": "*",
+                        "description": "you can use '*' to allow all methods when no credentials and '**','**' to allow forcefully(it will bring some security risks, be carefully),multiple method use ',' to split. default: *.",
+                        "type": "string"
+                    },
+                    "allow_origins": {
+                        "default": "*",
+                        "description": "you can use '*' to allow all origins when no credentials,'**' to allow forcefully(it will bring some security risks, be carefully),multiple origin use ',' to split. default: *.",
+                        "type": "string"
+                    },
+                    "expose_headers": {
+                        "default": "*",
+                        "description": "you can use '*' to expose all header when no credentials,multiple header use ',' to split. default: *.",
+                        "type": "string"
+                    },
+                    "max_age": {
+                        "default": 5,
+                        "description": "maximum number of seconds the results can be cached.-1 mean no cached,the max value is depend on browser,more detail plz check MDN. default: 5.",
+                        "type": "integer"
+                    }
+                },
+                "type": "object"
+            },
+            "version": 0.1
+        },
+        "echo": {
+            "priority": 412,
+            "schema": {
+                "additionalProperties": false,
+                "anyOf": [
+                    {
+                        "required": [
+                            "before_body"
+                        ]
+                    },
+                    {
+                        "required": [
+                            "body"
+                        ]
+                    },
+                    {
+                        "required": [
+                            "after_body"
+                        ]
+                    }
+                ],
+                "minProperties": 1,
+                "properties": {
+                    "after_body": {
+                        "description": "body after the modification of filter phase.",
+                        "type": "string"
+                    },
+                    "auth_value": {
+                        "description": "auth value",
+                        "type": "string"
+                    },
+                    "before_body": {
+                        "description": "body before the filter phase.",
+                        "type": "string"
+                    },
+                    "body": {
+                        "description": "body to replace upstream response.",
+                        "type": "string"
+                    },
+                    "headers": {
+                        "description": "new headers for response",
+                        "minProperties": 1,
+                        "type": "object"
+                    }
+                },
+                "type": "object"
+            },
+            "version": 0.1
+        },
+        "fault-injection": {
+            "priority": 11000,
+            "schema": {
+                "minProperties": 1,
+                "properties": {
+                    "abort": {
+                        "properties": {
+                            "body": {
+                                "minLength": 0,
+                                "type": "string"
+                            },
+                            "http_status": {
+                                "minimum": 200,
+                                "type": "integer"
+                            },
+                            "percentage": {
+                                "maximum": 100,
+                                "minimum": 0,
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "http_status"
+                        ],
+                        "type": "object"
+                    },
+                    "delay": {
+                        "properties": {
+                            "duration": {
+                                "minimum": 0,
+                                "type": "number"
+                            },
+                            "percentage": {
+                                "maximum": 100,
+                                "minimum": 0,
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "duration"
+                        ],
+                        "type": "object"
+                    }
+                },
+                "type": "object"
+            },
+            "version": 0.1
+        },
+        "grpc-transcode": {
+            "priority": 506,
+            "schema": {
+                "additionalProperties": true,
+                "properties": {
+                    "deadline": {
+                        "default": 0,
+                        "description": "deadline for grpc, millisecond",
+                        "type": "number"
+                    },
+                    "method": {
+                        "description": "the method name in the grpc service.",
+                        "type": "string"
+                    },
+                    "pb_option": {
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "description": "enum as result",
+                                    "enum": [
+                                        "int64_as_hexstring",
+                                        "int64_as_number",
+                                        "int64_as_string"
+                                    ],
+                                    "type": "string"
+                                },
+                                {
+                                    "description": "int64 as result",
+                                    "enum": [
+                                        "enum_as_value",
+                                        "ienum_as_name"
+                                    ],
+                                    "type": "string"
+                                },
+                                {
+                                    "description": "default values option",
+                                    "enum": [
+                                        "auto_default_values",
+                                        "no_default_values",
+                                        "use_default_metatable",
+                                        "use_default_values"
+                                    ],
+                                    "type": "string"
+                                },
+                                {
+                                    "description": "hooks option",
+                                    "enum": [
+                                        "disable_hooks",
+                                        "enable_hooks"
+                                    ],
+                                    "type": "string"
+                                }
+                            ],
+                            "type": "string"
+                        },
+                        "minItems": 1,
+                        "type": "array"
+                    },
+                    "proto_id": {
+                        "anyOf": [
+                            {
+                                "maxLength": 64,
+                                "minLength": 1,
+                                "pattern": "^[a-zA-Z0-9-_.]+$",
+                                "type": "string"
+                            },
+                            {
+                                "minimum": 1,
+                                "type": "integer"
+                            }
+                        ]
+                    },
+                    "service": {
+                        "description": "the grpc service name",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "method",
+                    "proto_id",
+                    "service"
+                ],
+                "type": "object"
+            },
+            "version": 0.1
+        },
+        "hmac-auth": {
+            "consumer_schema": {
+                "additionalProperties": false,
+                "properties": {
+                    "access_key": {
+                        "maxLength": 256,
+                        "minLength": 1,
+                        "type": "string"
+                    },
+                    "algorithm": {
+                        "default": "hmac-sha256",
+                        "enum": [
+                            "hmac-sha1",
+                            "hmac-sha256",
+                            "hmac-sha512"
+                        ],
+                        "type": "string"
+                    },
+                    "clock_skew": {
+                        "default": 0,
+                        "type": "integer"
+                    },
+                    "encode_uri_params": {
+                        "default": true,
+                        "title": "Whether to escape the uri parameter",
+                        "type": "boolean"
+                    },
+                    "keep_headers": {
+                        "default": false,
+                        "title": "whether to keep the http request header",
+                        "type": "boolean"
+                    },
+                    "secret_key": {
+                        "maxLength": 256,
+                        "minLength": 1,
+                        "type": "string"
+                    },
+                    "signed_headers": {
+                        "items": {
+                            "maxLength": 50,
+                            "minLength": 1,
+                            "type": "string"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": [
+                    "access_key",
+                    "secret_key"
+                ],
+                "title": "work with consumer object",
+                "type": "object"
+            },
+            "priority": 2530,
+            "schema": {
+                "additionalProperties": false,
+                "properties": {
+                    "disable": {
+                        "type": "boolean"
+                    }
+                },
+                "title": "work with route or service object",
+                "type": "object"
+            },
+            "type": "auth",
+            "version": 0.1
+        },
+        "http-logger": {
+            "metadata_schema": {
+                "additionalProperties": false,
+                "properties": {
+                    "log_format": {
+                        "default": {
+                            "@timestamp": "$time_iso8601",
+                            "client_ip": "$remote_addr",
+                            "host": "$host"
+                        },
+                        "type": "object"
+                    }
+                },
+                "type": "object"
+            },
+            "priority": 410,
+            "schema": {
+                "properties": {
+                    "auth_header": {
+                        "default": "",
+                        "type": "string"
+                    },
+                    "batch_max_size": {
+                        "default": 1000,
+                        "minimum": 1,
+                        "type": "integer"
+                    },
+                    "buffer_duration": {
+                        "default": 60,
+                        "minimum": 1,
+                        "type": "integer"
+                    },
+                    "concat_method": {
+                        "default": "json",
+                        "enum": [
+                            "json",
+                            "new_line"
+                        ],
+                        "type": "string"
+                    },
+                    "inactive_timeout": {
+                        "default": 5,
+                        "minimum": 1,
+                        "type": "integer"
+                    },
+                    "include_req_body": {
+                        "default": false,
+                        "type": "boolean"
+                    },
+                    "max_retry_count": {
+                        "default": 0,
+                        "minimum": 0,
+                        "type": "integer"
+                    },
+                    "name": {
+                        "default": "http logger",
+                        "type": "string"
+                    },
+                    "retry_delay": {
+                        "default": 1,
+                        "minimum": 0,
+                        "type": "integer"
+                    },
+                    "timeout": {
+                        "default": 3,
+                        "minimum": 1,
+                        "type": "integer"
+                    },
+                    "uri": {
+                        "pattern": "^[^\\/]+:\\/\\/([\\da-zA-Z.-]+|\\[[\\da-fA-F:]+\\])(:\\d+)?",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "uri"
+                ],
+                "type": "object"
+            },
+            "version": 0.1
+        },
+        "ip-restriction": {
+            "priority": 3000,
+            "schema": {
+                "oneOf": [
+                    {
+                        "additionalProperties": false,
+                        "properties": {
+                            "whitelist": {
+                                "items": {
+                                    "anyOf": [
+                                        {
+                                            "format": "ipv4",
+                                            "title": "IPv4",
+                                            "type": "string"
+                                        },
+                                        {
+                                            "pattern": "^([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])/([12]?[0-9]|3[0-2])$",
+                                            "title": "IPv4/CIDR",
+                                            "type": "string"
+                                        },
+                                        {
+                                            "format": "ipv6",
+                                            "title": "IPv6",
+                                            "type": "string"
+                                        },
+                                        {
+                                            "pattern": "^([a-fA-F0-9]{0,4}:){1,8}(:[a-fA-F0-9]{0,4}){0,8}([a-fA-F0-9]{0,4})?/[0-9]{1,3}$",
+                                            "title": "IPv6/CIDR",
+                                            "type": "string"
+                                        }
+                                    ]
+                                },
+                                "minItems": 1,
+                                "type": "array"
+                            }
+                        },
+                        "required": [
+                            "whitelist"
+                        ],
+                        "title": "whitelist"
+                    },
+                    {
+                        "additionalProperties": false,
+                        "properties": {
+                            "blacklist": {
+                                "items": {
+                                    "anyOf": [
+                                        {
+                                            "format": "ipv4",
+                                            "title": "IPv4",
+                                            "type": "string"
+                                        },
+                                        {
+                                            "pattern": "^([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])/([12]?[0-9]|3[0-2])$",
+                                            "title": "IPv4/CIDR",
+                                            "type": "string"
+                                        },
+                                        {
+                                            "format": "ipv6",
+                                            "title": "IPv6",
+                                            "type": "string"
+                                        },
+                                        {
+                                            "pattern": "^([a-fA-F0-9]{0,4}:){1,8}(:[a-fA-F0-9]{0,4}){0,8}([a-fA-F0-9]{0,4})?/[0-9]{1,3}$",
+                                            "title": "IPv6/CIDR",
+                                            "type": "string"
+                                        }
+                                    ]
+                                },
+                                "minItems": 1,
+                                "type": "array"
+                            }
+                        },
+                        "required": [
+                            "blacklist"
+                        ],
+                        "title": "blacklist"
+                    }
+                ],
+                "properties": {
+                    "disable": {
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "version": 0.1
+        },
+        "jwt-auth": {
+            "consumer_schema": {
+                "dependencies": {
+                    "algorithm": {
+                        "oneOf": [
+                            {
+                                "properties": {
+                                    "algorithm": {
+                                        "default": "HS256",
+                                        "enum": [
+                                            "HS256",
+                                            "HS512"
+                                        ]
+                                    }
+                                }
+                            },
+                            {
+                                "properties": {
+                                    "algorithm": {
+                                        "enum": [
+                                            "RS256"
+                                        ]
+                                    },
+                                    "private_key": {
+                                        "type": "string"
+                                    },
+                                    "public_key": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "private_key",
+                                    "public_key"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "properties": {
+                    "algorithm": {
+                        "default": "HS256",
+                        "enum": [
+                            "HS256",
+                            "HS512",
+                            "RS256"
+                        ],
+                        "type": "string"
+                    },
+                    "base64_secret": {
+                        "default": false,
+                        "type": "boolean"
+                    },
+                    "exp": {
+                        "default": 86400,
+                        "minimum": 1,
+                        "type": "integer"
+                    },
+                    "key": {
+                        "type": "string"
+                    },
+                    "secret": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "key"
+                ],
+                "type": "object"
+            },
+            "priority": 2510,
+            "schema": {
+                "additionalProperties": false,
+                "properties": {
+                    "disable": {
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "type": "auth",
+            "version": 0.1
+        },
+        "kafka-logger": {
+            "priority": 403,
+            "schema": {
+                "properties": {
+                    "batch_max_size": {
+                        "default": 1000,
+                        "minimum": 1,
+                        "type": "integer"
+                    },
+                    "broker_list": {
+                        "type": "object"
+                    },
+                    "buffer_duration": {
+                        "default": 60,
+                        "minimum": 1,
+                        "type": "integer"
+                    },
+                    "inactive_timeout": {
+                        "default": 5,
+                        "minimum": 1,
+                        "type": "integer"
+                    },
+                    "include_req_body": {
+                        "default": false,
+                        "type": "boolean"
+                    },
+                    "kafka_topic": {
+                        "type": "string"
+                    },
+                    "key": {
+                        "type": "string"
+                    },
+                    "max_retry_count": {
+                        "default": 0,
+                        "minimum": 0,
+                        "type": "integer"
+                    },
+                    "meta_format": {
+                        "default": "default",
+                        "enum": [
+                            "default",
+                            "origin"
+                        ],
+                        "type": "string"
+                    },
+                    "name": {
+                        "default": "kafka logger",
+                        "type": "string"
+                    },
+                    "retry_delay": {
+                        "default": 1,
+                        "minimum": 0,
+                        "type": "integer"
+                    },
+                    "timeout": {
+                        "default": 3,
+                        "minimum": 1,
+                        "type": "integer"
+                    }
+                },
+                "required": [
+                    "broker_list",
+                    "kafka_topic"
+                ],
+                "type": "object"
+            },
+            "version": 0.1
+        },
+        "key-auth": {
+            "consumer_schema": {
+                "additionalProperties": false,
+                "properties": {
+                    "key": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "key"
+                ],
+                "type": "object"
+            },
+            "priority": 2500,
+            "schema": {
+                "additionalProperties": false,
+                "properties": {
+                    "disable": {
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "type": "auth",
+            "version": 0.1
+        },
+        "limit-conn": {
+            "priority": 1003,
+            "schema": {
+                "properties": {
+                    "burst": {
+                        "minimum": 0,
+                        "type": "integer"
+                    },
+                    "conn": {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                    },
+                    "default_conn_delay": {
+                        "exclusiveMinimum": 0,
+                        "type": "number"
+                    },
+                    "key": {
+                        "enum": [
+                            "consumer_name",
+                            "http_x_forwarded_for",
+                            "http_x_real_ip",
+                            "remote_addr",
+                            "server_addr"
+                        ],
+                        "type": "string"
+                    },
+                    "rejected_code": {
+                        "default": 503,
+                        "minimum": 200,
+                        "type": "integer"
+                    }
+                },
+                "required": [
+                    "burst",
+                    "conn",
+                    "default_conn_delay",
+                    "key"
+                ],
+                "type": "object"
+            },
+            "version": 0.1
+        },
+        "limit-count": {
+            "priority": 1002,
+            "schema": {
+                "dependencies": {
+                    "policy": {
+                        "oneOf": [
+                            {
+                                "properties": {
+                                    "policy": {
+                                        "enum": [
+                                            "local"
+                                        ]
+                                    }
+                                }
+                            },
+                            {
+                                "properties": {
+                                    "policy": {
+                                        "enum": [
+                                            "redis"
+                                        ]
+                                    },
+                                    "redis_host": {
+                                        "minLength": 2,
+                                        "type": "string"
+                                    },
+                                    "redis_password": {
+                                        "minLength": 0,
+                                        "type": "string"
+                                    },
+                                    "redis_port": {
+                                        "default": 6379,
+                                        "minimum": 1,
+                                        "type": "integer"
+                                    },
+                                    "redis_timeout": {
+                                        "default": 1000,
+                                        "minimum": 1,
+                                        "type": "integer"
+                                    }
+                                },
+                                "required": [
+                                    "redis_host"
+                                ]
+                            },
+                            {
+                                "properties": {
+                                    "policy": {
+                                        "enum": [
+                                            "redis-cluster"
+                                        ]
+                                    },
+                                    "redis_cluster_nodes": {
+                                        "items": {
+                                            "maxLength": 100,
+                                            "minLength": 2,
+                                            "type": "string"
+                                        },
+                                        "minItems": 2,
+                                        "type": "array"
+                                    },
+                                    "redis_password": {
+                                        "minLength": 0,
+                                        "type": "string"
+                                    },
+                                    "redis_timeout": {
+                                        "default": 1000,
+                                        "minimum": 1,
+                                        "type": "integer"
+                                    }
+                                },
+                                "required": [
+                                    "redis_cluster_nodes"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "properties": {
+                    "count": {
+                        "minimum": 0,
+                        "type": "integer"
+                    },
+                    "key": {
+                        "default": "remote_addr",
+                        "enum": [
+                            "consumer_name",
+                            "http_x_forwarded_for",
+                            "http_x_real_ip",
+                            "remote_addr",
+                            "server_addr",
+                            "service_id"
+                        ],
+                        "type": "string"
+                    },
+                    "policy": {
+                        "default": "local",
+                        "enum": [
+                            "local",
+                            "redis",
+                            "redis-cluster"
+                        ],
+                        "type": "string"
+                    },
+                    "rejected_code": {
+                        "default": 503,
+                        "maximum": 600,
+                        "minimum": 200,
+                        "type": "integer"
+                    },
+                    "time_window": {
+                        "minimum": 0,
+                        "type": "integer"
+                    }
+                },
+                "required": [
+                    "count",
+                    "time_window"
+                ],
+                "type": "object"
+            },
+            "version": 0.4
+        },
+        "limit-req": {
+            "priority": 1001,
+            "schema": {
+                "properties": {
+                    "burst": {
+                        "minimum": 0,
+                        "type": "number"
+                    },
+                    "key": {
+                        "enum": [
+                            "consumer_name",
+                            "http_x_forwarded_for",
+                            "http_x_real_ip",
+                            "remote_addr",
+                            "server_addr"
+                        ],
+                        "type": "string"
+                    },
+                    "rate": {
+                        "minimum": 0,
+                        "type": "number"
+                    },
+                    "rejected_code": {
+                        "default": 503,
+                        "minimum": 200,
+                        "type": "integer"
+                    }
+                },
+                "required": [
+                    "burst",
+                    "key",
+                    "rate"
+                ],
+                "type": "object"
+            },
+            "version": 0.1
+        },
+        "mqtt-proxy": {
+            "priority": 1000,
+            "schema": {
+                "properties": {
+                    "protocol_level": {
+                        "type": "integer"
+                    },
+                    "protocol_name": {
+                        "type": "string"
+                    },
+                    "upstream": {
+                        "properties": {
+                            "ip": {
+                                "type": "string"
+                            },
+                            "port": {
+                                "type": "number"
+                            }
+                        },
+                        "type": "object"
+                    }
+                },
+                "required": [
+                    "protocol_level",
+                    "protocol_name",
+                    "upstream"
+                ],
+                "type": "object"
+            },
+            "version": 0.1
+        },
+        "openid-connect": {
+            "priority": 2599,
+            "schema": {
+                "properties": {
+                    "bearer_only": {
+                        "default": false,
+                        "type": "boolean"
+                    },
+                    "client_id": {
+                        "type": "string"
+                    },
+                    "client_secret": {
+                        "type": "string"
+                    },
+                    "discovery": {
+                        "type": "string"
+                    },
+                    "introspection_endpoint": {
+                        "type": "string"
+                    },
+                    "introspection_endpoint_auth_method": {
+                        "default": "client_secret_basic",
+                        "type": "string"
+                    },
+                    "logout_path": {
+                        "default": "/logout",
+                        "type": "string"
+                    },
+                    "public_key": {
+                        "type": "string"
+                    },
+                    "realm": {
+                        "default": "apisix",
+                        "type": "string"
+                    },
+                    "redirect_uri": {
+                        "description": "use ngx.var.request_uri if not configured",
+                        "type": "string"
+                    },
+                    "scope": {
+                        "default": "openid",
+                        "type": "string"
+                    },
+                    "ssl_verify": {
+                        "default": false,
+                        "type": "boolean"
+                    },
+                    "timeout": {
+                        "default": 3,
+                        "description": "timeout in seconds",
+                        "minimum": 1,
+                        "type": "integer"
+                    },
+                    "token_signing_alg_values_expected": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "client_id",
+                    "client_secret",
+                    "discovery"
+                ],
+                "type": "object"
+            },
+            "version": 0.1
+        },
+        "prometheus": {
+            "priority": 500,
+            "schema": {
+                "additionalProperties": false,
+                "properties": {
+                    "disable": {
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "version": 0.2
+        },
+        "proxy-cache": {
+            "priority": 1009,
+            "schema": {
+                "properties": {
+                    "cache_bypass": {
+                        "items": {
+                            "pattern": "(^[^\\$].+$|^\\$[0-9a-zA-Z_]+$)",
+                            "type": "string"
+                        },
+                        "minItems": 1,
+                        "type": "array"
+                    },
+                    "cache_http_status": {
+                        "default": [
+                            200,
+                            301,
+                            404
+                        ],
+                        "items": {
+                            "description": "http response status",
+                            "maximum": 599,
+                            "minimum": 200,
+                            "type": "integer"
+                        },
+                        "minItems": 1,
+                        "type": "array",
+                        "uniqueItems": true
+                    },
+                    "cache_key": {
+                        "default": [
+                            "$host",
+                            "$request_uri"
+                        ],
+                        "items": {
+                            "description": "a key for caching",
+                            "pattern": "(^[^\\$].+$|^\\$[0-9a-zA-Z_]+$)",
+                            "type": "string"
+                        },
+                        "minItems": 1,
+                        "type": "array"
+                    },
+                    "cache_method": {
+                        "default": [
+                            "GET",
+                            "HEAD"
+                        ],
+                        "items": {
+                            "description": "http method",
+                            "enum": [
+                                "CONNECT",
+                                "DELETE",
+                                "GET",
+                                "HEAD",
+                                "OPTIONS",
+                                "PATCH",
+                                "POST",
+                                "PUT",
+                                "TRACE"
+                            ],
+                            "type": "string"
+                        },
+                        "minItems": 1,
+                        "type": "array",
+                        "uniqueItems": true
+                    },
+                    "cache_zone": {
+                        "default": "disk_cache_one",
+                        "maxLength": 100,
+                        "minLength": 1,
+                        "type": "string"
+                    },
+                    "hide_cache_headers": {
+                        "default": false,
+                        "type": "boolean"
+                    },
+                    "no_cache": {
+                        "items": {
+                            "pattern": "(^[^\\$].+$|^\\$[0-9a-zA-Z_]+$)",
+                            "type": "string"
+                        },
+                        "minItems": 1,
+                        "type": "array"
+                    }
+                },
+                "type": "object"
+            },
+            "version": 0.1
+        },
+        "proxy-mirror": {
+            "priority": 1010,
+            "schema": {
+                "minProperties": 1,
+                "properties": {
+                    "host": {
+                        "pattern": "^http(s)?:\\/\\/[a-zA-Z0-9][-a-zA-Z0-9]{0,62}(\\.[a-zA-Z0-9][-a-zA-Z0-9]{0,62})+(:[0-9]{1,5})?$",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "host"
+                ],
+                "type": "object"
+            },
+            "version": 0.1
+        },
+        "proxy-rewrite": {
+            "priority": 1008,
+            "schema": {
+                "additionalProperties": false,
+                "minProperties": 1,
+                "properties": {
+                    "headers": {
+                        "description": "new headers for request",
+                        "minProperties": 1,
+                        "type": "object"
+                    },
+                    "host": {
+                        "description": "new host for upstream",
+                        "pattern": "^[0-9a-zA-Z-.]+$",
+                        "type": "string"
+                    },
+                    "regex_uri": {
+                        "description": "new uri that substitute from client uri for upstream, lower priority than uri property",
+                        "items": {
+                            "description": "regex uri",
+                            "type": "string"
+                        },
+                        "maxItems": 2,
+                        "minItems": 2,
+                        "type": "array"
+                    },
+                    "scheme": {
+                        "description": "new scheme for upstream",
+                        "enum": [
+                            "http",
+                            "https"
+                        ],
+                        "type": "string"
+                    },
+                    "uri": {
+                        "description": "new uri for upstream",
+                        "maxLength": 4096,
+                        "minLength": 1,
+                        "pattern": "^\\/.*",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "version": 0.1
+        },
+        "redirect": {
+            "priority": 900,
+            "schema": {
+                "oneOf": [
+                    {
+                        "required": [
+                            "uri"
+                        ]
+                    },
+                    {
+                        "required": [
+                            "http_to_https"
+                        ]
+                    }
+                ],
+                "properties": {
+                    "http_to_https": {
+                        "type": "boolean"
+                    },
+                    "ret_code": {
+                        "default": 302,
+                        "minimum": 200,
+                        "type": "integer"
+                    },
+                    "uri": {
+                        "minLength": 2,
+                        "pattern": "(\\\\\\$[0-9a-zA-Z_]+)|\\$\\{([0-9a-zA-Z_]+)\\}|\\$([0-9a-zA-Z_]+)|(\\$|[^$\\\\]+)",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "version": 0.1
+        },
+        "referer-restriction": {
+            "priority": 2990,
+            "schema": {
+                "additionalProperties": false,
+                "properties": {
+                    "bypass_missing": {
+                        "default": false,
+                        "type": "boolean"
+                    },
+                    "whitelist": {
+                        "items": {
+                            "pattern": "^\\*?[0-9a-zA-Z-._]+$",
+                            "type": "string"
+                        },
+                        "minItems": 1,
+                        "type": "array"
+                    }
+                },
+                "required": [
+                    "whitelist"
+                ],
+                "type": "object"
+            },
+            "version": 0.1
+        },
+        "request-id": {
+            "priority": 11010,
+            "schema": {
+                "properties": {
+                    "header_name": {
+                        "default": "X-Request-Id",
+                        "type": "string"
+                    },
+                    "include_in_response": {
+                        "default": true,
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "version": 0.1
+        },
+        "request-validation": {
+            "priority": 2800,
+            "schema": {
+                "anyOf": [
+                    {
+                        "properties": {
+                            "body_schema": {
+                                "type": "object"
+                            }
+                        },
+                        "required": [
+                            "body_schema"
+                        ],
+                        "title": "Body schema"
+                    },
+                    {
+                        "properties": {
+                            "header_schema": {
+                                "type": "object"
+                            }
+                        },
+                        "required": [
+                            "header_schema"
+                        ],
+                        "title": "Header schema"
+                    }
+                ],
+                "properties": {
+                    "disable": {
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "type": "validation",
+            "version": 0.1
+        },
+        "response-rewrite": {
+            "priority": 899,
+            "schema": {
+                "additionalProperties": false,
+                "minProperties": 1,
+                "properties": {
+                    "body": {
+                        "description": "new body for response",
+                        "type": "string"
+                    },
+                    "body_base64": {
+                        "default": false,
+                        "description": "whether new body for response need base64 decode before return",
+                        "type": "boolean"
+                    },
+                    "headers": {
+                        "description": "new headers for response",
+                        "minProperties": 1,
+                        "type": "object"
+                    },
+                    "status_code": {
+                        "description": "new status code for response",
+                        "maximum": 598,
+                        "minimum": 200,
+                        "type": "integer"
+                    }
+                },
+                "type": "object"
+            },
+            "version": 0.1
+        },
+        "serverless-post-function": {
+            "priority": -2000,
+            "schema": {
+                "properties": {
+                    "functions": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "minItems": 1,
+                        "type": "array"
+                    },
+                    "phase": {
+                        "default": "access",
+                        "enum": [
+                            "access",
+                            "balancer",
+                            "body_filter",
+                            "header_filter",
+                            "log",
+                            "rewrite"
+                        ],
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "functions"
+                ],
+                "type": "object"
+            },
+            "version": 0.1
+        },
+        "serverless-pre-function": {
+            "priority": 10000,
+            "schema": {
+                "properties": {
+                    "functions": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "minItems": 1,
+                        "type": "array"
+                    },
+                    "phase": {
+                        "default": "access",
+                        "enum": [
+                            "access",
+                            "balancer",
+                            "body_filter",
+                            "header_filter",
+                            "log",
+                            "rewrite"
+                        ],
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "functions"
+                ],
+                "type": "object"
+            },
+            "version": 0.1
+        },
+        "sls-logger": {
+            "priority": 406,
+            "schema": {
+                "properties": {
+                    "access_key_id": {
+                        "type": "string"
+                    },
+                    "access_key_secret": {
+                        "type": "string"
+                    },
+                    "batch_max_size": {
+                        "default": 1000,
+                        "minimum": 1,
+                        "type": "integer"
+                    },
+                    "buffer_duration": {
+                        "default": 60,
+                        "minimum": 1,
+                        "type": "integer"
+                    },
+                    "host": {
+                        "type": "string"
+                    },
+                    "inactive_timeout": {
+                        "default": 5,
+                        "minimum": 1,
+                        "type": "integer"
+                    },
+                    "include_req_body": {
+                        "default": false,
+                        "type": "boolean"
+                    },
+                    "logstore": {
+                        "type": "string"
+                    },
+                    "max_retry_count": {
+                        "default": 0,
+                        "minimum": 0,
+                        "type": "integer"
+                    },
+                    "name": {
+                        "default": "sls-logger",
+                        "type": "string"
+                    },
+                    "port": {
+                        "type": "integer"
+                    },
+                    "project": {
+                        "type": "string"
+                    },
+                    "retry_delay": {
+                        "default": 1,
+                        "minimum": 0,
+                        "type": "integer"
+                    },
+                    "timeout": {
+                        "default": 5000,
+                        "minimum": 1,
+                        "type": "integer"
+                    }
+                },
+                "required": [
+                    "access_key_id",
+                    "access_key_secret",
+                    "host",
+                    "logstore",
+                    "port",
+                    "project"
+                ],
+                "type": "object"
+            },
+            "version": 0.1
+        },
+        "syslog": {
+            "priority": 401,
+            "schema": {
+                "properties": {
+                    "batch_max_size": {
+                        "default": 1000,
+                        "minimum": 1,
+                        "type": "integer"
+                    },
+                    "buffer_duration": {
+                        "default": 60,
+                        "minimum": 1,
+                        "type": "integer"
+                    },
+                    "drop_limit": {
+                        "default": 1048576,
+                        "type": "integer"
+                    },
+                    "flush_limit": {
+                        "default": 4096,
+                        "minimum": 1,
+                        "type": "integer"
+                    },
+                    "host": {
+                        "type": "string"
+                    },
+                    "include_req_body": {
+                        "default": false,
+                        "type": "boolean"
+                    },
+                    "max_retry_times": {
+                        "default": 1,
+                        "minimum": 1,
+                        "type": "integer"
+                    },
+                    "name": {
+                        "default": "sys logger",
+                        "type": "string"
+                    },
+                    "pool_size": {
+                        "default": 5,
+                        "minimum": 5,
+                        "type": "integer"
+                    },
+                    "port": {
+                        "type": "integer"
+                    },
+                    "retry_interval": {
+                        "default": 1,
+                        "minimum": 0,
+                        "type": "integer"
+                    },
+                    "sock_type": {
+                        "default": "tcp",
+                        "enum": [
+                            "tcp",
+                            "udp"
+                        ],
+                        "type": "string"
+                    },
+                    "timeout": {
+                        "default": 3,
+                        "minimum": 1,
+                        "type": "integer"
+                    },
+                    "tls": {
+                        "default": false,
+                        "type": "boolean"
+                    }
+                },
+                "required": [
+                    "host",
+                    "port"
+                ],
+                "type": "object"
+            },
+            "version": 0.1
+        },
+        "tcp-logger": {
+            "priority": 405,
+            "schema": {
+                "properties": {
+                    "batch_max_size": {
+                        "default": 1000,
+                        "minimum": 1,
+                        "type": "integer"
+                    },
+                    "buffer_duration": {
+                        "default": 60,
+                        "minimum": 1,
+                        "type": "integer"
+                    },
+                    "host": {
+                        "type": "string"
+                    },
+                    "inactive_timeout": {
+                        "default": 5,
+                        "minimum": 1,
+                        "type": "integer"
+                    },
+                    "include_req_body": {
+                        "default": false,
+                        "type": "boolean"
+                    },
+                    "max_retry_count": {
+                        "default": 0,
+                        "minimum": 0,
+                        "type": "integer"
+                    },
+                    "name": {
+                        "default": "tcp logger",
+                        "type": "string"
+                    },
+                    "port": {
+                        "minimum": 0,
+                        "type": "integer"
+                    },
+                    "retry_delay": {
+                        "default": 1,
+                        "minimum": 0,
+                        "type": "integer"
+                    },
+                    "timeout": {
+                        "default": 1000,
+                        "minimum": 1,
+                        "type": "integer"
+                    },
+                    "tls": {
+                        "default": false,
+                        "type": "boolean"
+                    },
+                    "tls_options": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "host",
+                    "port"
+                ],
+                "type": "object"
+            },
+            "version": 0.1
+        },
+        "traffic-split": {
+            "priority": 966,
+            "schema": {
+                "properties": {
+                    "rules": {
+                        "items": {
+                            "properties": {
+                                "match": {
+                                    "default": [
+                                        {
+                                            "vars": [
+                                                [
+                                                    0,
+                                                    ">",
+                                                    "server_port"
+                                                ]
+                                            ]
+                                        }
+                                    ],
+                                    "items": {
+                                        "properties": {
+                                            "vars": {
+                                                "items": {
+                                                    "additionalItems": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "type": "number"
+                                                            },
+                                                            {
+                                                                "type": "boolean"
+                                                            },
+                                                            {
+                                                                "items": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "maxLength": 100,
+                                                                            "minLength": 1,
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "number"
+                                                                        },
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "type": "array",
+                                                                "uniqueItems": true
+                                                            }
+                                                        ]
+                                                    },
+                                                    "items": [
+                                                        {
+                                                            "maxLength": 100,
+                                                            "minLength": 1,
+                                                            "type": "string"
+                                                        },
+                                                        {
+                                                            "maxLength": 2,
+                                                            "minLength": 1,
+                                                            "type": "string"
+                                                        }
+                                                    ],
+                                                    "maxItems": 10,
+                                                    "minItems": 0,
+                                                    "type": "array"
+                                                },
+                                                "type": "array"
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    "type": "array"
+                                },
+                                "weighted_upstreams": {
+                                    "default": [
+                                        {
+                                            "weight": 1
+                                        }
+                                    ],
+                                    "items": {
+                                        "properties": {
+                                            "upstream": {
+                                                "additionalProperties": false,
+                                                "anyOf": [
+                                                    {
+                                                        "required": [
+                                                            "nodes",
+                                                            "type"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "required": [
+                                                            "service_name",
+                                                            "type"
+                                                        ]
+                                                    }
+                                                ],
+                                                "properties": {
+                                                    "checks": {
+                                                        "additionalProperties": false,
+                                                        "anyOf": [
+                                                            {
+                                                                "required": [
+                                                                    "active"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "required": [
+                                                                    "active",
+                                                                    "passive"
+                                                                ]
+                                                            }
+                                                        ],
+                                                        "properties": {
+                                                            "active": {
+                                                                "properties": {
+                                                                    "concurrency": {
+                                                                        "default": 10,
+                                                                        "type": "integer"
+                                                                    },
+                                                                    "healthy": {
+                                                                        "properties": {
+                                                                            "http_statuses": {
+                                                                                "default": [
+                                                                                    200,
+                                                                                    302
+                                                                                ],
+                                                                                "items": {
+                                                                                    "maximum": 599,
+                                                                                    "minimum": 200,
+                                                                                    "type": "integer"
+                                                                                },
+                                                                                "minItems": 1,
+                                                                                "type": "array",
+                                                                                "uniqueItems": true
+                                                                            },
+                                                                            "interval": {
+                                                                                "default": 0,
+                                                                                "minimum": 1,
+                                                                                "type": "integer"
+                                                                            },
+                                                                            "successes": {
+                                                                                "default": 2,
+                                                                                "maximum": 254,
+                                                                                "minimum": 1,
+                                                                                "type": "integer"
+                                                                            }
+                                                                        },
+                                                                        "type": "object"
+                                                                    },
+                                                                    "host": {
+                                                                        "pattern": "^\\*?[0-9a-zA-Z-._]+$",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "http_path": {
+                                                                        "default": "/",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "https_verify_certificate": {
+                                                                        "default": true,
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    "port": {
+                                                                        "maximum": 65535,
+                                                                        "minimum": 1,
+                                                                        "type": "integer"
+                                                                    },
+                                                                    "req_headers": {
+                                                                        "items": {
+                                                                            "type": "string",
+                                                                            "uniqueItems": true
+                                                                        },
+                                                                        "minItems": 1,
+                                                                        "type": "array"
+                                                                    },
+                                                                    "timeout": {
+                                                                        "default": 1,
+                                                                        "type": "number"
+                                                                    },
+                                                                    "type": {
+                                                                        "default": "http",
+                                                                        "enum": [
+                                                                            "http",
+                                                                            "https",
+                                                                            "tcp"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    "unhealthy": {
+                                                                        "properties": {
+                                                                            "http_failures": {
+                                                                                "default": 5,
+                                                                                "maximum": 254,
+                                                                                "minimum": 1,
+                                                                                "type": "integer"
+                                                                            },
+                                                                            "http_statuses": {
+                                                                                "default": [
+                                                                                    404,
+                                                                                    429,
+                                                                                    500,
+                                                                                    501,
+                                                                                    502,
+                                                                                    503,
+                                                                                    504,
+                                                                                    505
+                                                                                ],
+                                                                                "items": {
+                                                                                    "maximum": 599,
+                                                                                    "minimum": 200,
+                                                                                    "type": "integer"
+                                                                                },
+                                                                                "minItems": 1,
+                                                                                "type": "array",
+                                                                                "uniqueItems": true
+                                                                            },
+                                                                            "interval": {
+                                                                                "default": 0,
+                                                                                "minimum": 1,
+                                                                                "type": "integer"
+                                                                            },
+                                                                            "tcp_failures": {
+                                                                                "default": 2,
+                                                                                "maximum": 254,
+                                                                                "minimum": 1,
+                                                                                "type": "integer"
+                                                                            },
+                                                                            "timeouts": {
+                                                                                "default": 3,
+                                                                                "maximum": 254,
+                                                                                "minimum": 1,
+                                                                                "type": "integer"
+                                                                            }
+                                                                        },
+                                                                        "type": "object"
+                                                                    }
+                                                                },
+                                                                "type": "object"
+                                                            },
+                                                            "passive": {
+                                                                "properties": {
+                                                                    "healthy": {
+                                                                        "properties": {
+                                                                            "http_statuses": {
+                                                                                "default": [
+                                                                                    200,
+                                                                                    201,
+                                                                                    202,
+                                                                                    203,
+                                                                                    204,
+                                                                                    205,
+                                                                                    206,
+                                                                                    207,
+                                                                                    208,
+                                                                                    226,
+                                                                                    300,
+                                                                                    301,
+                                                                                    302,
+                                                                                    303,
+                                                                                    304,
+                                                                                    305,
+                                                                                    306,
+                                                                                    307,
+                                                                                    308
+                                                                                ],
+                                                                                "items": {
+                                                                                    "maximum": 599,
+                                                                                    "minimum": 200,
+                                                                                    "type": "integer"
+                                                                                },
+                                                                                "minItems": 1,
+                                                                                "type": "array",
+                                                                                "uniqueItems": true
+                                                                            },
+                                                                            "successes": {
+                                                                                "default": 5,
+                                                                                "maximum": 254,
+                                                                                "minimum": 1,
+                                                                                "type": "integer"
+                                                                            }
+                                                                        },
+                                                                        "type": "object"
+                                                                    },
+                                                                    "type": {
+                                                                        "default": "http",
+                                                                        "enum": [
+                                                                            "http",
+                                                                            "https",
+                                                                            "tcp"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    "unhealthy": {
+                                                                        "properties": {
+                                                                            "http_failures": {
+                                                                                "default": 5,
+                                                                                "maximum": 254,
+                                                                                "minimum": 1,
+                                                                                "type": "integer"
+                                                                            },
+                                                                            "http_statuses": {
+                                                                                "default": [
+                                                                                    429,
+                                                                                    500,
+                                                                                    503
+                                                                                ],
+                                                                                "items": {
+                                                                                    "maximum": 599,
+                                                                                    "minimum": 200,
+                                                                                    "type": "integer"
+                                                                                },
+                                                                                "minItems": 1,
+                                                                                "type": "array",
+                                                                                "uniqueItems": true
+                                                                            },
+                                                                            "tcp_failures": {
+                                                                                "default": 2,
+                                                                                "maximum": 254,
+                                                                                "minimum": 1,
+                                                                                "type": "integer"
+                                                                            },
+                                                                            "timeouts": {
+                                                                                "default": 7,
+                                                                                "maximum": 254,
+                                                                                "minimum": 1,
+                                                                                "type": "integer"
+                                                                            }
+                                                                        },
+                                                                        "type": "object"
+                                                                    }
+                                                                },
+                                                                "type": "object"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    },
+                                                    "create_time": {
+                                                        "type": "integer"
+                                                    },
+                                                    "desc": {
+                                                        "maxLength": 256,
+                                                        "type": "string"
+                                                    },
+                                                    "discovery_type": {
+                                                        "description": "discovery type",
+                                                        "type": "string"
+                                                    },
+                                                    "enable_websocket": {
+                                                        "description": "enable websocket for request",
+                                                        "type": "boolean"
+                                                    },
+                                                    "hash_on": {
+                                                        "default": "vars",
+                                                        "enum": [
+                                                            "consumer",
+                                                            "cookie",
+                                                            "header",
+                                                            "vars"
+                                                        ],
+                                                        "type": "string"
+                                                    },
+                                                    "id": {
+                                                        "anyOf": [
+                                                            {
+                                                                "maxLength": 64,
+                                                                "minLength": 1,
+                                                                "pattern": "^[a-zA-Z0-9-_.]+$",
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "minimum": 1,
+                                                                "type": "integer"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "key": {
+                                                        "description": "the key of chash for dynamic load balancing",
+                                                        "type": "string"
+                                                    },
+                                                    "labels": {
+                                                        "description": "key/value pairs to specify attributes",
+                                                        "maxProperties": 16,
+                                                        "patternProperties": {
+                                                            ".*": {
+                                                                "description": "value of label",
+                                                                "maxLength": 64,
+                                                                "minLength": 1,
+                                                                "pattern": "^[a-zA-Z0-9-_.]+$",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    },
+                                                    "name": {
+                                                        "maxLength": 100,
+                                                        "minLength": 1,
+                                                        "type": "string"
+                                                    },
+                                                    "nodes": {
+                                                        "anyOf": [
+                                                            {
+                                                                "minProperties": 1,
+                                                                "patternProperties": {
+                                                                    ".*": {
+                                                                        "description": "weight of node",
+                                                                        "minimum": 0,
+                                                                        "type": "integer"
+                                                                    }
+                                                                },
+                                                                "type": "object"
+                                                            },
+                                                            {
+                                                                "items": {
+                                                                    "properties": {
+                                                                        "host": {
+                                                                            "pattern": "^\\*?[0-9a-zA-Z-._]+$",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "metadata": {
+                                                                            "description": "metadata of node",
+                                                                            "type": "object"
+                                                                        },
+                                                                        "port": {
+                                                                            "description": "port of node",
+                                                                            "minimum": 1,
+                                                                            "type": "integer"
+                                                                        },
+                                                                        "weight": {
+                                                                            "description": "weight of node",
+                                                                            "minimum": 0,
+                                                                            "type": "integer"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "host",
+                                                                        "port",
+                                                                        "weight"
+                                                                    ],
+                                                                    "type": "object"
+                                                                },
+                                                                "type": "array"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "pass_host": {
+                                                        "default": "pass",
+                                                        "description": "mod of host passing",
+                                                        "enum": [
+                                                            "node",
+                                                            "pass",
+                                                            "rewrite"
+                                                        ],
+                                                        "type": "string"
+                                                    },
+                                                    "retries": {
+                                                        "minimum": 0,
+                                                        "type": "integer"
+                                                    },
+                                                    "service_name": {
+                                                        "maxLength": 100,
+                                                        "minLength": 1,
+                                                        "type": "string"
+                                                    },
+                                                    "timeout": {
+                                                        "properties": {
+                                                            "connect": {
+                                                                "minimum": 0,
+                                                                "type": "number"
+                                                            },
+                                                            "read": {
+                                                                "minimum": 0,
+                                                                "type": "number"
+                                                            },
+                                                            "send": {
+                                                                "minimum": 0,
+                                                                "type": "number"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "connect",
+                                                            "read",
+                                                            "send"
+                                                        ],
+                                                        "type": "object"
+                                                    },
+                                                    "type": {
+                                                        "description": "algorithms of load balancing",
+                                                        "enum": [
+                                                            "chash",
+                                                            "ewma",
+                                                            "roundrobin"
+                                                        ],
+                                                        "type": "string"
+                                                    },
+                                                    "update_time": {
+                                                        "type": "integer"
+                                                    },
+                                                    "upstream_host": {
+                                                        "pattern": "^\\*?[0-9a-zA-Z-._]+$",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object"
+                                            },
+                                            "upstream_id": {
+                                                "anyOf": [
+                                                    {
+                                                        "maxLength": 64,
+                                                        "minLength": 1,
+                                                        "pattern": "^[a-zA-Z0-9-_.]+$",
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "minimum": 1,
+                                                        "type": "integer"
+                                                    }
+                                                ]
+                                            },
+                                            "weight": {
+                                                "default": 1,
+                                                "description": "used to split traffic between differentupstreams for plugin configuration",
+                                                "minimum": 0,
+                                                "type": "integer"
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    "maxItems": 20,
+                                    "minItems": 1,
+                                    "type": "array"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "type": "array"
+                    }
+                },
+                "type": "object"
+            },
+            "version": 0.1
+        },
+        "udp-logger": {
+            "priority": 400,
+            "schema": {
+                "properties": {
+                    "batch_max_size": {
+                        "default": 1000,
+                        "minimum": 1,
+                        "type": "integer"
+                    },
+                    "buffer_duration": {
+                        "default": 60,
+                        "minimum": 1,
+                        "type": "integer"
+                    },
+                    "host": {
+                        "type": "string"
+                    },
+                    "inactive_timeout": {
+                        "default": 5,
+                        "minimum": 1,
+                        "type": "integer"
+                    },
+                    "include_req_body": {
+                        "default": false,
+                        "type": "boolean"
+                    },
+                    "name": {
+                        "default": "udp logger",
+                        "type": "string"
+                    },
+                    "port": {
+                        "minimum": 0,
+                        "type": "integer"
+                    },
+                    "timeout": {
+                        "default": 3,
+                        "minimum": 1,
+                        "type": "integer"
+                    }
+                },
+                "required": [
+                    "host",
+                    "port"
+                ],
+                "type": "object"
+            },
+            "version": 0.1
+        },
+        "uri-blocker": {
+            "priority": 2900,
+            "schema": {
+                "properties": {
+                    "block_rules": {
+                        "items": {
+                            "maxLength": 4096,
+                            "minLength": 1,
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "uniqueItems": true
+                    },
+                    "rejected_code": {
+                        "default": 403,
+                        "minimum": 200,
+                        "type": "integer"
+                    }
+                },
+                "required": [
+                    "block_rules"
+                ],
+                "type": "object"
+            },
+            "version": 0.1
+        },
+        "wolf-rbac": {
+            "priority": 2555,
+            "schema": {
+                "properties": {
+                    "appid": {
+                        "default": "unset",
+                        "type": "string"
+                    },
+                    "header_prefix": {
+                        "default": "X-",
+                        "type": "string"
+                    },
+                    "server": {
+                        "default": "http://127.0.0.1:10080",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "type": "auth",
+            "version": 0.1
+        },
+        "zipkin": {
+            "priority": 11011,
+            "schema": {
+                "properties": {
+                    "endpoint": {
+                        "type": "string"
+                    },
+                    "sample_ratio": {
+                        "maximum": 1,
+                        "minimum": 0.00001,
+                        "type": "number"
+                    },
+                    "server_addr": {
+                        "description": "default is $server_addr, you can specify your external ip address",
+                        "pattern": "^[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}$",
+                        "type": "string"
+                    },
+                    "service_name": {
+                        "default": "APISIX",
+                        "description": "service name for zipkin reporter",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "endpoint",
+                    "sample_ratio"
+                ],
+                "type": "object"
+            },
+            "version": 0.1
+        }
+    }
 }

--- a/api/internal/core/entity/entity.go
+++ b/api/internal/core/entity/entity.go
@@ -237,7 +237,7 @@ type Script struct {
 
 // swagger:model GlobalPlugins
 type GlobalPlugins struct {
-	ID      interface{}            `json:"id"`
+	BaseInfo
 	Plugins map[string]interface{} `json:"plugins"`
 }
 

--- a/api/internal/handler/global_rule/global_rule_test.go
+++ b/api/internal/handler/global_rule/global_rule_test.go
@@ -142,15 +142,15 @@ func TestHandler_List(t *testing.T) {
 				PageNumber: 1,
 			},
 			giveData: []*entity.GlobalPlugins{
-				{ID: "global-rules-1"},
-				{ID: "global-rules-2"},
-				{ID: "global-rules-3"},
+				{BaseInfo: entity.BaseInfo{ID: "global-rules-1"}},
+				{BaseInfo: entity.BaseInfo{ID: "global-rules-2"}},
+				{BaseInfo: entity.BaseInfo{ID: "global-rules-3"}},
 			},
 			wantRet: &store.ListOutput{
 				Rows: []interface{}{
-					&entity.GlobalPlugins{ID: "global-rules-1"},
-					&entity.GlobalPlugins{ID: "global-rules-2"},
-					&entity.GlobalPlugins{ID: "global-rules-3"},
+					&entity.GlobalPlugins{BaseInfo: entity.BaseInfo{ID: "global-rules-1"}},
+					&entity.GlobalPlugins{BaseInfo: entity.BaseInfo{ID: "global-rules-2"}},
+					&entity.GlobalPlugins{BaseInfo: entity.BaseInfo{ID: "global-rules-3"}},
 				},
 				TotalSize: 3,
 			},
@@ -229,7 +229,7 @@ func TestHandler_Set(t *testing.T) {
 			},
 			giveCtx: context.WithValue(context.Background(), "test", "value"),
 			wantInput: &entity.GlobalPlugins{
-				ID: "name",
+				BaseInfo: entity.BaseInfo{ID: "name"},
 				Plugins: map[string]interface{}{
 					"jwt-auth": map[string]interface{}{},
 				},
@@ -245,8 +245,8 @@ func TestHandler_Set(t *testing.T) {
 			},
 			giveErr: fmt.Errorf("create failed"),
 			wantInput: &entity.GlobalPlugins{
-				ID:      "name",
-				Plugins: map[string]interface{}(nil),
+				BaseInfo: entity.BaseInfo{ID: "name"},
+				Plugins:  map[string]interface{}(nil),
 			},
 			wantErr: fmt.Errorf("create failed"),
 			wantRet: &data.SpecCodeResponse{

--- a/api/test/e2e/global_rule_test.go
+++ b/api/test/e2e/global_rule_test.go
@@ -17,8 +17,14 @@
 package e2e
 
 import (
+	"fmt"
+	"io/ioutil"
 	"net/http"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tidwall/gjson"
 )
 
 func TestGlobalRule(t *testing.T) {
@@ -275,6 +281,111 @@ func TestGlobalRule(t *testing.T) {
 			ExpectStatus: http.StatusNotFound,
 			ExpectBody:   `{"error_msg":"404 Route Not Found"}`,
 			Sleep:        sleepTime,
+		},
+	}
+
+	for _, tc := range tests {
+		testCaseCheck(tc, t)
+	}
+}
+
+func TestGlobalRule_with_createtime_updatetime(t *testing.T) {
+	tests := []HttpTestCase{
+		{
+			Desc:   "create global rule",
+			Object: ManagerApiExpect(t),
+			Path:   "/apisix/admin/global_rules/1",
+			Method: http.MethodPut,
+			Body: `{
+				     "plugins": {
+					   "response-rewrite": {
+					     "headers": {
+						   "X-VERSION":"1.0"
+						 }
+					   },
+					   "uri-blocker": {
+					     "block_rules": ["select.+(from|limit)", "(?:(union(.*?)select))"]
+					   }
+					 }
+				   }`,
+			Headers:      map[string]string{"Authorization": token},
+			ExpectStatus: http.StatusOK,
+			Sleep:        sleepTime,
+		},
+	}
+
+	for _, tc := range tests {
+		testCaseCheck(tc, t)
+	}
+
+	basepath := "http://127.0.0.1:9000/apisix/admin/global_rules/1"
+	time.Sleep(time.Duration(1) * time.Second)
+
+	// get the global_rule, save createtime and updatetime
+	request, _ := http.NewRequest("GET", basepath, nil)
+	request.Header.Add("Authorization", token)
+	resp, err := http.DefaultClient.Do(request)
+	if err != nil {
+		fmt.Printf("server not responding %s", err.Error())
+	}
+	defer resp.Body.Close()
+	respBody, _ := ioutil.ReadAll(resp.Body)
+	createtime := gjson.Get(string(respBody), "data.create_time")
+	updatetime := gjson.Get(string(respBody), "data.update_time")
+
+	// wait 1 second so the update_time should be different
+	time.Sleep(time.Duration(1) * time.Second)
+
+	tests = []HttpTestCase{
+		{
+			Desc:   "update the global rule",
+			Object: ManagerApiExpect(t),
+			Path:   "/apisix/admin/global_rules/1",
+			Method: http.MethodPut,
+			Body: `{
+			         "plugins": {
+			           "response-rewrite": {
+			            "headers": {
+			              "X-VERSION":"1.1"
+			            }
+			           },
+			            "uri-blocker": {
+			              "block_rules": ["select.+(from|limit)", "(?:(union(.*?)select))"]
+			            }
+			         }
+			      }`,
+			Headers:      map[string]string{"Authorization": token},
+			ExpectStatus: http.StatusOK,
+			Sleep:        sleepTime,
+		},
+	}
+
+	for _, tc := range tests {
+		testCaseCheck(tc, t)
+	}
+
+	// get the global rule
+	time.Sleep(time.Duration(1) * time.Second)
+	request, _ = http.NewRequest("GET", basepath, nil)
+	request.Header.Add("Authorization", token)
+	resp, _ = http.DefaultClient.Do(request)
+	respBody, _ = ioutil.ReadAll(resp.Body)
+	createtime2 := gjson.Get(string(respBody), "data.create_time")
+	updatetime2 := gjson.Get(string(respBody), "data.update_time")
+
+	// verify the global and compare result
+	assert.Equal(t, "1.1", gjson.Get(string(respBody), "data.plugins.response-rewrite.headers.X-VERSION").String())
+	assert.Equal(t, createtime.String(), createtime2.String())
+	assert.NotEqual(t, updatetime.String(), updatetime2.String())
+
+	tests = []HttpTestCase{
+		{
+			Desc:         "delete the global rule",
+			Object:       ManagerApiExpect(t),
+			Method:       http.MethodDelete,
+			Path:         "/apisix/admin/global_rules/1",
+			Headers:      map[string]string{"Authorization": token},
+			ExpectStatus: http.StatusOK,
 		},
 	}
 

--- a/api/test/e2e/go.sum
+++ b/api/test/e2e/go.sum
@@ -65,6 +65,7 @@ github.com/savsgio/gotils v0.0.0-20200117113501-90175b0fbe3f h1:PgA+Olipyj258EIE
 github.com/savsgio/gotils v0.0.0-20200117113501-90175b0fbe3f/go.mod h1:lHhJedqxCoHN+zMtwGNTXWmF0u9Jt363FYRhV6g0CdY=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=


### PR DESCRIPTION
Signed-off-by: imjoey <majunjiev@gmail.com>

Please answer these questions before submitting a pull request

- Why submit this pull request?
- [ ] Bugfix
- [x] New feature provided
- [ ] Improve performance

- Related issues

fix #1143 , taking charge of the manager-api part.

___
### New feature or improvement
- Describe the details and related test reports.

As #1143 comes to a conclusion that `create_time` and `update_time` are needed for global_rule entity. This PR is going to  add the two fields and relevant test cases. 

**Note:**

Cause manager-api will validate the schema defined in `schema.json` right before writing to etcd, current test cases will always fail due to the `additionalProperties` for `GlobalRule` is `false`. This PR can only be marked as ready-to-view util the schema is updated from apache/apisix project.
