### PR TITLE
fix(be): search by status on the route list page is invalid (backport to v2.3)

### DIFF
--- a/api/internal/handler/route/route.go
+++ b/api/internal/handler/route/route.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -178,9 +179,10 @@ func (h *Handler) Get(c droplet.Context) (interface{}, error) {
 }
 
 type ListInput struct {
-	Name  string `auto_read:"name,query"`
-	URI   string `auto_read:"uri,query"`
-	Label string `auto_read:"label,query"`
+	Name   string `auto_read:"name,query"`
+	URI    string `auto_read:"uri,query"`
+	Label  string `auto_read:"label,query"`
+	Status string `auto_read:"status,query"`
 	store.Pagination
 }
 
@@ -216,6 +218,10 @@ func (h *Handler) List(c droplet.Context) (interface{}, error) {
 			}
 
 			if input.Label != "" && !utils.LabelContains(obj.(*entity.Route).Labels, labelMap) {
+				return false
+			}
+
+			if input.Status != "" && strconv.Itoa(int(obj.(*entity.Route).Status)) != input.Status {
 				return false
 			}
 

--- a/api/internal/handler/route/route_test.go
+++ b/api/internal/handler/route/route_test.go
@@ -59,6 +59,7 @@ func TestRoute(t *testing.T) {
 	  "vars": [],
 	  "remote_addrs": ["127.0.0.0/8"],
 	  "methods": ["PUT", "GET"],
+	  "status": 1,
 	  "upstream": {
 	      "type": "roundrobin",
 	      "nodes": [{
@@ -415,6 +416,7 @@ func TestRoute(t *testing.T) {
 	  "hosts": ["foo.com", "*.bar.com"],
 	  "remote_addrs": ["127.0.0.0/8"],
 	  "methods": ["PUT", "GET"],
+	  "status": 1,
 	  "labels": {
 	      "l1": "v1",
 	      "l2": "v2"
@@ -925,6 +927,42 @@ func TestRoute(t *testing.T) {
 	dataPage = retPage.(*store.ListOutput)
 	assert.Equal(t, len(dataPage.Rows), 0)
 
+	// list search and status match
+	listInput = &ListInput{}
+	reqBody = `{"page_size": 1, "page": 1, "status": "1"}`
+	err = json.Unmarshal([]byte(reqBody), listInput)
+	assert.Nil(t, err)
+	ctx.SetInput(listInput)
+	retPage, err = handler.List(ctx)
+	assert.Nil(t, err)
+	dataPage = retPage.(*store.ListOutput)
+	assert.Equal(t, len(dataPage.Rows), 1)
+
+        //sleep
+	time.Sleep(time.Duration(100) * time.Millisecond)
+
+	// list search and status not match
+	listInput = &ListInput{}
+	reqBody = `{"page_size": 1, "page": 1, "name": "a", "status": "0"}`
+	err = json.Unmarshal([]byte(reqBody), listInput)
+	assert.Nil(t, err)
+	ctx.SetInput(listInput)
+	retPage, err = handler.List(ctx)
+	assert.Nil(t, err)
+	dataPage = retPage.(*store.ListOutput)
+	assert.Equal(t, len(dataPage.Rows), 0)
+
+	//list search with name and status
+	listInput = &ListInput{}
+	reqBody = `{"page_size": 1, "page": 1, "name": "a", "status": "1"}`
+	err = json.Unmarshal([]byte(reqBody), listInput)
+	assert.Nil(t, err)
+	ctx.SetInput(listInput)
+	retPage, err = handler.List(ctx)
+	assert.Nil(t, err)
+	dataPage = retPage.(*store.ListOutput)
+	assert.Equal(t, len(dataPage.Rows), 1)
+
 	//list search with name and label
 	listInput = &ListInput{}
 	reqBody = `{"page_size": 1, "page": 1, "name": "a", "label":"l1:v1"}`
@@ -950,6 +988,17 @@ func TestRoute(t *testing.T) {
 	//list search with uri,name and label
 	listInput = &ListInput{}
 	reqBody = `{"page_size": 1, "page": 1, "name": "a", "uri": "index", "label":"l1:v1"}`
+	err = json.Unmarshal([]byte(reqBody), listInput)
+	assert.Nil(t, err)
+	ctx.SetInput(listInput)
+	retPage, err = handler.List(ctx)
+	assert.Nil(t, err)
+	dataPage = retPage.(*store.ListOutput)
+	assert.Equal(t, len(dataPage.Rows), 1)
+
+	//list search with uri,name, status and label
+	listInput = &ListInput{}
+	reqBody = `{"page_size": 1, "page": 1, "name": "a", "status": "1", "uri": "index", "label":"l1:v1"}`
 	err = json.Unmarshal([]byte(reqBody), listInput)
 	assert.Nil(t, err)
 	ctx.SetInput(listInput)


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [ ] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [x] Backport patches

As the preparation for release v2.3, this PR is going to cherry-pick 3f8060ead988364972bb2a23f2bedd0dcb1e6ecd from master branch to v2.3 branch . Regarding to the details, please refer to #1207 . 

Noted that the FE counterpart of the bugfix (#1189) has already been merged into v2.3, no need for cherry-pick.

