### PR TITLE
feat(release): Enable CI trigger for v2.3 branch

### DIFF
--- a/.github/workflows/backend-cli-test.yml
+++ b/.github/workflows/backend-cli-test.yml
@@ -3,10 +3,10 @@ name: Backend CLI Test
 on:
   push:
     branches:
-      - master
+      - v2.3
   pull_request:
     branches:
-      - master
+      - v2.3
 
 jobs:
   run-test:

--- a/.github/workflows/backend-e2e-test.yml
+++ b/.github/workflows/backend-e2e-test.yml
@@ -3,10 +3,10 @@ name: Backend E2E Test
 on:
   push:
     branches:
-      - master
+      - v2.3
   pull_request:
     branches:
-      - master
+      - v2.3
 
 jobs:
   run-test:

--- a/.github/workflows/backend-unit-test.yml
+++ b/.github/workflows/backend-unit-test.yml
@@ -3,10 +3,10 @@ name: Backend Unit Test
 on:
   push:
     branches:
-      - master
+      - v2.3
   pull_request:
     branches:
-      - master
+      - v2.3
 
 jobs:
   run-test:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [master]
+    branches: [v2.3]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [master]
+    branches: [v2.3]
   schedule:
     - cron: '18 23 * * 0'
 

--- a/.github/workflows/deploy-with-docker.yml
+++ b/.github/workflows/deploy-with-docker.yml
@@ -3,7 +3,7 @@ name: Test and Deploy with Docker
 on:
   push:
     branches:
-      - master
+      - v2.3
 
 jobs:
   build:

--- a/.github/workflows/frontend-e2e-test.yml
+++ b/.github/workflows/frontend-e2e-test.yml
@@ -3,10 +3,10 @@ name: Frontend e2e test
 on:
   push:
     branches:
-      - master
+      - v2.3
   pull_request:
     branches:
-      - master
+      - v2.3
 defaults:
   run:
     working-directory: web

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -5,10 +5,10 @@ name: gitLeaks
 on:
   push:
     branches:
-      - master
+      - v2.3
   pull_request:
     branches:
-      - master
+      - v2.3
 
 jobs:
   gitleaks:

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -1,4 +1,5 @@
 name: go-lint
+
 on:
   push:
     branches:

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -2,10 +2,10 @@ name: go-lint
 on:
   push:
     branches:
-      - master
+      - v2.3
   pull_request:
     branches:
-      - master
+      - v2.3
 
 jobs:
   golangci:

--- a/.github/workflows/license-checker.yml
+++ b/.github/workflows/license-checker.yml
@@ -3,10 +3,10 @@ name: License checker
 on:
   push:
     branches:
-      - master
+      - v2.3
   pull_request:
     branches:
-      - master
+      - v2.3
 
 jobs:
   check-license:

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -3,10 +3,10 @@ name: Release Test
 on:
   push:
     branches:
-      - master
+      - v2.3
   pull_request:
     branches:
-      - master
+      - v2.3
 
 jobs:
   run-test:

--- a/.github/workflows/spellchecker.yml
+++ b/.github/workflows/spellchecker.yml
@@ -2,7 +2,7 @@ name: spellchecker
 on:
   pull_request:
     branches:
-      - master
+      - v2.3
 jobs:
   misspell:
     name: runner/misspell

--- a/.github/workflows/test-frontend-multiple-node-build.yml
+++ b/.github/workflows/test-frontend-multiple-node-build.yml
@@ -3,14 +3,14 @@
 name: Test building web in multiple node version
 
 # Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
+# events but only for the v2.3 branch
 on:
   push:
     branches:
-      - master
+      - v2.3
   pull_request:
     branches:
-      - master
+      - v2.3
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
Signed-off-by: imjoey <majunjiev@gmail.com>

Please answer these questions before submitting a pull request

- Why submit this pull request?
- [ ] Bugfix
- [x] New feature provided
- [ ] Improve performance

___
### New feature or improvement
- Describe the details and related test reports.

As the preparation of v2.3 release, we need to continuously backport hot bugfixs to `v2.3` branch, so enable CI process at v2.3 branch would help us keep the release more stable. 

Since v2.3 will not be a LTS version, which means there will no activities in v2.3 branch after release v2.3, so this PR is going to use the single `v2.3` for all branch configurations.

