### PR TITLE
fix: debug page error occured when change method from post to get when post contains bodyparams

### DIFF
--- a/web/src/pages/Route/components/DebugViews/DebugDrawView.tsx
+++ b/web/src/pages/Route/components/DebugViews/DebugDrawView.tsx
@@ -81,6 +81,9 @@ const DebugDrawView: React.FC<RouteModule.DebugDrawProps> = (props) => {
     let transformDataForm: string[];
     let transformDataJson: object;
     const formData: RouteModule.debugRequestParamsFormData[] = bodyForm.getFieldsValue().params;
+    if (methodWithoutBody.includes(httpMethod)) {
+      return undefined
+    }
     switch (bodyType) {
       case 'x-www-form-urlencoded':
         transformDataForm = (formData || [])


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bugfix

- Related issues

___
### Bugfix
- Description
1 debug a route: http method POST, with bodyparams
2 change http method to GET, click button `Send`, error occured

- how to fix

GET/HEAD request should not contain bodyparams