### PR TITLE
feat(FE): skip Cypress binary install when build

### DIFF
--- a/.github/workflows/test-frontend-multiple-node-build.yml
+++ b/.github/workflows/test-frontend-multiple-node-build.yml
@@ -35,7 +35,7 @@ jobs:
       # Install dependencies
       - name: Install dependencies
         working-directory: web
-        run: yarn
+        run: CYPRESS_INSTALL_BINARY=0 yarn
 
       - name: Lint
         working-directory: web

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ help:
 ### build:		Build Apache APISIX Dashboard, it contains web and manager-api
 .PHONY: build
 build: web-default api-default
-	api/build.sh && cd ./web && export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true && yarn install && yarn build  && mkdir -p ../output/logs
+	api/build.sh && cd ./web && export CYPRESS_INSTALL_BINARY=0  && yarn install && yarn build  && mkdir -p ../output/logs
 
 
 .PHONY: web-default


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [ ] Bugfix
- [ ] New feature provided
- [x] Improve performance
- [ ] Backport patches
___
### New feature or improvement
- Describe the details and related test reports.
To reduce the front-end build time, need to skip Cypress binary install when build.
