### PR TITLE
fix: incomplete label display #1044

### DIFF
--- a/web/src/pages/Route/components/Step1/MatchingRulesView.tsx
+++ b/web/src/pages/Route/components/Step1/MatchingRulesView.tsx
@@ -169,7 +169,7 @@ const MatchingRulesView: React.FC<RouteModule.Step1PassProps> = ({
       cancelText={formatMessage({ id: 'component.global.cancel' })}
       destroyOnClose
     >
-      <Form form={modalForm} labelCol={{ span: 4 }}>
+      <Form form={modalForm} layout="vertical">
         <Form.Item
           label={formatMessage({ id: 'page.route.parameterPosition' })}
           name="position"


### PR DESCRIPTION
- Why submit this pull request?
- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

- Related issues
- fix #1044

___
### Bugfix
- Description
 Incomplete label display when create rule in route step1 page

- How to fix?
I have updated MatchingRulesView.tsx to make the Incomplete label display  as expected behavior when create rule in route step1 page  
