### PR TITLE
fix(CI): Update lint workflow so that the Markdown and YAML linters run

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,5 +19,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'  # Version range or exact version of a Python version to use, using SemVer's version range syntax
+          architecture: 'x64'  # optional x64 or x86. Defaults to x64 if not specified
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install yamllint
       - name: 🧹 YAML Lint
-        uses: ibiqlik/action-yamllint@v3
+        run: |
+          yamllint .

--- a/api/test/docker/apisix_config.yaml
+++ b/api/test/docker/apisix_config.yaml
@@ -22,7 +22,7 @@ etcd:
     - "http://172.16.238.10:2379"
     - "http://172.16.238.11:2379"
     - "http://172.16.238.12:2379"
-  resync_delay: 0.1 # sync data from etcd quickly for e2e test
+  resync_delay: 0.1  # sync data from etcd quickly for e2e test
 
 apisix:
   id: "apisix-server1"

--- a/api/test/docker/apisix_config2.yaml
+++ b/api/test/docker/apisix_config2.yaml
@@ -22,7 +22,7 @@ etcd:
     - "http://172.16.238.10:2379"
     - "http://172.16.238.11:2379"
     - "http://172.16.238.12:2379"
-  resync_delay: 0.1 # sync data from etcd quickly for e2e test
+  resync_delay: 0.1  # sync data from etcd quickly for e2e test
 
 apisix:
   id: "apisix-server2"


### PR DESCRIPTION
Due to the ASF's policies changing we cannot use the original GitHub Actions for linting as they are not approved

Lint some YAML

Please answer these questions before submitting a pull request

- Why submit this pull request?
- [X] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

- Related issues
refs https://github.com/apache/apisix/pull/3196
___
### Bugfix
- Description


- How to fix?

___
### New feature or improvement
- Describe the details and related test reports.

___
### Backport patches
- Why need to backport?

- Source branch

- Related commits and pull requests

- Target branch
