### PR TITLE
feat: return back the data just created via POST method in manager API

### DIFF
--- a/api/internal/core/store/store_mock.go
+++ b/api/internal/core/store/store_mock.go
@@ -18,6 +18,7 @@ package store
 
 import (
 	"context"
+
 	"github.com/stretchr/testify/mock"
 )
 
@@ -48,9 +49,9 @@ func (m *MockInterface) List(input ListInput) (*ListOutput, error) {
 	return r0, r1
 }
 
-func (m *MockInterface) Create(ctx context.Context, obj interface{}) error {
+func (m *MockInterface) Create(ctx context.Context, obj interface{}) (interface{}, error) {
 	ret := m.Mock.Called(ctx, obj)
-	return ret.Error(0)
+	return ret.Get(0), ret.Error(1)
 }
 
 func (m *MockInterface) Update(ctx context.Context, obj interface{}, createOnFail bool) error {

--- a/api/internal/core/store/store_test.go
+++ b/api/internal/core/store/store_test.go
@@ -613,12 +613,17 @@ func TestGenericStore_Create(t *testing.T) {
 
 		tc.giveStore.Stg = mStorage
 		tc.giveStore.opt.Validator = mValidator
-		err := tc.giveStore.Create(context.TODO(), tc.giveObj)
+		ret, err := tc.giveStore.Create(context.TODO(), tc.giveObj)
 		assert.True(t, validateCalled, tc.caseDesc)
 		if err != nil {
 			assert.Equal(t, tc.wantErr, err, tc.caseDesc)
 			continue
 		}
+		retTs, ok := ret.(*TestStruct)
+		assert.True(t, ok)
+		// The returned value (retTs) should be the same as the input (tc.giveObj)
+		assert.Equal(t, tc.giveObj.Field1, retTs.Field1, tc.caseDesc)
+		assert.Equal(t, tc.giveObj.Field2, retTs.Field2, tc.caseDesc)
 		assert.True(t, createCalled, tc.caseDesc)
 	}
 }

--- a/api/internal/handler/route/route.go
+++ b/api/internal/handler/route/route.go
@@ -348,16 +348,17 @@ func (h *Handler) Create(c droplet.Context) (interface{}, error) {
 		}
 
 		//save original conf
-		if err = h.scriptStore.Create(c.Context(), script); err != nil {
+		if _, err = h.scriptStore.Create(c.Context(), script); err != nil {
 			return nil, err
 		}
 	}
 
-	if err := h.routeStore.Create(c.Context(), input); err != nil {
+	ret, err := h.routeStore.Create(c.Context(), input)
+	if err != nil {
 		return handler.SpecCodeResponse(err), err
 	}
 
-	return nil, nil
+	return ret, nil
 }
 
 type UpdateInput struct {
@@ -429,7 +430,7 @@ func (h *Handler) Update(c droplet.Context) (interface{}, error) {
 		if err = h.scriptStore.Update(c.Context(), script, true); err != nil {
 			//if not exists, create
 			if err.Error() == fmt.Sprintf("key: %s is not found", script.ID) {
-				if err := h.scriptStore.Create(c.Context(), script); err != nil {
+				if _, err := h.scriptStore.Create(c.Context(), script); err != nil {
 					return handler.SpecCodeResponse(err), err
 				}
 			} else {

--- a/api/internal/handler/route/route_test.go
+++ b/api/internal/handler/route/route_test.go
@@ -391,8 +391,12 @@ func TestRoute(t *testing.T) {
 	err = json.Unmarshal([]byte(reqBody), route)
 	assert.Nil(t, err)
 	ctx.SetInput(route)
-	_, err = handler.Create(ctx)
+	ret, err := handler.Create(ctx)
 	assert.Nil(t, err)
+	// check the returned valued
+	objRet, ok := ret.(*entity.Route)
+	assert.True(t, ok)
+	assert.Equal(t, "1", objRet.ID)
 
 	//sleep
 	time.Sleep(time.Duration(100) * time.Millisecond)
@@ -401,7 +405,7 @@ func TestRoute(t *testing.T) {
 	input := &GetInput{}
 	input.ID = "1"
 	ctx.SetInput(input)
-	ret, err := handler.Get(ctx)
+	ret, err = handler.Get(ctx)
 	stored := ret.(*entity.Route)
 	assert.Nil(t, err)
 	assert.Equal(t, stored.ID, route.ID)
@@ -938,7 +942,7 @@ func TestRoute(t *testing.T) {
 	dataPage = retPage.(*store.ListOutput)
 	assert.Equal(t, len(dataPage.Rows), 1)
 
-	//sleep
+	// sleep
 	time.Sleep(time.Duration(100) * time.Millisecond)
 
 	// list search and status not match
@@ -1024,8 +1028,11 @@ func TestRoute(t *testing.T) {
 	err = json.Unmarshal([]byte(reqBody), route3)
 	assert.Nil(t, err)
 	ctx.SetInput(route3)
-	_, err = handler.Create(ctx)
+	ret, err = handler.Create(ctx)
 	assert.Nil(t, err)
+	objRet, ok = ret.(*entity.Route)
+	assert.True(t, ok)
+	assert.Equal(t, "2", objRet.ID)
 
 	//sleep
 	time.Sleep(time.Duration(100) * time.Millisecond)
@@ -1153,8 +1160,11 @@ func TestRoute(t *testing.T) {
 	err = json.Unmarshal([]byte(reqBody), route11)
 	assert.Nil(t, err)
 	ctx.SetInput(route11)
-	_, err = handler.Create(ctx)
+	ret, err = handler.Create(ctx)
 	assert.Nil(t, err)
+	objRet, ok = ret.(*entity.Route)
+	assert.True(t, ok)
+	assert.Equal(t, "11", objRet.ID)
 
 	//sleep
 	time.Sleep(time.Duration(100) * time.Millisecond)
@@ -1288,8 +1298,11 @@ func Test_Route_With_Script_Dag2lua(t *testing.T) {
 	err = json.Unmarshal([]byte(reqBody), route)
 	assert.Nil(t, err)
 	ctx.SetInput(route)
-	_, err = handler.Create(ctx)
+	ret, err := handler.Create(ctx)
 	assert.Nil(t, err)
+	objRet, ok := ret.(*entity.Route)
+	assert.True(t, ok)
+	assert.Equal(t, "1", objRet.ID)
 
 	//sleep
 	time.Sleep(time.Duration(20) * time.Millisecond)
@@ -1298,7 +1311,7 @@ func Test_Route_With_Script_Dag2lua(t *testing.T) {
 	input := &GetInput{}
 	input.ID = "1"
 	ctx.SetInput(input)
-	ret, err := handler.Get(ctx)
+	ret, err = handler.Get(ctx)
 	stored := ret.(*entity.Route)
 	assert.Nil(t, err)
 	assert.Equal(t, stored.ID, route.ID)

--- a/api/internal/handler/service/service.go
+++ b/api/internal/handler/service/service.go
@@ -165,11 +165,12 @@ func (h *Handler) Create(c droplet.Context) (interface{}, error) {
 		}
 	}
 
-	if err := h.serviceStore.Create(c.Context(), input); err != nil {
+	ret, err := h.serviceStore.Create(c.Context(), input)
+	if err != nil {
 		return handler.SpecCodeResponse(err), err
 	}
 
-	return nil, nil
+	return ret, nil
 }
 
 type UpdateInput struct {

--- a/api/internal/handler/service/service_test.go
+++ b/api/internal/handler/service/service_test.go
@@ -68,8 +68,11 @@ func TestService(t *testing.T) {
 	err = json.Unmarshal([]byte(reqBody), service)
 	assert.Nil(t, err)
 	ctx.SetInput(service)
-	_, err = handler.Create(ctx)
+	ret, err := handler.Create(ctx)
 	assert.Nil(t, err)
+	objRet, ok := ret.(*entity.Service)
+	assert.True(t, ok)
+	assert.Equal(t, "1", objRet.ID)
 
 	//sleep
 	time.Sleep(time.Duration(100) * time.Millisecond)
@@ -78,7 +81,7 @@ func TestService(t *testing.T) {
 	input := &GetInput{}
 	input.ID = "1"
 	ctx.SetInput(input)
-	ret, err := handler.Get(ctx)
+	ret, err = handler.Get(ctx)
 	stored := ret.(*entity.Service)
 	assert.Nil(t, err)
 	assert.Equal(t, stored.ID, service.ID)
@@ -173,8 +176,11 @@ func TestService(t *testing.T) {
 	err = json.Unmarshal([]byte(reqBody), service11)
 	assert.Nil(t, err)
 	ctx.SetInput(service11)
-	_, err = handler.Create(ctx)
+	ret, err = handler.Create(ctx)
 	assert.Nil(t, err)
+	objRet, ok = ret.(*entity.Service)
+	assert.True(t, ok)
+	assert.Equal(t, "11", objRet.ID)
 
 	//sleep
 	time.Sleep(time.Duration(100) * time.Millisecond)

--- a/api/internal/handler/ssl/ssl.go
+++ b/api/internal/handler/ssl/ssl.go
@@ -189,11 +189,12 @@ func (h *Handler) Create(c droplet.Context) (interface{}, error) {
 	ssl.ID = input.ID
 	//set default value for SSL status, if not set, it will be 0 which means disable.
 	ssl.Status = conf.SSLDefaultStatus
-	if err := h.sslStore.Create(c.Context(), ssl); err != nil {
+	ret, err := h.sslStore.Create(c.Context(), ssl)
+	if err != nil {
 		return handler.SpecCodeResponse(err), err
 	}
 
-	return nil, nil
+	return ret, nil
 }
 
 type UpdateInput struct {

--- a/api/internal/handler/ssl/ssl_test.go
+++ b/api/internal/handler/ssl/ssl_test.go
@@ -54,8 +54,11 @@ func TestSSL(t *testing.T) {
 	err = json.Unmarshal([]byte(reqBody), ssl)
 	assert.Nil(t, err)
 	ctx.SetInput(ssl)
-	_, err = handler.Create(ctx)
+	ret, err := handler.Create(ctx)
 	assert.Nil(t, err)
+	objRet, ok := ret.(*entity.SSL)
+	assert.True(t, ok)
+	assert.Equal(t, "1", objRet.ID)
 
 	//sleep
 	time.Sleep(time.Duration(100) * time.Millisecond)
@@ -64,7 +67,7 @@ func TestSSL(t *testing.T) {
 	input := &GetInput{}
 	input.ID = "1"
 	ctx.SetInput(input)
-	ret, err := handler.Get(ctx)
+	ret, err = handler.Get(ctx)
 	stored := ret.(*entity.SSL)
 	assert.Nil(t, err)
 	assert.Equal(t, stored.ID, ssl.ID)

--- a/api/internal/handler/upstream/upstream.go
+++ b/api/internal/handler/upstream/upstream.go
@@ -149,11 +149,12 @@ func (h *Handler) List(c droplet.Context) (interface{}, error) {
 func (h *Handler) Create(c droplet.Context) (interface{}, error) {
 	input := c.Input().(*entity.Upstream)
 
-	if err := h.upstreamStore.Create(c.Context(), input); err != nil {
+	ret, err := h.upstreamStore.Create(c.Context(), input)
+	if err != nil {
 		return handler.SpecCodeResponse(err), err
 	}
 
-	return nil, nil
+	return ret, nil
 }
 
 type UpdateInput struct {

--- a/api/internal/handler/upstream/upstream_test.go
+++ b/api/internal/handler/upstream/upstream_test.go
@@ -96,8 +96,11 @@ func TestUpstream(t *testing.T) {
 	err = json.Unmarshal([]byte(reqBody), upstream)
 	assert.Nil(t, err)
 	ctx.SetInput(upstream)
-	_, err = upstreamHandler.Create(ctx)
+	ret, err := upstreamHandler.Create(ctx)
 	assert.Nil(t, err)
+	objRet, ok := ret.(*entity.Upstream)
+	assert.True(t, ok)
+	assert.Equal(t, "1", objRet.ID)
 
 	//sleep
 	time.Sleep(time.Duration(100) * time.Millisecond)
@@ -106,7 +109,7 @@ func TestUpstream(t *testing.T) {
 	input := &GetInput{}
 	input.ID = "1"
 	ctx.SetInput(input)
-	ret, err := upstreamHandler.Get(ctx)
+	ret, err = upstreamHandler.Get(ctx)
 	stored := ret.(*entity.Upstream)
 	assert.Nil(t, err)
 	assert.Equal(t, stored.ID, upstream.ID)
@@ -205,8 +208,11 @@ func TestUpstream_Pass_Host(t *testing.T) {
 	err := json.Unmarshal([]byte(reqBody), upstream)
 	assert.Nil(t, err)
 	ctx.SetInput(upstream)
-	_, err = upstreamHandler.Create(ctx)
+	ret, err := upstreamHandler.Create(ctx)
 	assert.Nil(t, err)
+	objRet, ok := ret.(*entity.Upstream)
+	assert.True(t, ok)
+	assert.Equal(t, "2", objRet.ID)
 
 	//sleep
 	time.Sleep(time.Duration(20) * time.Millisecond)
@@ -215,7 +221,7 @@ func TestUpstream_Pass_Host(t *testing.T) {
 	input := &GetInput{}
 	input.ID = "2"
 	ctx.SetInput(input)
-	ret, err := upstreamHandler.Get(ctx)
+	ret, err = upstreamHandler.Get(ctx)
 	stored := ret.(*entity.Upstream)
 	assert.Nil(t, err)
 	assert.Equal(t, stored.ID, upstream.ID)

--- a/api/test/e2e/service_test.go
+++ b/api/test/e2e/service_test.go
@@ -156,14 +156,17 @@ func TestService(t *testing.T) {
 	assert.Equal(t, "100", resp.Header["X-Ratelimit-Limit"][0])
 	assert.Equal(t, "99", resp.Header["X-Ratelimit-Remaining"][0])
 
+	// Create another service(id=s2) via HTTP POST to check the
+	// returned value, still attached to route(id=r1)
 	tests = []HttpTestCase{
 		{
-			Desc:    "create service with all options",
+			Desc:    "create service with all options via POST method",
 			Object:  ManagerApiExpect(t),
 			Method:  http.MethodPut,
-			Path:    "/apisix/admin/services/s1",
+			Path:    "/apisix/admin/services",
 			Headers: map[string]string{"Authorization": token},
 			Body: `{
+				"id": "s2",
 				"name": "testservice",
 				"desc": "testservice_desc",
 				"labels": {
@@ -192,12 +195,13 @@ func TestService(t *testing.T) {
 				}
 			}`,
 			ExpectStatus: http.StatusOK,
+			ExpectBody:   "\"id\":\"s2\"",
 		},
 		{
-			Desc:       "get the service s1",
+			Desc:       "get the service s2",
 			Object:     ManagerApiExpect(t),
 			Method:     http.MethodGet,
-			Path:       "/apisix/admin/services/s1",
+			Path:       "/apisix/admin/services/s2",
 			Headers:    map[string]string{"Authorization": token},
 			ExpectCode: http.StatusOK,
 			ExpectBody: "\"name\":\"testservice\",\"desc\":\"testservice_desc\",\"upstream\":{\"nodes\":[{\"host\":\"172.16.238.20\",\"port\":1980,\"weight\":1}],\"type\":\"roundrobin\"},\"plugins\":{\"limit-count\":{\"count\":100,\"key\":\"remote_addr\",\"rejected_code\":503,\"time_window\":60}},\"labels\":{\"build\":\"16\",\"env\":\"production\",\"version\":\"v2\"},\"enable_websocket\":true}",
@@ -209,7 +213,7 @@ func TestService(t *testing.T) {
 			Path:   "/apisix/admin/routes/r1",
 			Body: `{
 				"uri": "/hello",
-				"service_id": "s1"
+				"service_id": "s2"
 			}`,
 			Headers:      map[string]string{"Authorization": token},
 			ExpectStatus: http.StatusOK,
@@ -232,10 +236,21 @@ func TestService(t *testing.T) {
 func TestService_Teardown(t *testing.T) {
 	tests := []HttpTestCase{
 		{
-			Desc:         "delete the service",
+			// Delete the service created via HTTP PUT
+			Desc:         "delete the service(id=s1)",
 			Object:       ManagerApiExpect(t),
 			Method:       http.MethodDelete,
 			Path:         "/apisix/admin/services/s1",
+			Headers:      map[string]string{"Authorization": token},
+			ExpectStatus: http.StatusOK,
+			Sleep:        sleepTime,
+		},
+		{
+			// Delete the service created via HTTP POST
+			Desc:         "delete the service(id=s2)",
+			Object:       ManagerApiExpect(t),
+			Method:       http.MethodDelete,
+			Path:         "/apisix/admin/services/s2",
 			Headers:      map[string]string{"Authorization": token},
 			ExpectStatus: http.StatusOK,
 			Sleep:        sleepTime,

--- a/api/test/e2e/service_test.go
+++ b/api/test/e2e/service_test.go
@@ -162,7 +162,7 @@ func TestService(t *testing.T) {
 		{
 			Desc:    "create service with all options via POST method",
 			Object:  ManagerApiExpect(t),
-			Method:  http.MethodPut,
+			Method:  http.MethodPost,
 			Path:    "/apisix/admin/services",
 			Headers: map[string]string{"Authorization": token},
 			Body: `{

--- a/api/test/e2e/ssl_test.go
+++ b/api/test/e2e/ssl_test.go
@@ -82,6 +82,7 @@ func TestSSL_Basic(t *testing.T) {
 			Body:         string(body),
 			Headers:      map[string]string{"Authorization": token},
 			ExpectStatus: http.StatusOK,
+			ExpectBody:   "\"id\":\"1\"",
 		},
 		{
 			Desc:   "create route",


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [ ] Bugfix
- [x] New feature provided
- [ ] Improve performance
- [ ] Backport patches

- Related issues

Related to https://github.com/apache/apisix-dashboard/issues/1154 .

This PR is only going to support HTTP POST method for returning data. In order to completely fix #1154 , we also need to fix that for HTTP PUT methods. I will commit another PR for that soon.

___
### New feature or improvement
- Describe the details and related test reports.

As mentioned in #1154 , when creating an object via `POST` method in manager-api, there is no way to refer to that new object for API caller. This PR is going to additionally return all the object data stored in etcd back. See the following example:

Request sent to manager-api:

```
$ curl http://127.0.0.1:9000/apisix/admin/routes -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -H 'Authorization:auth-token' -X POST -d '{"uri": "/get","methods": ["GET"],"upstream": {"type": "roundrobin","nodes": {"httpbin.org:443": 1}},"plugins": {"proxy-rewrite": {"uri": "\/get","scheme": "https"},"key-auth": {},"response-rewrite": {"status_code": 200,"body": "{\"code\": 200, \"msg\": \"success\"}"}}}'
```

Response back to API caller:
```
{"code":0,"message":"","data":{"id":"337109164457198464","create_time":1610462319,"update_time":1610462319,"uri":"/get","methods":["GET"],"plugins":{"key-auth":{},"proxy-rewrite":{"scheme":"https","uri":"/get"},"response-rewrite":{"body":"{\"code\": 200, \"msg\": \"success\"}","status_code":200}},"upstream":{"nodes":{"httpbin.org:443":1},"type":"roundrobin"},"status":1},"request_id":"f9520603-528a-4494-9934-5620788f2ec2"
```
