### PR TITLE
fix: set get called false in the declaration 

### DIFF
--- a/api/internal/handler/consumer/consumer_test.go
+++ b/api/internal/handler/consumer/consumer_test.go
@@ -63,7 +63,7 @@ func TestHandler_Get(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.caseDesc, func(t *testing.T) {
-			getCalled := true
+			getCalled := false
 			mStore := &store.MockInterface{}
 			mStore.On("Get", mock.Anything).Run(func(args mock.Arguments) {
 				getCalled = true
@@ -140,7 +140,7 @@ func TestHandler_List(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.caseDesc, func(t *testing.T) {
-			getCalled := true
+			getCalled := false
 			mStore := &store.MockInterface{}
 			mStore.On("List", mock.Anything).Run(func(args mock.Arguments) {
 				getCalled = true

--- a/api/internal/handler/global_rule/global_rule_test.go
+++ b/api/internal/handler/global_rule/global_rule_test.go
@@ -101,7 +101,7 @@ func TestHandler_Get(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.caseDesc, func(t *testing.T) {
-			getCalled := true
+			getCalled := false
 			mStore := &store.MockInterface{}
 			mStore.On("Get", mock.Anything).Run(func(args mock.Arguments) {
 				getCalled = true
@@ -175,7 +175,7 @@ func TestHandler_List(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.caseDesc, func(t *testing.T) {
-			getCalled := true
+			getCalled := false
 			mStore := &store.MockInterface{}
 			mStore.On("List", mock.Anything).Run(func(args mock.Arguments) {
 				getCalled = true

--- a/api/internal/handler/server_info/server_info_test.go
+++ b/api/internal/handler/server_info/server_info_test.go
@@ -76,7 +76,7 @@ func TestHandler_Get(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.caseDesc, func(t *testing.T) {
-			getCalled := true
+			getCalled := false
 			mStore := &store.MockInterface{}
 			mStore.On("Get", mock.Anything).Run(func(args mock.Arguments) {
 				getCalled = true
@@ -188,7 +188,7 @@ func TestHandler_List(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.caseDesc, func(t *testing.T) {
-			getCalled := true
+			getCalled := false
 			mStore := &store.MockInterface{}
 			mStore.On("List", mock.Anything).Run(func(args mock.Arguments) {
 				getCalled = true


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

- Related issues

(#1281)
___
### Bugfix
- Description

Set get called false in the declaration so that we can check the value of `getCalled` accurately if the mock function is called.
