### PR TITLE
feat: Add returning value for HTTP PUT and PATCH methods

### DIFF
--- a/api/internal/core/store/store.go
+++ b/api/internal/core/store/store.go
@@ -284,8 +284,7 @@ func (s *GenericStore) Update(ctx context.Context, obj interface{}, createIfNotE
 	storedObj, ok := s.cache.Load(key)
 	if !ok {
 		if createIfNotExist {
-			_, err := s.Create(ctx, obj)
-			return nil, err
+			return s.Create(ctx, obj)
 		}
 		log.Warnf("key: %s is not found", key)
 		return nil, fmt.Errorf("key: %s is not found", key)

--- a/api/internal/core/store/store.go
+++ b/api/internal/core/store/store.go
@@ -38,7 +38,7 @@ type Interface interface {
 	Get(key string) (interface{}, error)
 	List(input ListInput) (*ListOutput, error)
 	Create(ctx context.Context, obj interface{}) (interface{}, error)
-	Update(ctx context.Context, obj interface{}, createIfNotExist bool) error
+	Update(ctx context.Context, obj interface{}, createIfNotExist bool) (interface{}, error)
 	BatchDelete(ctx context.Context, keys []string) error
 }
 
@@ -272,23 +272,23 @@ func (s *GenericStore) Create(ctx context.Context, obj interface{}) (interface{}
 	return obj, nil
 }
 
-func (s *GenericStore) Update(ctx context.Context, obj interface{}, createIfNotExist bool) error {
+func (s *GenericStore) Update(ctx context.Context, obj interface{}, createIfNotExist bool) (interface{}, error) {
 	if err := s.ingestValidate(obj); err != nil {
-		return err
+		return nil, err
 	}
 
 	key := s.opt.KeyFunc(obj)
 	if key == "" {
-		return fmt.Errorf("key is required")
+		return nil, fmt.Errorf("key is required")
 	}
 	storedObj, ok := s.cache.Load(key)
 	if !ok {
 		if createIfNotExist {
 			_, err := s.Create(ctx, obj)
-			return err
+			return nil, err
 		}
 		log.Warnf("key: %s is not found", key)
-		return fmt.Errorf("key: %s is not found", key)
+		return nil, fmt.Errorf("key: %s is not found", key)
 	}
 
 	if setter, ok := obj.(entity.BaseInfoGetter); ok {
@@ -301,13 +301,13 @@ func (s *GenericStore) Update(ctx context.Context, obj interface{}, createIfNotE
 	bs, err := json.Marshal(obj)
 	if err != nil {
 		log.Errorf("json marshal failed: %s", err)
-		return fmt.Errorf("json marshal failed: %s", err)
+		return nil, fmt.Errorf("json marshal failed: %s", err)
 	}
 	if err := s.Stg.Update(ctx, s.GetObjStorageKey(obj), string(bs)); err != nil {
-		return err
+		return nil, err
 	}
 
-	return nil
+	return obj, nil
 }
 
 func (s *GenericStore) BatchDelete(ctx context.Context, keys []string) error {

--- a/api/internal/core/store/store_mock.go
+++ b/api/internal/core/store/store_mock.go
@@ -54,9 +54,9 @@ func (m *MockInterface) Create(ctx context.Context, obj interface{}) (interface{
 	return ret.Get(0), ret.Error(1)
 }
 
-func (m *MockInterface) Update(ctx context.Context, obj interface{}, createOnFail bool) error {
+func (m *MockInterface) Update(ctx context.Context, obj interface{}, createOnFail bool) (interface{}, error) {
 	ret := m.Mock.Called(ctx, obj, createOnFail)
-	return ret.Error(0)
+	return ret.Get(0), ret.Error(1)
 }
 
 func (m *MockInterface) BatchDelete(ctx context.Context, keys []string) error {

--- a/api/internal/core/store/store_test.go
+++ b/api/internal/core/store/store_test.go
@@ -727,12 +727,17 @@ func TestGenericStore_Update(t *testing.T) {
 		tc.giveStore.Stg = mStorage
 		tc.giveStore.opt.Validator = mValidator
 
-		err := tc.giveStore.Update(context.TODO(), tc.giveObj, false)
+		ret, err := tc.giveStore.Update(context.TODO(), tc.giveObj, false)
 		assert.True(t, validateCalled, tc.caseDesc)
 		if err != nil {
 			assert.Equal(t, tc.wantErr, err, tc.caseDesc)
 			continue
 		}
+		retTs, ok := ret.(*TestStruct)
+		assert.True(t, ok)
+		// The returned value (retTs) should be the same as the input (tc.giveObj)
+		assert.Equal(t, tc.giveObj.Field1, retTs.Field1, tc.caseDesc)
+		assert.Equal(t, tc.giveObj.Field2, retTs.Field2, tc.caseDesc)
 		assert.True(t, createCalled, tc.caseDesc)
 	}
 }

--- a/api/internal/handler/consumer/consumer.go
+++ b/api/internal/handler/consumer/consumer.go
@@ -147,11 +147,12 @@ func (h *Handler) Set(c droplet.Context) (interface{}, error) {
 	input.Consumer.ID = input.Consumer.Username
 	ensurePluginsDefValue(input.Plugins)
 
-	if err := h.consumerStore.Update(c.Context(), &input.Consumer, true); err != nil {
+	ret, err := h.consumerStore.Update(c.Context(), &input.Consumer, true)
+	if err != nil {
 		return handler.SpecCodeResponse(err), err
 	}
 
-	return nil, nil
+	return ret, nil
 }
 
 func ensurePluginsDefValue(plugins map[string]interface{}) {

--- a/api/internal/handler/consumer/consumer_test.go
+++ b/api/internal/handler/consumer/consumer_test.go
@@ -177,6 +177,7 @@ func TestHandler_Create(t *testing.T) {
 		giveInput  *SetInput
 		giveCtx    context.Context
 		giveErr    error
+		giveRet    interface{}
 		wantErr    error
 		wantInput  *SetInput
 		wantRet    interface{}
@@ -193,6 +194,17 @@ func TestHandler_Create(t *testing.T) {
 				},
 			},
 			giveCtx: context.WithValue(context.Background(), "test", "value"),
+			giveRet: &entity.Consumer{
+				BaseInfo: entity.BaseInfo{
+					ID: "name",
+				},
+				Username: "name",
+				Plugins: map[string]interface{}{
+					"jwt-auth": map[string]interface{}{
+						"exp": 86400,
+					},
+				},
+			},
 			wantInput: &SetInput{
 				Consumer: entity.Consumer{
 					BaseInfo: entity.BaseInfo{
@@ -231,6 +243,9 @@ func TestHandler_Create(t *testing.T) {
 					},
 				},
 			},
+			giveRet: &data.SpecCodeResponse{
+				StatusCode: http.StatusInternalServerError,
+			},
 			giveErr: fmt.Errorf("create failed"),
 			wantInput: &SetInput{
 				Consumer: entity.Consumer{
@@ -262,7 +277,7 @@ func TestHandler_Create(t *testing.T) {
 				assert.Equal(t, tc.giveCtx, args.Get(0))
 				assert.Equal(t, &tc.wantInput.Consumer, args.Get(1))
 				assert.True(t, args.Bool(2))
-			}).Return(tc.giveErr)
+			}).Return(tc.giveRet, tc.giveErr)
 
 			h := Handler{consumerStore: mStore}
 			ctx := droplet.NewContext()
@@ -270,16 +285,7 @@ func TestHandler_Create(t *testing.T) {
 			ctx.SetContext(tc.giveCtx)
 			ret, err := h.Set(ctx)
 			assert.Equal(t, tc.wantCalled, methodCalled)
-			// if ret is entity.Consumer, need to ignore
-			// create_time and update_time before assertion
-			if retObj, ok := ret.(*entity.Consumer); ok {
-				retObj.BaseInfo.CreateTime = 0
-				retObj.BaseInfo.UpdateTime = 0
-				assert.Equal(t, tc.wantRet, retObj)
-			} else {
-				// tc.wantRet is *data.SpecCodeResponse
-				assert.Equal(t, tc.wantRet, ret)
-			}
+			assert.Equal(t, tc.wantRet, ret)
 			assert.Equal(t, tc.wantErr, err)
 		})
 	}
@@ -290,6 +296,7 @@ func TestHandler_Update(t *testing.T) {
 		caseDesc   string
 		giveInput  *SetInput
 		giveCtx    context.Context
+		giveRet    interface{}
 		giveErr    error
 		wantErr    error
 		wantInput  *entity.Consumer
@@ -309,6 +316,17 @@ func TestHandler_Update(t *testing.T) {
 				},
 			},
 			giveCtx: context.WithValue(context.Background(), "test", "value"),
+			giveRet: &entity.Consumer{
+				BaseInfo: entity.BaseInfo{
+					ID: "name",
+				},
+				Username: "name",
+				Plugins: map[string]interface{}{
+					"jwt-auth": map[string]interface{}{
+						"exp": 500,
+					},
+				},
+			},
 			wantInput: &entity.Consumer{
 				BaseInfo: entity.BaseInfo{
 					ID: "name",
@@ -343,6 +361,9 @@ func TestHandler_Update(t *testing.T) {
 					},
 				},
 			},
+			giveRet: &data.SpecCodeResponse{
+				StatusCode: http.StatusInternalServerError,
+			},
 			giveErr: fmt.Errorf("create failed"),
 			wantInput: &entity.Consumer{
 				BaseInfo: entity.BaseInfo{
@@ -372,7 +393,7 @@ func TestHandler_Update(t *testing.T) {
 				assert.Equal(t, tc.giveCtx, args.Get(0))
 				assert.Equal(t, tc.wantInput, args.Get(1))
 				assert.True(t, args.Bool(2))
-			}).Return(tc.giveErr)
+			}).Return(tc.giveRet, tc.giveErr)
 
 			h := Handler{consumerStore: mStore}
 			ctx := droplet.NewContext()
@@ -380,16 +401,7 @@ func TestHandler_Update(t *testing.T) {
 			ctx.SetContext(tc.giveCtx)
 			ret, err := h.Set(ctx)
 			assert.Equal(t, tc.wantCalled, methodCalled)
-			// if ret is entity.Consumer, need to ignore
-			// create_time and update_time before assertion
-			if retObj, ok := ret.(*entity.Consumer); ok {
-				retObj.BaseInfo.CreateTime = 0
-				retObj.BaseInfo.UpdateTime = 0
-				assert.Equal(t, tc.wantRet, retObj)
-			} else {
-				// tc.wantRet is *data.SpecCodeResponse
-				assert.Equal(t, tc.wantRet, ret)
-			}
+			assert.Equal(t, tc.wantRet, ret)
 			assert.Equal(t, tc.wantErr, err)
 		})
 	}

--- a/api/internal/handler/consumer/consumer_test.go
+++ b/api/internal/handler/consumer/consumer_test.go
@@ -206,7 +206,17 @@ func TestHandler_Create(t *testing.T) {
 					},
 				},
 			},
-			wantRet:    nil,
+			wantRet: &entity.Consumer{
+				BaseInfo: entity.BaseInfo{
+					ID: "name",
+				},
+				Username: "name",
+				Plugins: map[string]interface{}{
+					"jwt-auth": map[string]interface{}{
+						"exp": 86400,
+					},
+				},
+			},
 			wantCalled: true,
 		},
 		{
@@ -260,7 +270,16 @@ func TestHandler_Create(t *testing.T) {
 			ctx.SetContext(tc.giveCtx)
 			ret, err := h.Set(ctx)
 			assert.Equal(t, tc.wantCalled, methodCalled)
-			assert.Equal(t, tc.wantRet, ret)
+			// if ret is entity.Consumer, need to ignore
+			// create_time and update_time before assertion
+			if retObj, ok := ret.(*entity.Consumer); ok {
+				retObj.BaseInfo.CreateTime = 0
+				retObj.BaseInfo.UpdateTime = 0
+				assert.Equal(t, tc.wantRet, retObj)
+			} else {
+				// tc.wantRet is *data.SpecCodeResponse
+				assert.Equal(t, tc.wantRet, ret)
+			}
 			assert.Equal(t, tc.wantErr, err)
 		})
 	}
@@ -301,7 +320,17 @@ func TestHandler_Update(t *testing.T) {
 					},
 				},
 			},
-			wantRet:    nil,
+			wantRet: &entity.Consumer{
+				BaseInfo: entity.BaseInfo{
+					ID: "name",
+				},
+				Username: "name",
+				Plugins: map[string]interface{}{
+					"jwt-auth": map[string]interface{}{
+						"exp": 500,
+					},
+				},
+			},
 			wantCalled: true,
 		},
 		{
@@ -351,7 +380,16 @@ func TestHandler_Update(t *testing.T) {
 			ctx.SetContext(tc.giveCtx)
 			ret, err := h.Set(ctx)
 			assert.Equal(t, tc.wantCalled, methodCalled)
-			assert.Equal(t, tc.wantRet, ret)
+			// if ret is entity.Consumer, need to ignore
+			// create_time and update_time before assertion
+			if retObj, ok := ret.(*entity.Consumer); ok {
+				retObj.BaseInfo.CreateTime = 0
+				retObj.BaseInfo.UpdateTime = 0
+				assert.Equal(t, tc.wantRet, retObj)
+			} else {
+				// tc.wantRet is *data.SpecCodeResponse
+				assert.Equal(t, tc.wantRet, ret)
+			}
 			assert.Equal(t, tc.wantErr, err)
 		})
 	}

--- a/api/internal/handler/global_rule/global_rule.go
+++ b/api/internal/handler/global_rule/global_rule.go
@@ -141,11 +141,12 @@ func (h *Handler) Set(c droplet.Context) (interface{}, error) {
 		input.GlobalPlugins.ID = input.ID
 	}
 
-	if err := h.globalRuleStore.Update(c.Context(), &input.GlobalPlugins, true); err != nil {
+	ret, err := h.globalRuleStore.Update(c.Context(), &input.GlobalPlugins, true)
+	if err != nil {
 		return handler.SpecCodeResponse(err), err
 	}
 
-	return nil, nil
+	return ret, nil
 }
 
 func Patch(c *gin.Context) (interface{}, error) {
@@ -170,11 +171,12 @@ func Patch(c *gin.Context) (interface{}, error) {
 		return handler.SpecCodeResponse(err), err
 	}
 
-	if err := routeStore.Update(c, &globalRule, false); err != nil {
+	ret, err := routeStore.Update(c, &globalRule, false)
+	if err != nil {
 		return handler.SpecCodeResponse(err), err
 	}
 
-	return nil, nil
+	return ret, nil
 }
 
 type BatchDeleteInput struct {

--- a/api/internal/handler/global_rule/global_rule_test.go
+++ b/api/internal/handler/global_rule/global_rule_test.go
@@ -234,7 +234,12 @@ func TestHandler_Set(t *testing.T) {
 					"jwt-auth": map[string]interface{}{},
 				},
 			},
-			wantRet:    nil,
+			wantRet: &entity.GlobalPlugins{
+				BaseInfo: entity.BaseInfo{ID: "name"},
+				Plugins: map[string]interface{}{
+					"jwt-auth": map[string]interface{}{},
+				},
+			},
 			wantCalled: true,
 		},
 		{
@@ -273,7 +278,16 @@ func TestHandler_Set(t *testing.T) {
 			ctx.SetContext(tc.giveCtx)
 			ret, err := h.Set(ctx)
 			assert.Equal(t, tc.wantCalled, methodCalled)
-			assert.Equal(t, tc.wantRet, ret)
+			// if ret is entity.GlobalPlugins, need to ignore
+			// create_time and update_time before assertion
+			if retObj, ok := ret.(*entity.GlobalPlugins); ok {
+				retObj.BaseInfo.CreateTime = 0
+				retObj.BaseInfo.UpdateTime = 0
+				assert.Equal(t, tc.wantRet, retObj)
+			} else {
+				// tc.wantRet is *data.SpecCodeResponse
+				assert.Equal(t, tc.wantRet, ret)
+			}
 			assert.Equal(t, tc.wantErr, err)
 		})
 	}

--- a/api/internal/handler/route/route.go
+++ b/api/internal/handler/route/route.go
@@ -101,11 +101,12 @@ func Patch(c *gin.Context) (interface{}, error) {
 		return handler.SpecCodeResponse(err), err
 	}
 
-	if err := routeStore.Update(c, &route, false); err != nil {
+	ret, err := routeStore.Update(c, &route, false)
+	if err != nil {
 		return handler.SpecCodeResponse(err), err
 	}
 
-	return nil, nil
+	return ret, nil
 }
 
 type GetInput struct {
@@ -427,7 +428,7 @@ func (h *Handler) Update(c droplet.Context) (interface{}, error) {
 		}
 
 		//save original conf
-		if err = h.scriptStore.Update(c.Context(), script, true); err != nil {
+		if _, err = h.scriptStore.Update(c.Context(), script, true); err != nil {
 			//if not exists, create
 			if err.Error() == fmt.Sprintf("key: %s is not found", script.ID) {
 				if _, err := h.scriptStore.Create(c.Context(), script); err != nil {
@@ -448,11 +449,12 @@ func (h *Handler) Update(c droplet.Context) (interface{}, error) {
 		}
 	}
 
-	if err := h.routeStore.Update(c.Context(), &input.Route, true); err != nil {
+	ret, err := h.routeStore.Update(c.Context(), &input.Route, true)
+	if err != nil {
 		return handler.SpecCodeResponse(err), err
 	}
 
-	return nil, nil
+	return ret, nil
 }
 
 type BatchDelete struct {

--- a/api/internal/handler/route/route_test.go
+++ b/api/internal/handler/route/route_test.go
@@ -757,8 +757,13 @@ func TestRoute(t *testing.T) {
 	err = json.Unmarshal([]byte(reqBody), route2)
 	assert.Nil(t, err)
 	ctx.SetInput(route2)
-	_, err = handler.Update(ctx)
+	ret, err = handler.Update(ctx)
 	assert.Nil(t, err)
+	// check the returned value
+	objRet, ok = ret.(*entity.Route)
+	assert.True(t, ok)
+	assert.Equal(t, route2.ID, objRet.ID)
+	assert.Equal(t, route2.Labels, objRet.Labels)
 
 	//sleep
 	time.Sleep(time.Duration(100) * time.Millisecond)
@@ -819,6 +824,10 @@ func TestRoute(t *testing.T) {
 	ctx.SetInput(errRoute)
 	ret, err = handler.Update(ctx)
 	assert.Nil(t, err)
+	// Check the returned value
+	objRet, ok = ret.(*entity.Route)
+	assert.True(t, ok)
+	assert.Equal(t, errRoute.ID, objRet.ID)
 
 	// Success: tests the Body ID can be nil
 	reqBodyErr = `{
@@ -839,6 +848,10 @@ func TestRoute(t *testing.T) {
 	ctx.SetInput(errRoute)
 	ret, err = handler.Update(ctx)
 	assert.Nil(t, err)
+	// Check the returned value
+	objRet, ok = ret.(*entity.Route)
+	assert.True(t, ok)
+	assert.Equal(t, errRoute.ID, objRet.ID)
 
 	//sleep
 	time.Sleep(time.Duration(100) * time.Millisecond)
@@ -1339,6 +1352,12 @@ func Test_Route_With_Script_Dag2lua(t *testing.T) {
 	ctx.SetInput(route2)
 	_, err = handler.Update(ctx)
 	assert.Nil(t, err)
+	// check the returned value
+	objRet, ok = ret.(*entity.Route)
+	assert.True(t, ok)
+	assert.Equal(t, route2.ID, objRet.ID)
+	// script returned should be nil
+	assert.Nil(t, objRet.Script)
 
 	//sleep
 	time.Sleep(time.Duration(100) * time.Millisecond)
@@ -1433,8 +1452,14 @@ func Test_Route_With_Script_Luacode(t *testing.T) {
 	err = json.Unmarshal([]byte(reqBody), route2)
 	assert.Nil(t, err)
 	ctx.SetInput(route2)
-	_, err = handler.Update(ctx)
+	ret, err = handler.Update(ctx)
 	assert.Nil(t, err)
+	// check the returned value
+	objRet, ok := ret.(*entity.Route)
+	assert.True(t, ok)
+	assert.Equal(t, route2.ID, objRet.ID)
+	// script returned should be nil
+	assert.Nil(t, objRet.Script)
 
 	//sleep
 	time.Sleep(time.Duration(100) * time.Millisecond)

--- a/api/internal/handler/route/route_test.go
+++ b/api/internal/handler/route/route_test.go
@@ -1350,7 +1350,7 @@ func Test_Route_With_Script_Dag2lua(t *testing.T) {
 	err = json.Unmarshal([]byte(reqBody), route2)
 	assert.Nil(t, err)
 	ctx.SetInput(route2)
-	_, err = handler.Update(ctx)
+	ret, err = handler.Update(ctx)
 	assert.Nil(t, err)
 	// check the returned value
 	objRet, ok = ret.(*entity.Route)

--- a/api/internal/handler/service/service.go
+++ b/api/internal/handler/service/service.go
@@ -202,11 +202,12 @@ func (h *Handler) Update(c droplet.Context) (interface{}, error) {
 		}
 	}
 
-	if err := h.serviceStore.Update(c.Context(), &input.Service, true); err != nil {
+	ret, err := h.serviceStore.Update(c.Context(), &input.Service, true)
+	if err != nil {
 		return handler.SpecCodeResponse(err), err
 	}
 
-	return nil, nil
+	return ret, nil
 }
 
 type BatchDelete struct {
@@ -255,9 +256,10 @@ func (h *Handler) Patch(c droplet.Context) (interface{}, error) {
 		return handler.SpecCodeResponse(err), err
 	}
 
-	if err := h.serviceStore.Update(c.Context(), &stored, false); err != nil {
+	ret, err := h.serviceStore.Update(c.Context(), &stored, false)
+	if err != nil {
 		return handler.SpecCodeResponse(err), err
 	}
 
-	return nil, nil
+	return ret, nil
 }

--- a/api/internal/handler/service/service_test.go
+++ b/api/internal/handler/service/service_test.go
@@ -112,8 +112,13 @@ func TestService(t *testing.T) {
 	err = json.Unmarshal([]byte(reqBody), service2)
 	assert.Nil(t, err)
 	ctx.SetInput(service2)
-	_, err = handler.Update(ctx)
+	ret, err = handler.Update(ctx)
 	assert.Nil(t, err)
+	// Check the returned value
+	objRet, ok = ret.(*entity.Service)
+	assert.True(t, ok)
+	assert.Equal(t, service2.ID, objRet.ID)
+	assert.Equal(t, service2.Name, objRet.Name)
 
 	//sleep
 	time.Sleep(time.Duration(100) * time.Millisecond)

--- a/api/internal/handler/ssl/ssl.go
+++ b/api/internal/handler/ssl/ssl.go
@@ -221,11 +221,12 @@ func (h *Handler) Update(c droplet.Context) (interface{}, error) {
 
 	//set default value for SSL status, if not set, it will be 0 which means disable.
 	ssl.Status = conf.SSLDefaultStatus
-	if err := h.sslStore.Update(c.Context(), ssl, true); err != nil {
+	ret, err := h.sslStore.Update(c.Context(), ssl, true)
+	if err != nil {
 		return handler.SpecCodeResponse(err), err
 	}
 
-	return nil, nil
+	return ret, nil
 }
 
 func Patch(c *gin.Context) (interface{}, error) {
@@ -250,11 +251,12 @@ func Patch(c *gin.Context) (interface{}, error) {
 		return handler.SpecCodeResponse(err), err
 	}
 
-	if err := sslStore.Update(c, &ssl, false); err != nil {
+	ret, err := sslStore.Update(c, &ssl, false)
+	if err != nil {
 		return handler.SpecCodeResponse(err), err
 	}
 
-	return nil, nil
+	return ret, nil
 }
 
 type BatchDelete struct {

--- a/api/internal/handler/ssl/ssl_test.go
+++ b/api/internal/handler/ssl/ssl_test.go
@@ -85,6 +85,12 @@ func TestSSL(t *testing.T) {
 	ctx.SetInput(ssl2)
 	_, err = handler.Update(ctx)
 	assert.Nil(t, err)
+	// check the returned value
+	objRet, ok = ret.(*entity.SSL)
+	assert.True(t, ok)
+	assert.Equal(t, "1", objRet.ID)
+	assert.Equal(t, ssl2.Key, objRet.Key)
+	assert.Equal(t, ssl2.Cert, objRet.Cert)
 
 	//list
 	listInput := &ListInput{}

--- a/api/internal/handler/ssl/ssl_test.go
+++ b/api/internal/handler/ssl/ssl_test.go
@@ -83,7 +83,7 @@ func TestSSL(t *testing.T) {
 	err = json.Unmarshal([]byte(reqBody), ssl2)
 	assert.Nil(t, err)
 	ctx.SetInput(ssl2)
-	_, err = handler.Update(ctx)
+	ret, err = handler.Update(ctx)
 	assert.Nil(t, err)
 	// check the returned value
 	objRet, ok = ret.(*entity.SSL)

--- a/api/internal/handler/upstream/upstream.go
+++ b/api/internal/handler/upstream/upstream.go
@@ -174,11 +174,12 @@ func (h *Handler) Update(c droplet.Context) (interface{}, error) {
 		input.Upstream.ID = input.ID
 	}
 
-	if err := h.upstreamStore.Update(c.Context(), &input.Upstream, true); err != nil {
+	ret, err := h.upstreamStore.Update(c.Context(), &input.Upstream, true)
+	if err != nil {
 		return handler.SpecCodeResponse(err), err
 	}
 
-	return nil, nil
+	return ret, nil
 }
 
 type BatchDelete struct {
@@ -227,11 +228,12 @@ func (h *Handler) Patch(c droplet.Context) (interface{}, error) {
 		return handler.SpecCodeResponse(err), err
 	}
 
-	if err := h.upstreamStore.Update(c.Context(), &stored, false); err != nil {
+	ret, err := h.upstreamStore.Update(c.Context(), &stored, false)
+	if err != nil {
 		return handler.SpecCodeResponse(err), err
 	}
 
-	return nil, nil
+	return ret, nil
 }
 
 type ExistInput struct {

--- a/api/internal/handler/upstream/upstream_test.go
+++ b/api/internal/handler/upstream/upstream_test.go
@@ -166,8 +166,12 @@ func TestUpstream(t *testing.T) {
 	err = json.Unmarshal([]byte(reqBody), upstream2)
 	assert.Nil(t, err)
 	ctx.SetInput(upstream2)
-	_, err = upstreamHandler.Update(ctx)
+	ret, err = upstreamHandler.Update(ctx)
 	assert.Nil(t, err)
+	// check the returned value
+	objRet, ok = ret.(*entity.Upstream)
+	assert.True(t, ok)
+	assert.Equal(t, upstream2.ID, objRet.ID)
 
 	//list
 	listInput := &ListInput{}

--- a/api/test/e2e/consumer_test.go
+++ b/api/test/e2e/consumer_test.go
@@ -87,7 +87,7 @@ func TestConsumer_Create_And_Get(t *testing.T) {
 			}`,
 			Headers:      map[string]string{"Authorization": token},
 			ExpectStatus: http.StatusOK,
-			ExpectBody:   "\"code\":0",
+			ExpectBody:   []string{"\"code\":0", "\"username\":\"consumer_2\""},
 		},
 		{
 			Desc:         "get consumer",
@@ -156,7 +156,7 @@ func TestConsumer_Update_And_Get(t *testing.T) {
 			}`,
 			Headers:      map[string]string{"Authorization": token},
 			ExpectStatus: http.StatusOK,
-			ExpectBody:   "\"code\":0",
+			ExpectBody:   []string{"\"code\":0", "\"username\":\"consumer_3\"", "\"rejected_code\":503"},
 		},
 		{
 			Desc:   "update consumer by PUT",
@@ -177,7 +177,7 @@ func TestConsumer_Update_And_Get(t *testing.T) {
 			}`,
 			Headers:      map[string]string{"Authorization": token},
 			ExpectStatus: http.StatusOK,
-			ExpectBody:   "\"code\":0",
+			ExpectBody:   []string{"\"code\":0", "\"username\":\"consumer_3\"", "\"rejected_code\":504"},
 		},
 		{
 			Desc:         "get consumer",

--- a/api/test/e2e/global_rule_test.go
+++ b/api/test/e2e/global_rule_test.go
@@ -74,6 +74,7 @@ func TestGlobalRule(t *testing.T) {
                         }`,
 			Headers:      map[string]string{"Authorization": token},
 			ExpectStatus: http.StatusOK,
+			ExpectBody:   "\"X-VERSION\":\"1.0\"",
 		},
 		{
 			Desc:          "verify route with header",
@@ -119,6 +120,7 @@ func TestGlobalRule(t *testing.T) {
 			 }`,
 			Headers:      map[string]string{"Authorization": token},
 			ExpectStatus: http.StatusOK,
+			ExpectBody:   "\"X-VERSION\":\"2.0\"",
 		},
 		{
 			Desc:          "verify route that header should be the same as the route config",
@@ -154,6 +156,7 @@ func TestGlobalRule(t *testing.T) {
 			}`,
 			Headers:      map[string]string{"Authorization": token},
 			ExpectStatus: http.StatusOK,
+			ExpectBody:   "\"key-auth\":{}",
 		},
 		{
 			Desc:         "make sure that patch succeeded",
@@ -175,6 +178,7 @@ func TestGlobalRule(t *testing.T) {
 			}`,
 			Headers:      map[string]string{"Authorization": token},
 			ExpectStatus: http.StatusOK,
+			UnexpectBody: "\"key-auth\":{}",
 		},
 		{
 			Desc:          "make sure that patch succeeded",

--- a/api/test/e2e/route_test.go
+++ b/api/test/e2e/route_test.go
@@ -131,6 +131,7 @@ func TestRoute_Create_With_Hosts(t *testing.T) {
 			}`,
 			Headers:      map[string]string{"Authorization": token},
 			ExpectStatus: http.StatusOK,
+			ExpectBody:   []string{"\"id\":\"1\"", "\"uri\":\"/hello_\""},
 		},
 		{
 			Desc:   "create route with int uri",
@@ -227,6 +228,7 @@ func TestRoute_Update_Routes_With_Hosts(t *testing.T) {
 			}`,
 			Headers:      map[string]string{"Authorization": token},
 			ExpectStatus: http.StatusOK,
+			ExpectBody:   []string{"\"id\":\"1\"", "\"hosts\":[\"foo.com\"]"},
 		},
 		{
 			Desc:         "hit the route just create",
@@ -254,6 +256,7 @@ func TestRoute_Update_Routes_With_Hosts(t *testing.T) {
 			}`,
 			Headers:      map[string]string{"Authorization": token},
 			ExpectStatus: http.StatusOK,
+			ExpectBody:   []string{"\"id\":\"1\"", "\"hosts\":[\"bar.com\"]"},
 		},
 		{
 			Desc:         "hit the route with host foo.com",

--- a/api/test/e2e/route_test.go
+++ b/api/test/e2e/route_test.go
@@ -131,7 +131,7 @@ func TestRoute_Create_With_Hosts(t *testing.T) {
 			}`,
 			Headers:      map[string]string{"Authorization": token},
 			ExpectStatus: http.StatusOK,
-			ExpectBody:   []string{"\"id\":\"1\"", "\"uri\":\"/hello_\""},
+			ExpectBody:   []string{"\"id\":\"r1\"", "\"uri\":\"/hello_\""},
 		},
 		{
 			Desc:   "create route with int uri",
@@ -228,7 +228,7 @@ func TestRoute_Update_Routes_With_Hosts(t *testing.T) {
 			}`,
 			Headers:      map[string]string{"Authorization": token},
 			ExpectStatus: http.StatusOK,
-			ExpectBody:   []string{"\"id\":\"1\"", "\"hosts\":[\"foo.com\"]"},
+			ExpectBody:   []string{"\"id\":\"r1\"", "\"hosts\":[\"foo.com\"]"},
 		},
 		{
 			Desc:         "hit the route just create",
@@ -256,7 +256,7 @@ func TestRoute_Update_Routes_With_Hosts(t *testing.T) {
 			}`,
 			Headers:      map[string]string{"Authorization": token},
 			ExpectStatus: http.StatusOK,
-			ExpectBody:   []string{"\"id\":\"1\"", "\"hosts\":[\"bar.com\"]"},
+			ExpectBody:   []string{"\"id\":\"r1\"", "\"hosts\":[\"bar.com\"]"},
 		},
 		{
 			Desc:         "hit the route with host foo.com",

--- a/api/test/e2e/service_test.go
+++ b/api/test/e2e/service_test.go
@@ -54,6 +54,7 @@ func TestService(t *testing.T) {
 				}
 			}`,
 			ExpectStatus: http.StatusOK,
+			ExpectBody:   []string{"\"id\":\"s1\"", "\"name\":\"testservice\""},
 		},
 		{
 			Desc:       "get the service s1",

--- a/api/test/e2e/ssl_test.go
+++ b/api/test/e2e/ssl_test.go
@@ -131,6 +131,7 @@ func TestSSL_Basic(t *testing.T) {
 			}`,
 			Headers:      map[string]string{"Authorization": token},
 			ExpectStatus: http.StatusOK,
+			ExpectBody:   "\"status\": 0",
 		},
 	}
 
@@ -155,6 +156,7 @@ func TestSSL_Basic(t *testing.T) {
 			Body:         `1`,
 			Headers:      map[string]string{"Authorization": token},
 			ExpectStatus: http.StatusOK,
+			ExpectBody:   "\"status\": 1",
 		},
 		{
 			Desc:         "hit the route using HTTPS, make sure enable successful",

--- a/api/test/e2e/ssl_test.go
+++ b/api/test/e2e/ssl_test.go
@@ -131,7 +131,7 @@ func TestSSL_Basic(t *testing.T) {
 			}`,
 			Headers:      map[string]string{"Authorization": token},
 			ExpectStatus: http.StatusOK,
-			ExpectBody:   "\"status\": 0",
+			ExpectBody:   "\"status\":0",
 		},
 	}
 
@@ -156,7 +156,7 @@ func TestSSL_Basic(t *testing.T) {
 			Body:         `1`,
 			Headers:      map[string]string{"Authorization": token},
 			ExpectStatus: http.StatusOK,
-			ExpectBody:   "\"status\": 1",
+			ExpectBody:   "\"status\":1",
 		},
 		{
 			Desc:         "hit the route using HTTPS, make sure enable successful",

--- a/api/test/e2e/upstream_chash_query_string_arg_xxx_test.go
+++ b/api/test/e2e/upstream_chash_query_string_arg_xxx_test.go
@@ -55,6 +55,7 @@ func TestUpstream_chash_query_string(t *testing.T) {
 				}`,
 			Headers:      map[string]string{"Authorization": token},
 			ExpectStatus: http.StatusOK,
+			ExpectBody:   []string{"\"id\":\"1\"", "\"key\":\"query_string\""},
 		},
 		{
 			Desc:   "create route using the upstream just created",
@@ -131,6 +132,7 @@ func TestUpstream_chash_arg_xxx(t *testing.T) {
 				}`,
 			Headers:      map[string]string{"Authorization": token},
 			ExpectStatus: http.StatusOK,
+			ExpectBody:   []string{"\"id\":\"1\"", "\"key\":\"arg_device_id\""},
 		},
 	}
 


### PR DESCRIPTION
Signed-off-by: imjoey <majunjiev@gmail.com>

Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

- Related issues

Related to https://github.com/apache/apisix-dashboard/issues/1154 .

___
### Bugfix
- Description

As described in #1154 , when manipulating an object via PUT/PATCH method in manager-api, there is no data returned.

- How to fix?

 In order to get along with APISIX Admin API, this PR is going to additionally return all the object data back for  PUT or PATCH methods. 

> This PR is also a counterpart of https://github.com/apache/apisix-dashboard/pull/1277 , will completely revolve #1154 .

