### PR TITLE
fix: ignore the init_dir event when watching etcd events

### DIFF
--- a/api/internal/core/storage/etcd.go
+++ b/api/internal/core/storage/etcd.go
@@ -29,9 +29,9 @@ import (
 )
 
 const (
-	// SkippedValueInitDir indicates the init_dir etcd
-	// event will be skipped
-	SkippedValueInitDir = "init_dir"
+	// SkippedValueEtcdInitDir indicates the init_dir
+	// etcd event will be skipped
+	SkippedValueEtcdInitDir = "init_dir"
 )
 
 var (
@@ -127,7 +127,7 @@ func (s *EtcdV3Storage) List(ctx context.Context, key string) ([]Keypair, error)
 			Key:   string(resp.Kvs[i].Key),
 			Value: string(resp.Kvs[i].Value),
 			// Mark the init_dir etcd event as skippable if value is init_dir
-			Skipped: string(resp.Kvs[i].Value) == SkippedValueInitDir,
+			Skipped: string(resp.Kvs[i].Value) == SkippedValueEtcdInitDir,
 		}
 		ret = append(ret, data)
 	}
@@ -184,7 +184,7 @@ func (s *EtcdV3Storage) Watch(ctx context.Context, key string) <-chan WatchRespo
 						Value: string(event.Events[i].Kv.Value),
 						// Mark the init_dir etcd event as skippable
 						// if it's a init_dir event
-						Skipped: string(event.Events[i].Kv.Value) == SkippedValueInitDir,
+						Skipped: string(event.Events[i].Kv.Value) == SkippedValueEtcdInitDir,
 					},
 				}
 				switch event.Events[i].Type {

--- a/api/internal/core/storage/etcd.go
+++ b/api/internal/core/storage/etcd.go
@@ -30,8 +30,16 @@ import (
 
 const (
 	// SkippedValueEtcdInitDir indicates the init_dir
-	// etcd event will be skipped
+	// etcd event will be skipped.
 	SkippedValueEtcdInitDir = "init_dir"
+
+	// SkippedValueEtcdEmptyObject indicates the data with an
+	// empty JSON value `{}`, which may be set by APISIX,
+	// should be also skipped.
+	//
+	// Important: at present, `{}`` is considered as invalid,
+	// but may be changed in the future.
+	SkippedValueEtcdEmptyObject = "{}"
 )
 
 var (
@@ -126,8 +134,13 @@ func (s *EtcdV3Storage) List(ctx context.Context, key string) ([]Keypair, error)
 		data := Keypair{
 			Key:   string(resp.Kvs[i].Key),
 			Value: string(resp.Kvs[i].Value),
-			// Mark the init_dir etcd event as skippable if value is init_dir
-			Skipped: string(resp.Kvs[i].Value) == SkippedValueEtcdInitDir,
+			// Mark as skippable if its value is init_dir or {}
+			// during fetching-all phase.
+			//
+			// For more complex cases, a explicit function to determine if
+			// skippable would be better.
+			Skipped: string(resp.Kvs[i].Value) == SkippedValueEtcdInitDir ||
+				string(resp.Kvs[i].Value) == SkippedValueEtcdEmptyObject,
 		}
 		ret = append(ret, data)
 	}
@@ -182,9 +195,13 @@ func (s *EtcdV3Storage) Watch(ctx context.Context, key string) <-chan WatchRespo
 					Keypair: Keypair{
 						Key:   string(event.Events[i].Kv.Key),
 						Value: string(event.Events[i].Kv.Value),
-						// Mark the init_dir etcd event as skippable
-						// if it's a init_dir event
-						Skipped: string(event.Events[i].Kv.Value) == SkippedValueEtcdInitDir,
+						// Mark this Keypais as skippable if its value is init_dir or {}
+						// during watching phase.
+						//
+						// For more complex cases, a explicit function to determine if
+						// skippable would be better.
+						Skipped: string(event.Events[i].Kv.Value) == SkippedValueEtcdInitDir ||
+							string(event.Events[i].Kv.Value) == SkippedValueEtcdEmptyObject,
 					},
 				}
 				switch event.Events[i].Type {

--- a/api/internal/core/storage/storage.go
+++ b/api/internal/core/storage/storage.go
@@ -36,7 +36,7 @@ type WatchResponse struct {
 type Keypair struct {
 	Key   string
 	Value string
-	// If true, this keypair will NOT be processed in store
+	// If true, this keypair will NOT be processed in store.
 	Skipped bool
 }
 

--- a/api/internal/core/storage/storage.go
+++ b/api/internal/core/storage/storage.go
@@ -36,12 +36,13 @@ type WatchResponse struct {
 type Keypair struct {
 	Key   string
 	Value string
+	// If true, this keypair will NOT be processed in store
+	Skipped bool
 }
 
 type Event struct {
-	Type  EventType
-	Key   string
-	Value string
+	Keypair
+	Type EventType
 }
 
 type EventType string

--- a/api/internal/core/store/store.go
+++ b/api/internal/core/store/store.go
@@ -96,7 +96,9 @@ func (s *GenericStore) Init() error {
 		return err
 	}
 	for i := range ret {
-		if ret[i].Value == "init_dir" {
+		// If the kv has been marked as skippable in underlying storage,
+		// just skip it
+		if ret[i].Skipped {
 			continue
 		}
 		key := ret[i].Key[len(s.opt.BasePath)+1:]
@@ -119,6 +121,11 @@ func (s *GenericStore) Init() error {
 			for i := range event.Events {
 				switch event.Events[i].Type {
 				case storage.EventTypePut:
+					// If the watch event has been marked as skippable
+					// in underlying storage, just skip it
+					if event.Events[i].Skipped {
+						continue
+					}
 					key := event.Events[i].Key[len(s.opt.BasePath)+1:]
 					objPtr, err := s.StringToObjPtr(event.Events[i].Value, key)
 					if err != nil {

--- a/api/internal/core/store/store_test.go
+++ b/api/internal/core/store/store_test.go
@@ -148,13 +148,17 @@ func TestGenericStore_Init(t *testing.T) {
 			giveResp: storage.WatchResponse{
 				Events: []storage.Event{
 					{
-						Type:  storage.EventTypePut,
-						Key:   "test/demo3-f1",
-						Value: `{"Field1":"demo3-f1", "Field2":"demo3-f2"}`,
+						Keypair: storage.Keypair{
+							Key:   "test/demo3-f1",
+							Value: `{"Field1":"demo3-f1", "Field2":"demo3-f2"}`,
+						},
+						Type: storage.EventTypePut,
 					},
 					{
 						Type: storage.EventTypeDelete,
-						Key:  "test/demo1-f1",
+						Keypair: storage.Keypair{
+							Key: "test/demo1-f1",
+						},
 					},
 				},
 			},

--- a/api/internal/core/store/store_test.go
+++ b/api/internal/core/store/store_test.go
@@ -136,12 +136,21 @@ func TestGenericStore_Init(t *testing.T) {
 			},
 			giveListRet: []storage.Keypair{
 				{
-					Key:   "test/demo1-f1",
-					Value: `{"Field1":"demo1-f1", "Field2":"demo1-f2"}`,
+					Key:     "test/demo1-f1",
+					Value:   `{"Field1":"demo1-f1", "Field2":"demo1-f2"}`,
+					Skipped: false,
 				},
 				{
-					Key:   "test/demo2-f1",
-					Value: `{"Field1":"demo2-f1", "Field2":"demo2-f2"}`,
+					Key:     "test/demo2-f1",
+					Value:   `{"Field1":"demo2-f1", "Field2":"demo2-f2"}`,
+					Skipped: false,
+				},
+				{
+					// It's an skippable data, which would be skipped
+					// to initialize cache
+					Key:     "test/demoX-f1",
+					Value:   "skippable value",
+					Skipped: true,
 				},
 			},
 			giveWatchCh: make(chan storage.WatchResponse),
@@ -159,6 +168,16 @@ func TestGenericStore_Init(t *testing.T) {
 						Keypair: storage.Keypair{
 							Key: "test/demo1-f1",
 						},
+					},
+					{
+						// As an skippable event from watch, it will be
+						// skipped to store in cache
+						Keypair: storage.Keypair{
+							Key:     "test/demoY-f1",
+							Value:   "skippable value",
+							Skipped: true,
+						},
+						Type: storage.EventTypePut,
 					},
 				},
 			},


### PR DESCRIPTION
Signed-off-by: imjoey <majunjie@apache.org>

Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

- Related issues

Fixes #1329 .

___
### Bugfix
- Description

Current implementation only ignores the `init_dir` etcd event at `init` stage, not at `watch` stage. This would lead to JSON unmarshaling error when re-initialization the etcd data via `apisix init_etcd` command.

- How to fix?

This PR will make an additional check for each event at `watch` stage, skipping the `init_dir` ones.

IMHO, each kind of storage and even each kind of data in single storage, will have their own rules to check if the data is skippable. So this PR will also move the `init_dir` judgement from store to storage.

This PR also introduce the `Keypair` into `Event` as the embedded field, to simply the definitions.
