### PR TITLE
fix: Skip the data directly in Storage level

### DIFF
--- a/api/internal/core/storage/etcd.go
+++ b/api/internal/core/storage/etcd.go
@@ -34,10 +34,10 @@ const (
 	SkippedValueEtcdInitDir = "init_dir"
 
 	// SkippedValueEtcdEmptyObject indicates the data with an
-	// empty JSON value `{}`, which may be set by APISIX,
+	// empty JSON value {}, which may be set by APISIX,
 	// should be also skipped.
 	//
-	// Important: at present, `{}`` is considered as invalid,
+	// Important: at present, {} is considered as invalid,
 	// but may be changed in the future.
 	SkippedValueEtcdEmptyObject = "{}"
 )
@@ -131,16 +131,21 @@ func (s *EtcdV3Storage) List(ctx context.Context, key string) ([]Keypair, error)
 	}
 	var ret []Keypair
 	for i := range resp.Kvs {
+		key := string(resp.Kvs[i].Key)
+		value := string(resp.Kvs[i].Value)
+
+		// Skip the data if its value is init_dir or {}
+		// during fetching-all phase.
+		//
+		// For more complex cases, an explicit function to determine if
+		// skippable would be better.
+		if value == SkippedValueEtcdInitDir || value == SkippedValueEtcdEmptyObject {
+			continue
+		}
+
 		data := Keypair{
-			Key:   string(resp.Kvs[i].Key),
-			Value: string(resp.Kvs[i].Value),
-			// Mark as skippable if its value is init_dir or {}
-			// during fetching-all phase.
-			//
-			// For more complex cases, a explicit function to determine if
-			// skippable would be better.
-			Skipped: string(resp.Kvs[i].Value) == SkippedValueEtcdInitDir ||
-				string(resp.Kvs[i].Value) == SkippedValueEtcdEmptyObject,
+			Key:   key,
+			Value: value,
 		}
 		ret = append(ret, data)
 	}
@@ -191,17 +196,22 @@ func (s *EtcdV3Storage) Watch(ctx context.Context, key string) <-chan WatchRespo
 			}
 
 			for i := range event.Events {
+				key := string(event.Events[i].Kv.Key)
+				value := string(event.Events[i].Kv.Value)
+
+				// Skip the data if its value is init_dir or {}
+				// during watching phase.
+				//
+				// For more complex cases, an explicit function to determine if
+				// skippable would be better.
+				if value == SkippedValueEtcdInitDir || value == SkippedValueEtcdEmptyObject {
+					continue
+				}
+
 				e := Event{
 					Keypair: Keypair{
-						Key:   string(event.Events[i].Kv.Key),
-						Value: string(event.Events[i].Kv.Value),
-						// Mark this Keypais as skippable if its value is init_dir or {}
-						// during watching phase.
-						//
-						// For more complex cases, a explicit function to determine if
-						// skippable would be better.
-						Skipped: string(event.Events[i].Kv.Value) == SkippedValueEtcdInitDir ||
-							string(event.Events[i].Kv.Value) == SkippedValueEtcdEmptyObject,
+						Key:   key,
+						Value: value,
 					},
 				}
 				switch event.Events[i].Type {

--- a/api/internal/core/storage/storage.go
+++ b/api/internal/core/storage/storage.go
@@ -36,8 +36,6 @@ type WatchResponse struct {
 type Keypair struct {
 	Key   string
 	Value string
-	// If true, this keypair will NOT be processed in store.
-	Skipped bool
 }
 
 type Event struct {

--- a/api/internal/core/store/store.go
+++ b/api/internal/core/store/store.go
@@ -96,11 +96,6 @@ func (s *GenericStore) Init() error {
 		return err
 	}
 	for i := range ret {
-		// If the kv has been marked as skippable in underlying storage,
-		// just skip it
-		if ret[i].Skipped {
-			continue
-		}
 		key := ret[i].Key[len(s.opt.BasePath)+1:]
 		objPtr, err := s.StringToObjPtr(ret[i].Value, key)
 		if err != nil {
@@ -121,11 +116,6 @@ func (s *GenericStore) Init() error {
 			for i := range event.Events {
 				switch event.Events[i].Type {
 				case storage.EventTypePut:
-					// If the watch event has been marked as skippable
-					// in underlying storage, just skip it
-					if event.Events[i].Skipped {
-						continue
-					}
 					key := event.Events[i].Key[len(s.opt.BasePath)+1:]
 					objPtr, err := s.StringToObjPtr(event.Events[i].Value, key)
 					if err != nil {

--- a/api/internal/core/store/store_test.go
+++ b/api/internal/core/store/store_test.go
@@ -136,21 +136,12 @@ func TestGenericStore_Init(t *testing.T) {
 			},
 			giveListRet: []storage.Keypair{
 				{
-					Key:     "test/demo1-f1",
-					Value:   `{"Field1":"demo1-f1", "Field2":"demo1-f2"}`,
-					Skipped: false,
+					Key:   "test/demo1-f1",
+					Value: `{"Field1":"demo1-f1", "Field2":"demo1-f2"}`,
 				},
 				{
-					Key:     "test/demo2-f1",
-					Value:   `{"Field1":"demo2-f1", "Field2":"demo2-f2"}`,
-					Skipped: false,
-				},
-				{
-					// It's an skippable data, which would be skipped
-					// to initialize cache
-					Key:     "test/demoX-f1",
-					Value:   "skippable value",
-					Skipped: true,
+					Key:   "test/demo2-f1",
+					Value: `{"Field1":"demo2-f1", "Field2":"demo2-f2"}`,
 				},
 			},
 			giveWatchCh: make(chan storage.WatchResponse),
@@ -168,16 +159,6 @@ func TestGenericStore_Init(t *testing.T) {
 						Keypair: storage.Keypair{
 							Key: "test/demo1-f1",
 						},
-					},
-					{
-						// As an skippable event from watch, it will be
-						// skipped to store in cache
-						Keypair: storage.Keypair{
-							Key:     "test/demoY-f1",
-							Value:   "skippable value",
-							Skipped: true,
-						},
-						Type: storage.EventTypePut,
 					},
 				},
 			},


### PR DESCRIPTION
Signed-off-by: imjoey <majunjie@apache.org>

Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

- Related issues

Fixes #1357 .

___
### Bugfix
- Description

As described in #1357 , we decide to move the skip logic to Storage from Store. This PR is going to achieve that.

- How to fix?

Remove `Skipped` field from `Event` object and Storage will eliminate the invalid data before sending to Store anymore.
