### PR TITLE
fix: make api-test failed

### DIFF
--- a/.github/workflows/backend-cli-test.yml
+++ b/.github/workflows/backend-cli-test.yml
@@ -27,6 +27,3 @@ jobs:
       - name: run test
         working-directory: ./api
         run: sudo ./test/shell/cli_test.sh
-
-      - name: make api-test
-        run: make api-test

--- a/.github/workflows/backend-cli-test.yml
+++ b/.github/workflows/backend-cli-test.yml
@@ -27,3 +27,6 @@ jobs:
       - name: run test
         working-directory: ./api
         run: sudo ./test/shell/cli_test.sh
+
+      - name: make api-test
+        run: make api-test

--- a/.github/workflows/backend-unit-test.yml
+++ b/.github/workflows/backend-unit-test.yml
@@ -24,13 +24,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: get lua lib
-        run: |
-          wget https://github.com/api7/dag-to-lua/archive/v1.1.tar.gz
-          sudo mkdir -p ./api/dag-to-lua
-          tar -zxvf v1.1.tar.gz
-          sudo mv ./dag-to-lua-1.1/lib/* ./api/dag-to-lua/
-
       - name: setup go
         uses: actions/setup-go@v2.1.3
         with:

--- a/Makefile
+++ b/Makefile
@@ -55,10 +55,21 @@ ifeq ("$(wildcard $(GO_EXEC))", "")
 endif
 
 
+### dag-lib:            get dag-lib
+.PHONY: dag-lib
+dag-lib:
+ifeq ("$(wildcard api/dag-to-lua/dag-to-lua.lua)", "")
+	wget https://github.com/api7/dag-to-lua/archive/v1.1.tar.gz -P /tmp
+	tar -zxvf /tmp/v1.1.tar.gz -C /tmp
+	mkdir ./api/dag-to-lua
+	cp -r /tmp/dag-to-lua-1.1/lib/* ./api/dag-to-lua
+endif
+
+
 ### api-test:		Run the tests of manager-api
 .PHONY: api-test
-api-test: api-default
-	cd api/ && APISIX_API_WORKDIR=$$PWD ENV=test go test -v -race -cover -coverprofile=coverage.txt -covermode=atomic ./...
+api-test: api-default dag-lib
+	cd api/ && APISIX_API_WORKDIR=$$PWD ENV=test go test -v -count=1 -race -cover -coverprofile=coverage.txt -covermode=atomic ./...
 
 
 ### api-run:		Run the manager-api


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

- Related issues
close #950
___
### Bugfix
- Description
some test cases rely on Lua and lib `dag-to-lua`,  without the lib will fail.

- How to fix?
when run `make api-test`, should check dag-to-lua dependencies, if the dependencies are not installed, we will download and install.
