### PR TITLE
 fix: When exporting route, whether the parameter is empty or not

### DIFF
--- a/api/internal/handler/data_loader/route_export.go
+++ b/api/internal/handler/data_loader/route_export.go
@@ -67,6 +67,11 @@ type ExportInput struct {
 //ExportRoutes Export data by passing route ID, such as "R1" or multiple route parameters, such as "R1,R2"
 func (h *Handler) ExportRoutes(c droplet.Context) (interface{}, error) {
 	input := c.Input().(*ExportInput)
+
+	if input.IDs == "" {
+		return nil, fmt.Errorf("Parameter IDs cannot be empty")
+	}
+
 	ids := strings.Split(input.IDs, ",")
 	routes := []*entity.Route{}
 
@@ -106,6 +111,10 @@ var (
 //ExportAllRoutes All routes can be directly exported without passing parameters
 func (h *Handler) ExportAllRoutes(c droplet.Context) (interface{}, error) {
 	routelist, err := h.routeStore.List(c.Context(), store.ListInput{})
+
+	if len(routelist.Rows) < 1 {
+		return nil, fmt.Errorf("Route data is empty, cannot be exported")
+	}
 
 	if err != nil {
 		return nil, err
@@ -485,4 +494,3 @@ func GetPathNumber() func() int {
 		return i
 	}
 }
-

--- a/api/internal/handler/data_loader/route_export_test.go
+++ b/api/internal/handler/data_loader/route_export_test.go
@@ -1906,32 +1906,14 @@ func TestExportRoutesSameURI(t *testing.T) {
 
 func TestExportRoutesParameterEmpty(t *testing.T) {
 	// Error test when pass parameter is null
-	r1 := `{
-		"uris": ["/test-test"],
-		"name": "route_all",
-		"desc": "所有",
-		"methods": ["GET"],
-		"hosts": ["test.com"],
-		"status": 1,
-		"upstream": {
-			"nodes": {
-				"172.16.238.20:1980": 1
-			},
-			"type": "roundrobin"
-		}
-}`
-	var route *entity.Route
-	err := json.Unmarshal([]byte(r1), &route)
-	assert.Nil(t, err)
-	mStore := &store.MockInterface{}
-	mStore.On("Get", mock.Anything).Run(func(args mock.Arguments) {
-	}).Return(route, nil)
+	h := Handler{}
 
-	h := Handler{routeStore: mStore}
 	exportInput := &ExportInput{}
 	exportInput.IDs = ""
+
 	ctx := droplet.NewContext()
 	ctx.SetInput(exportInput)
+
 	_, err1 := h.ExportRoutes(ctx)
 	assert.Equal(t, errors.New("Parameter IDs cannot be empty"), err1)
 }

--- a/api/test/e2e/route_export_test.go
+++ b/api/test/e2e/route_export_test.go
@@ -26,6 +26,24 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestExport_Route_Data_Empty(t *testing.T) {
+	tests := []HttpTestCase{
+		{
+			Desc:         "Export route when data is empty",
+			Object:       ManagerApiExpect(t),
+			Method:       http.MethodGet,
+			Path:         "/apisix/admin/export/routes",
+			Headers:      map[string]string{"Authorization": token},
+			ExpectStatus: http.StatusOK,
+			ExpectBody:   "{\"code\":10000,\"message\":\"Route data is empty, cannot be exported\",\"data\":null",
+		},
+	}
+	for _, tc := range tests {
+		testCaseCheck(tc, t)
+	}
+
+}
+
 func TestRoute_Export(t *testing.T) {
 
 	// 1.Export data as the route of URIs Hosts
@@ -2485,4 +2503,3 @@ func replaceStr(str string) string {
 	str = strings.Replace(str, " ", "", -1)
 	return str
 }
-


### PR DESCRIPTION

Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

- Related issues
#1383 
___
### Bugfix
- When exporting route data, the current logic will export empty swagger data when the route data is null or there is no route data. Whether to add judgment will directly return an error.

- How to fix?
When null characters are passed in, routeid is not passed in, or all routeid data is exported, there is no data in the database, and an error should be reported directly.