### PR TITLE
feat: Add script_id field in Route entity

### DIFF
--- a/api/internal/core/entity/entity.go
+++ b/api/internal/core/entity/entity.go
@@ -84,6 +84,7 @@ type Route struct {
 	Vars            interface{}            `json:"vars,omitempty"`
 	FilterFunc      string                 `json:"filter_func,omitempty"`
 	Script          interface{}            `json:"script,omitempty"`
+	ScriptID        interface{}            `json:"script_id,omitempty"` // For debug and optimization(cache), currently same as Route's ID
 	Plugins         map[string]interface{} `json:"plugins,omitempty"`
 	Upstream        *UpstreamDef           `json:"upstream,omitempty"`
 	ServiceID       interface{}            `json:"service_id,omitempty"`

--- a/api/internal/handler/route/route_test.go
+++ b/api/internal/handler/route/route_test.go
@@ -1577,6 +1577,7 @@ func Test_Route_With_Script_ID(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, ret.(*data.SpecCodeResponse).StatusCode)
 
 	// create with invalid script_id - set script_id but without id
+	route = &entity.Route{}
 	errReqBody = `{
 		"uri": "/index.html",
 		"upstream": {
@@ -1599,6 +1600,7 @@ func Test_Route_With_Script_ID(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, ret.(*data.SpecCodeResponse).StatusCode)
 
 	// create with invalid script_id - set script_id but without script
+	route = &entity.Route{}
 	errReqBody = `{
 		"id": "1",
 		"uri": "/index.html",
@@ -1621,6 +1623,7 @@ func Test_Route_With_Script_ID(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, ret.(*data.SpecCodeResponse).StatusCode)
 
 	// create with valid script_id
+	route = &entity.Route{}
 	reqBody := `{
 		"id": "1",
 		"uri": "/index.html",
@@ -1633,7 +1636,7 @@ func Test_Route_With_Script_ID(t *testing.T) {
 			}]
 		},
 		"script": "local _M = {} \n function _M.access(api_ctx) \n ngx.log(ngx.WARN,\"hit access phase\") \n end \nreturn _M",
-		"script": "1"
+		"script_id": "1"
 	}`
 	err = json.Unmarshal([]byte(reqBody), route)
 	assert.Nil(t, err)
@@ -1669,7 +1672,7 @@ func Test_Route_With_Script_ID(t *testing.T) {
 				}]
 			},
 			"script": "local _M = {} \n function _M.access(api_ctx) \n ngx.log(ngx.WARN,\"hit access phase\") \n end \nreturn _M",
-			"script_id: "not-1"
+			"script_id": "not-1"
 		}`
 
 	err = json.Unmarshal([]byte(errReqBody), route2)
@@ -1695,7 +1698,7 @@ func Test_Route_With_Script_ID(t *testing.T) {
 					"weight": 1
 				}]
 			},
-			"script_id: "1"
+			"script_id": "1"
 		}`
 	err = json.Unmarshal([]byte(errReqBody), route2)
 	assert.Nil(t, err)
@@ -1721,7 +1724,7 @@ func Test_Route_With_Script_ID(t *testing.T) {
 					}]
 				},
 				"script": "local _M = {} \n function _M.access(api_ctx) \n ngx.log(ngx.WARN,\"hit access phase, again\") \n end \nreturn _M",
-				"script_id: "1"
+				"script_id": "1"
 			}`
 	err = json.Unmarshal([]byte(reqBody), route2)
 	assert.Nil(t, err)

--- a/api/internal/handler/route/route_test.go
+++ b/api/internal/handler/route/route_test.go
@@ -1431,6 +1431,8 @@ func Test_Route_With_Script_Luacode(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, stored.ID, route.ID)
 	assert.Equal(t, "local _M = {} \n function _M.access(api_ctx) \n ngx.log(ngx.WARN,\"hit access phase\") \n end \nreturn _M", stored.Script)
+	// If not specify script_id in request, script_id should be equal to id
+	assert.Equal(t, stored.ScriptID, route.ID)
 
 	// update via empty script
 	route2 := &UpdateInput{}
@@ -1458,8 +1460,9 @@ func Test_Route_With_Script_Luacode(t *testing.T) {
 	objRet, ok := ret.(*entity.Route)
 	assert.True(t, ok)
 	assert.Equal(t, route2.ID, objRet.ID)
-	// script returned should be nil
+	// script and script_id returned should be nil
 	assert.Nil(t, objRet.Script)
+	assert.Nil(t, objRet.ScriptID)
 
 	//sleep
 	time.Sleep(time.Duration(100) * time.Millisecond)
@@ -1531,4 +1534,220 @@ func Test_Route_With_Script_Luacode(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.EqualError(t, err, "<string> at EOF:   syntax error\n")
 	assert.Equal(t, http.StatusBadRequest, ret.(*data.SpecCodeResponse).StatusCode)
+}
+
+func Test_Route_With_Script_ID(t *testing.T) {
+	// init
+	err := storage.InitETCDClient(conf.ETCDConfig)
+	assert.Nil(t, err)
+	err = store.InitStores()
+	assert.Nil(t, err)
+
+	handler := &Handler{
+		routeStore:    store.GetStore(store.HubKeyRoute),
+		svcStore:      store.GetStore(store.HubKeyService),
+		upstreamStore: store.GetStore(store.HubKeyUpstream),
+		scriptStore:   store.GetStore(store.HubKeyScript),
+	}
+	assert.NotNil(t, handler)
+
+	// create with invalid script_id - not equal to id
+	ctx := droplet.NewContext()
+	route := &entity.Route{}
+	errReqBody := `{
+		"id": "1",
+		"uri": "/index.html",
+		"upstream": {
+			"type": "roundrobin",
+			"nodes": [{
+				"host": "www.a.com",
+				"port": 80,
+				"weight": 1
+			}]
+		},
+		"script": "local _M = {} \n function _M.access(api_ctx) \n ngx.log(ngx.WARN,\"hit access phase\") \n end \nreturn _M",
+		"script_id": "not-1"
+	}`
+	err = json.Unmarshal([]byte(errReqBody), route)
+	assert.Nil(t, err)
+	ctx.SetInput(route)
+	ret, err := handler.Create(ctx)
+	assert.NotNil(t, err)
+	assert.EqualError(t, err, "script_id must be the same as id")
+	assert.Equal(t, http.StatusBadRequest, ret.(*data.SpecCodeResponse).StatusCode)
+
+	// create with invalid script_id - set script_id but without id
+	errReqBody = `{
+		"uri": "/index.html",
+		"upstream": {
+			"type": "roundrobin",
+			"nodes": [{
+				"host": "www.a.com",
+				"port": 80,
+				"weight": 1
+			}]
+		},
+		"script": "local _M = {} \n function _M.access(api_ctx) \n ngx.log(ngx.WARN,\"hit access phase\") \n end \nreturn _M",
+		"script_id": "1"
+	}`
+	err = json.Unmarshal([]byte(errReqBody), route)
+	assert.Nil(t, err)
+	ctx.SetInput(route)
+	ret, err = handler.Create(ctx)
+	assert.NotNil(t, err)
+	assert.EqualError(t, err, "script_id must be the same as id")
+	assert.Equal(t, http.StatusBadRequest, ret.(*data.SpecCodeResponse).StatusCode)
+
+	// create with invalid script_id - set script_id but without script
+	errReqBody = `{
+		"id": "1",
+		"uri": "/index.html",
+		"upstream": {
+			"type": "roundrobin",
+			"nodes": [{
+				"host": "www.a.com",
+				"port": 80,
+				"weight": 1
+			}]
+		},
+		"script_id": "1"
+	}`
+	err = json.Unmarshal([]byte(errReqBody), route)
+	assert.Nil(t, err)
+	ctx.SetInput(route)
+	ret, err = handler.Create(ctx)
+	assert.NotNil(t, err)
+	assert.EqualError(t, err, "script_id cannot be set if script is unset")
+	assert.Equal(t, http.StatusBadRequest, ret.(*data.SpecCodeResponse).StatusCode)
+
+	// create with valid script_id
+	reqBody := `{
+		"id": "1",
+		"uri": "/index.html",
+		"upstream": {
+			"type": "roundrobin",
+			"nodes": [{
+				"host": "www.a.com",
+				"port": 80,
+				"weight": 1
+			}]
+		},
+		"script": "local _M = {} \n function _M.access(api_ctx) \n ngx.log(ngx.WARN,\"hit access phase\") \n end \nreturn _M",
+		"script": "1"
+	}`
+	err = json.Unmarshal([]byte(reqBody), route)
+	assert.Nil(t, err)
+	ctx.SetInput(route)
+	_, err = handler.Create(ctx)
+	assert.Nil(t, err)
+
+	// sleep
+	time.Sleep(time.Duration(20) * time.Millisecond)
+
+	// get
+	input := &GetInput{}
+	input.ID = "1"
+	ctx.SetInput(input)
+	ret, err = handler.Get(ctx)
+	stored := ret.(*entity.Route)
+	assert.Nil(t, err)
+	assert.Equal(t, stored.ScriptID, route.ID)
+
+	// update via invalid script_id - not equal to id
+	route2 := &UpdateInput{}
+	route2.ID = "1"
+	errReqBody = `{
+			"id": "1",
+			"uri": "/index.html",
+			"enable_websocket": true,
+			"upstream": {
+				"type": "roundrobin",
+				"nodes": [{
+					"host": "www.a.com",
+					"port": 80,
+					"weight": 1
+				}]
+			},
+			"script": "local _M = {} \n function _M.access(api_ctx) \n ngx.log(ngx.WARN,\"hit access phase\") \n end \nreturn _M",
+			"script_id: "not-1"
+		}`
+
+	err = json.Unmarshal([]byte(errReqBody), route2)
+	assert.Nil(t, err)
+	ctx.SetInput(route2)
+	ret, err = handler.Update(ctx)
+	assert.NotNil(t, err)
+	assert.EqualError(t, err, "script_id must be the same as id")
+	assert.Equal(t, http.StatusBadRequest, ret.(*data.SpecCodeResponse).StatusCode)
+
+	// update via invalid script_id - set script_id but without script
+	route2 = &UpdateInput{}
+	route2.ID = "1"
+	errReqBody = `{
+			"id": "1",
+			"uri": "/index.html",
+			"enable_websocket": true,
+			"upstream": {
+				"type": "roundrobin",
+				"nodes": [{
+					"host": "www.a.com",
+					"port": 80,
+					"weight": 1
+				}]
+			},
+			"script_id: "1"
+		}`
+	err = json.Unmarshal([]byte(errReqBody), route2)
+	assert.Nil(t, err)
+	ctx.SetInput(route2)
+	ret, err = handler.Update(ctx)
+	assert.NotNil(t, err)
+	assert.EqualError(t, err, "script_id cannot be set if script is unset")
+	assert.Equal(t, http.StatusBadRequest, ret.(*data.SpecCodeResponse).StatusCode)
+
+	// update via valid script_id
+	route2 = &UpdateInput{}
+	route2.ID = "1"
+	reqBody = `{
+				"id": "1",
+				"uri": "/index.html",
+				"enable_websocket": true,
+				"upstream": {
+					"type": "roundrobin",
+					"nodes": [{
+						"host": "www.a.com",
+						"port": 80,
+						"weight": 1
+					}]
+				},
+				"script": "local _M = {} \n function _M.access(api_ctx) \n ngx.log(ngx.WARN,\"hit access phase, again\") \n end \nreturn _M",
+				"script_id: "1"
+			}`
+	err = json.Unmarshal([]byte(reqBody), route2)
+	assert.Nil(t, err)
+	ctx.SetInput(route2)
+	_, err = handler.Update(ctx)
+	assert.Nil(t, err)
+
+	// sleep
+	time.Sleep(time.Duration(20) * time.Millisecond)
+
+	// get
+	input = &GetInput{}
+	input.ID = "1"
+	ctx.SetInput(input)
+	ret, err = handler.Get(ctx)
+	stored = ret.(*entity.Route)
+	assert.Nil(t, err)
+	assert.Equal(t, stored.ScriptID, route.ID)
+	assert.Equal(t, "local _M = {} \n function _M.access(api_ctx) \n ngx.log(ngx.WARN,\"hit access phase, again\") \n end \nreturn _M", stored.Script)
+
+	// delete test data
+	inputDel := &BatchDelete{}
+	reqBody = `{"ids": "1"}`
+	err = json.Unmarshal([]byte(reqBody), inputDel)
+	assert.Nil(t, err)
+	ctx.SetInput(inputDel)
+	_, err = handler.BatchDelete(ctx)
+	assert.Nil(t, err)
 }


### PR DESCRIPTION
Signed-off-by: imjoey <majunjie@apache.org>

Please answer these questions before submitting a pull request

- Why submit this pull request?
- [ ] Bugfix
- [x] New feature provided
- [ ] Improve performance
- [ ] Backport patches

- Related issues

Related to #1085 .

___
### New feature or improvement
- Describe the details and related test reports.

As discussed in #1085 with @spacewander , this PR is going to add a new field `script_id` in `Route` entity to support for debug and optimization(cache) in the future. For now, we could assume that `script_id` will be always equal to the `id` of `Route` entity.

___
### Please add the corresponding test cases if necessary.

Yep, backend tests and backend e2e tests are added.
