### PR TITLE
fix: Add version ldflags for building manager-api in Dockerfile

### DIFF
--- a/.github/workflows/deploy-with-docker.yml
+++ b/.github/workflows/deploy-with-docker.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build:
@@ -13,6 +16,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: Azure/docker-login@v1
+        if: ${{ github.event_name == 'push' }}
         with:
           login-server: apisixacr.azurecr.cn
           username: ${{ secrets.REGISTRY_USERNAME }}
@@ -38,6 +42,7 @@ jobs:
         run: api/test/shell/docker_deploy_test.sh
 
       - name: Deploy
+        if: ${{ github.event_name == 'push' }}
         run: |
           docker tag dashboard:ci apisixacr.azurecr.cn/dashboard:${{ github.sha }}
           docker push apisixacr.azurecr.cn/dashboard:${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,21 +31,9 @@ WORKDIR /usr/local/apisix-dashboard
 
 COPY --from=pre-build /usr/local/apisix-dashboard .
 
-WORKDIR /usr/local/apisix-dashboard/api
-
-RUN mkdir -p ../output/conf \
-    && cp ./conf/*.json ../output/conf
-
-RUN wget https://github.com/api7/dag-to-lua/archive/v1.1.tar.gz -O /tmp/v1.1.tar.gz \
-    && mkdir /tmp/dag-to-lua \
-    && tar -xvf /tmp/v1.1.tar.gz -C /tmp/dag-to-lua --strip 1 \
-    && mkdir -p ../output/dag-to-lua \
-    && mv /tmp/dag-to-lua/lib/* ../output/dag-to-lua/
-
-RUN if [ "$ENABLE_PROXY" = "true" ] ; then go env -w GOPROXY=https://goproxy.io,direct ; fi
-
-RUN go env -w GO111MODULE=on \
-    && CGO_ENABLED=0 go build -o ../output/manager-api ./cmd/manager
+RUN if [ "$ENABLE_PROXY" = "true" ] ; then go env -w GOPROXY=https://goproxy.io,direct ; fi \
+    && go env -w GO111MODULE=on \
+    && CGO_ENABLED=0 ./api/build.sh
 
 FROM node:14-alpine as fe-builder
 
@@ -57,11 +45,9 @@ COPY --from=pre-build /usr/local/apisix-dashboard .
 
 WORKDIR /usr/local/apisix-dashboard/web
 
-RUN if [ "$ENABLE_PROXY" = "true" ] ; then yarn config set registry https://registry.npm.taobao.org/ ; fi
-
-RUN yarn install
-
-RUN yarn build
+RUN if [ "$ENABLE_PROXY" = "true" ] ; then yarn config set registry https://registry.npm.taobao.org/ ; fi \
+    && yarn install \
+    && yarn build
 
 FROM alpine:latest as prod
 

--- a/api/test/shell/docker_deploy_test.sh
+++ b/api/test/shell/docker_deploy_test.sh
@@ -19,6 +19,13 @@
 
 set -ex
 
+# Version output
+verline=$(docker logs docker-deploy_managerapi_1 | grep -E "^Version : [A-Za-z0-9\-\_\.]+")
+if [ -z "$verline" ];then
+    echo "no Version output"
+    exit 1
+fi
+
 # web page
 curl http://127.0.0.1:9000
 code=$(curl -k -i -m 20 -o /dev/null -s -w %{http_code} http://127.0.0.1:9000)
@@ -32,6 +39,7 @@ resp=$(curl http://127.0.0.1:9000/apisix/admin/user/login -X POST -d '{"username
 token=$(echo "${resp}" | sed 's/{/\n/g' | sed 's/,/\n/g' | grep "token" | sed 's/:/\n/g' | sed '1d' | sed 's/}//g'  | sed 's/"//g')
 if [ -z "${token}" ]; then
     echo "login failed"
+    exit 1
 fi
 
 # plugin orchestration


### PR DESCRIPTION
Signed-off-by: imjoey <majunjie@apache.org>

Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

- Related issues

Fixes #1350 .

___
### Bugfix
- Description

At previous manager-api build phase in Dockerfile, the ldflags of `github.com/apisix/manager-api/cmd.Version` and `github.com/apisix/manager-api/cmd.GitHash` are missing. This lead to the no `Version` output when running `manager-api`, as described in #1350 .

- How to fix?

Add missing `ldflags` in Dockerfile. For simplicity, this PR is going to reuse the existing built script `./api/build.sh` to compile out the binary. 

In addition, this PR will also reduce the usage of `RUN` commands for smaller image size.

- Additional 

FYI, since there is no `.githash` or `.git/` within the artifact downloaded from Github , the `GitHash` output is still missing.
