### PR TITLE
fix: Increase sleep time for balancer Backend E2E testing

### DIFF
--- a/api/test/e2e/balancer_test.go
+++ b/api/test/e2e/balancer_test.go
@@ -63,7 +63,7 @@ func TestBalancer_roundrobin_with_weight(t *testing.T) {
 			}`,
 			Headers:      map[string]string{"Authorization": token},
 			ExpectStatus: http.StatusOK,
-			Sleep:        sleepTime,
+			Sleep:        2 * sleepTime,
 		},
 	}
 
@@ -72,7 +72,7 @@ func TestBalancer_roundrobin_with_weight(t *testing.T) {
 	}
 
 	// hit routes
-	time.Sleep(sleepTime)
+	time.Sleep(2 * sleepTime)
 	// batch test /server_port api
 	res := BatchTestServerPort(t, 18)
 	// BatchTestServerPort


### PR DESCRIPTION
Signed-off-by: imjoey <majunjie@apache.org>

Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

- Related issues

___
### Bugfix
- Description

Backend E2E Test seems broken since this morning, prompted with the following error.

```
--- FAIL: TestBalancer_roundrobin_with_weight (0.66s)
    printer.go:54: PUT http://127.0.0.1:9000/apisix/admin/upstreams/1
    --- PASS: TestBalancer_roundrobin_with_weight/create_upstream_(roundrobin_with_same_weight) (0.06s)
    printer.go:54: PUT http://127.0.0.1:9000/apisix/admin/routes/1
    --- PASS: TestBalancer_roundrobin_with_weight/create_route_using_the_upstream_just_created (0.31s)
    base.go:150: 
        	Error Trace:	base.go:150
        	            				balancer_test.go:77
        	Error:      	Expected nil, but got: &url.Error{Op:"Get", URL:"http://127.0.0.1:9081/server_port", Err:(*net.OpError)(0xc0001b61e0)}
        	Test:       	TestBalancer_roundrobin_with_weight
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x48 pc=0x8c8eed]
```

- How to fix?

Increase the sleep time for balancer e2e testing cases.