### PR TITLE
chore: Use the original conf/config.yaml + sed to replace `api/test/docker/manager-api-conf.yaml`

### DIFF
--- a/.github/workflows/backend-e2e-test.yml
+++ b/.github/workflows/backend-e2e-test.yml
@@ -20,6 +20,13 @@ jobs:
         with:
           go-version: '1.13'
 
+      - name: Modify conf.yaml Configure for use by the manage-api cluster
+        run: |
+          sed -i 's/127.0.0.1:2379/172.16.238.10:2379/' ./conf/conf.yaml
+          sed -i 's/127.0.0.1/0.0.0.0/' ./conf/conf.yaml
+          sed -i '/172.16.238.10:2379/a\      - 172.16.238.11:2379' ./conf/conf.yaml
+          sed -i '/172.16.238.10:2379/a\      - 172.16.238.12:2379' ./conf/conf.yaml
+
       - name: run docker compose
         working-directory: ./api/test/docker
         run: |

--- a/.github/workflows/backend-e2e-test.yml
+++ b/.github/workflows/backend-e2e-test.yml
@@ -22,10 +22,10 @@ jobs:
 
       - name: Modify conf.yaml Configure for use by the manage-api cluster
         run: |
-          sed -i 's/127.0.0.1:2379/172.16.238.10:2379/' ./conf/conf.yaml
-          sed -i 's/127.0.0.1/0.0.0.0/' ./conf/conf.yaml
-          sed -i '/172.16.238.10:2379/a\      - 172.16.238.11:2379' ./conf/conf.yaml
-          sed -i '/172.16.238.10:2379/a\      - 172.16.238.12:2379' ./conf/conf.yaml
+          sed -i 's/127.0.0.1:2379/172.16.238.10:2379/' ./api/conf/conf.yaml
+          sed -i 's/127.0.0.1/0.0.0.0/' ./api/conf/conf.yaml
+          sed -i '/172.16.238.10:2379/a\      - 172.16.238.11:2379' ./api/conf/conf.yaml
+          sed -i '/172.16.238.10:2379/a\      - 172.16.238.12:2379' ./api/conf/conf.yaml
 
       - name: run docker compose
         working-directory: ./api/test/docker

--- a/.github/workflows/deploy-with-docker.yml
+++ b/.github/workflows/deploy-with-docker.yml
@@ -30,6 +30,8 @@ jobs:
         run: |
           sed -i 's/127.0.0.1:2379/172.16.238.10:2379/' api/conf/conf.yaml
           sed -i 's/host: 127.0.0.1/host: 0.0.0.0/' api/conf/conf.yaml
+          sed -i '/172.16.238.11:2379/d' api/conf/conf.yaml
+          sed -i '/172.16.238.12:2379/d' api/conf/conf.yaml
 
       - name: Run Docker Compose
         working-directory: ./api/test/docker-deploy

--- a/.github/workflows/deploy-with-docker.yml
+++ b/.github/workflows/deploy-with-docker.yml
@@ -30,8 +30,6 @@ jobs:
         run: |
           sed -i 's/127.0.0.1:2379/172.16.238.10:2379/' api/conf/conf.yaml
           sed -i 's/host: 127.0.0.1/host: 0.0.0.0/' api/conf/conf.yaml
-          sed -i '/172.16.238.11:2379/d' api/conf/conf.yaml
-          sed -i '/172.16.238.12:2379/d' api/conf/conf.yaml
 
       - name: Run Docker Compose
         working-directory: ./api/test/docker-deploy

--- a/api/test/docker/docker-compose.yaml
+++ b/api/test/docker/docker-compose.yaml
@@ -178,7 +178,7 @@ services:
       dockerfile: test/docker/Dockerfile
     restart: always
     volumes:
-      - ./manager-api-conf.yaml:/go/manager-api/conf/conf.yaml:ro
+      - ../../conf/conf.yaml:/go/manager-api/conf/conf.yaml:ro
       - ../testdata:/go/manager-api/testdata
     depends_on:
       - node1

--- a/docs/back-end-e2e.md
+++ b/docs/back-end-e2e.md
@@ -78,7 +78,7 @@ This document describes how to use E2E test locally.
 
 1. [install docker-compose](https://docs.docker.com/compose/install/)
 
-**NOTE:** To run docker compose locally, you need to modify `./api/conf/conf.yaml` `host` and `endpoints` configuration in the file
+**NOTE:** In order to run docker compose locally, please change the values of `listen.host` and `etcd.endpoints` within `./api/conf/conf.yaml` as follows:
 
    ```sh
    listen:

--- a/docs/back-end-e2e.md
+++ b/docs/back-end-e2e.md
@@ -78,7 +78,8 @@ This document describes how to use E2E test locally.
 
 1. [install docker-compose](https://docs.docker.com/compose/install/)
 
-**NOTE:** To run docker compose locally, you need to modify ./api/conf/conf.yaml 'host' and 'endpoints' configuration in the file
+**NOTE:** To run docker compose locally, you need to modify `./api/conf/conf.yaml` `host` and `endpoints` configuration in the file
+
    ```sh
    listen:
       host: 0.0.0.0

--- a/docs/back-end-e2e.md
+++ b/docs/back-end-e2e.md
@@ -78,6 +78,18 @@ This document describes how to use E2E test locally.
 
 1. [install docker-compose](https://docs.docker.com/compose/install/)
 
+**NOTE:** To run docker compose locally, you need to modify ./api/conf/conf.yaml 'host' and 'endpoints' configuration in the file
+   ```sh
+   listen:
+      host: 0.0.0.0
+      port: 9000
+   etcd:
+      endpoints:
+        - 172.16.238.10:2379
+        - 172.16.238.11:2379
+        - 172.16.238.12:2379
+   ```
+
 2. Use `docker-compose` to run services such as `manager-api`, `apisix`, `etcd` and `upstream-node`, run the command.
 
    ```sh


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [ ] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

- Related issues
close #698 
___
### Chore
- use the original conf/config.yaml + sed to replace `api/test/docker/manager-api-conf.yaml`
- manage-api-conf.yaml Keep the local test for use, and then put the E2E test step into the makefile for execution, and then delete it.