### PR TITLE
fix: docker build failed in backend e2e test CI

### DIFF
--- a/.github/workflows/backend-e2e-test.yml
+++ b/.github/workflows/backend-e2e-test.yml
@@ -27,9 +27,9 @@ jobs:
           sed -i '/172.16.238.10:2379/a\      - 172.16.238.11:2379' ./api/conf/conf.yaml
           sed -i '/172.16.238.10:2379/a\      - 172.16.238.12:2379' ./api/conf/conf.yaml
 
-      - name: download file Dockerfile-apisix	
-        working-directory: ./api/test/docker	
-        run: |	
+      - name: download file Dockerfile-apisix
+        working-directory: ./api/test/docker
+        run: |
           curl -o Dockerfile-apisix https://raw.githubusercontent.com/apache/apisix-docker/master/alpine/Dockerfile
 
       - name: run docker compose

--- a/.github/workflows/backend-e2e-test.yml
+++ b/.github/workflows/backend-e2e-test.yml
@@ -27,6 +27,11 @@ jobs:
           sed -i '/172.16.238.10:2379/a\      - 172.16.238.11:2379' ./api/conf/conf.yaml
           sed -i '/172.16.238.10:2379/a\      - 172.16.238.12:2379' ./api/conf/conf.yaml
 
+      - name: download file Dockerfile-apisix	
+        working-directory: ./api/test/docker	
+        run: |	
+          curl -o Dockerfile-apisix https://raw.githubusercontent.com/apache/apisix-docker/master/alpine/Dockerfile
+
       - name: run docker compose
         working-directory: ./api/test/docker
         run: |

--- a/api/test/docker/docker-compose.yaml
+++ b/api/test/docker/docker-compose.yaml
@@ -128,7 +128,7 @@ services:
   apisix:
     hostname: apisix_server1
     build:
-      context: https://github.com/apache/apisix-docker.git#master:alpine-dev/
+      context: https://github.com/apache/apisix-docker.git#:alpine
       dockerfile: Dockerfile
       args:
         - APISIX_VERSION=master
@@ -153,7 +153,7 @@ services:
   apisix2:
     hostname: apisix_server2
     build:
-      context: https://github.com/apache/apisix-docker.git#master:alpine-dev/
+      context: https://github.com/apache/apisix-docker.git#:alpine
       dockerfile: Dockerfile
       args:
         - APISIX_VERSION=master

--- a/api/test/docker/docker-compose.yaml
+++ b/api/test/docker/docker-compose.yaml
@@ -128,8 +128,8 @@ services:
   apisix:
     hostname: apisix_server1
     build:
-      context: https://github.com/apache/apisix-docker.git#master:alpine
-      dockerfile: Dockerfile
+      context: ../../
+      dockerfile: test/docker/Dockerfile-apisix
       args:
         - APISIX_VERSION=master
     restart: always
@@ -153,8 +153,8 @@ services:
   apisix2:
     hostname: apisix_server2
     build:
-      context: https://github.com/apache/apisix-docker.git#master:alpine
-      dockerfile: Dockerfile
+      context: ../../
+      dockerfile: test/docker/Dockerfile-apisix
       args:
         - APISIX_VERSION=master
     restart: always

--- a/api/test/docker/docker-compose.yaml
+++ b/api/test/docker/docker-compose.yaml
@@ -128,7 +128,7 @@ services:
   apisix:
     hostname: apisix_server1
     build:
-      context: https://github.com/apache/apisix-docker.git#:alpine
+      context: https://github.com/apache/apisix-docker.git#master:alpine
       dockerfile: Dockerfile
       args:
         - APISIX_VERSION=master
@@ -153,7 +153,7 @@ services:
   apisix2:
     hostname: apisix_server2
     build:
-      context: https://github.com/apache/apisix-docker.git#:alpine
+      context: https://github.com/apache/apisix-docker.git#master:alpine
       dockerfile: Dockerfile
       args:
         - APISIX_VERSION=master


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

___
### Bugfix
- Description

directly use the path in the `apisix-docker` github repo as the context, resulting the `Dockerfile` not being found.

- How to fix?

first download the `Dockerfile` in the github repo to the CI env local, using the local directory as the context


