### PR TITLE
fix: change setting smoke test validURL to http://localhost:8000/routes/list

### DIFF
--- a/web/cypress/integration/settings/settings-smoketest.spec.js
+++ b/web/cypress/integration/settings/settings-smoketest.spec.js
@@ -23,7 +23,7 @@ context('settings page smoke test', () => {
     grafanaExplanation2: 'Address is illegality',
     updateSuccessfully: 'Update Configuration Successfully',
     invalidURL: 'httx://www.test.com',
-    validURL: 'https://apisix.apache.org/',
+    validURL: 'http://localhost:8000/routes/list',
     fetchURL: 'fetchURL',
     fetch: '@fetchURL',
   }


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [ ] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

- Related issues

___
### Bugfix
- Description

https://github.com/apache/apisix-dashboard/pull/1435/checks?check_run_id=1840149946

Recently this test case failed many times, I tried locally and the same problem reproduced when the `https://apisix.apache.org/` is hard to visit, when I access the website smoothly, this case can also passed smoothly

* Many people have encountered this problem and there has not seem to be a good solution yet, see
https://github.com/cypress-io/cypress/issues/3427

* I tried to change the url from `https://apisix.apache.org/` to `http://localhost:8000/routes/list` the internal address in dashboard, run the case as many times as possible, it worked well

so I change the url to make this case more stable, maybe after the issue solved, we can change it back.

