### PR TITLE
feat: added tip on the Metrics page

### DIFF
--- a/web/cypress/integration/metrics/metrics-smoketest.spec.js
+++ b/web/cypress/integration/metrics/metrics-smoketest.spec.js
@@ -31,6 +31,6 @@ context('metrics page smoke test', () => {
       .children()
       .should('contain', 'Metrics')
       .and('contain', 'You have not configured Grafana')
-      .and('contain', 'Configure Now');
+      .and('contain', 'Configure');
   });
 });

--- a/web/src/pages/Metrics/Metrics.tsx
+++ b/web/src/pages/Metrics/Metrics.tsx
@@ -16,10 +16,11 @@
  */
 import React, { useState, useEffect } from 'react';
 import { PageHeaderWrapper } from '@ant-design/pro-layout';
-import { Empty, Button, Card } from 'antd';
+import { Empty, Button, Card, Tooltip } from 'antd';
 import { history, useIntl } from 'umi';
 
 import { getGrafanaURL } from './service';
+import { QuestionCircleOutlined } from '@ant-design/icons';
 
 const Metrics: React.FC = () => {
   const [grafanaURL, setGrafanaURL] = useState<string | undefined>();
@@ -32,7 +33,16 @@ const Metrics: React.FC = () => {
   }, []);
 
   return (
-    <PageHeaderWrapper title={formatMessage({ id: 'menu.metrics' })}>
+    <PageHeaderWrapper
+      title={
+        <>
+          {formatMessage({ id: 'menu.metrics' })}&nbsp;
+          <Tooltip title={formatMessage({ id: 'page.metrics.tip' })}>
+            <QuestionCircleOutlined />
+          </Tooltip>
+        </>
+      }
+    >
       <Card>
         {!grafanaURL && (
           <Empty

--- a/web/src/pages/Metrics/locales/en-US.ts
+++ b/web/src/pages/Metrics/locales/en-US.ts
@@ -16,5 +16,6 @@
  */
 export default {
   'page.metrics.empty.description.grafanaNotConfig': 'You have not configured Grafana',
-  'page.metrics.button.grafanaConfig': 'Configure Now',
+  'page.metrics.button.grafanaConfig': 'Configure',
+  'page.metrics.tip': 'Use browser iframe to store monitor page URL, local only.',
 };

--- a/web/src/pages/Metrics/locales/zh-CN.ts
+++ b/web/src/pages/Metrics/locales/zh-CN.ts
@@ -17,4 +17,5 @@
 export default {
   'page.metrics.empty.description.grafanaNotConfig': '您还未配置 Grafana',
   'page.metrics.button.grafanaConfig': '现在配置',
+  'page.metrics.tip': '使用浏览器 iframe 存储监控页访问地址，仅作用于本地。',
 };


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [ ] Bugfix
- [x] New feature provided
- [ ] Improve performance
- [ ] Backport patches

 added tip on the Metrics page, to tell users that the Metrics page should be used with Grafana Share URL, and it's stored in local only.

![image](https://user-images.githubusercontent.com/2106987/108306468-2a89f380-71e7-11eb-8b77-e39372d7b150.png)

NOTE: this is only a tip, no need to add a testcase.