### PR TITLE
ci: use the specified version of `skywalking`

### DIFF
--- a/api/test/docker/docker-compose.yaml
+++ b/api/test/docker/docker-compose.yaml
@@ -191,7 +191,7 @@ services:
         ipv4_address: 172.16.238.40
 
   skywalking:
-    image: apache/skywalking-oap-server
+    image: apache/skywalking-oap-server:8.3.0-es6
     restart: always
     ports:
       - '1234:1234/tcp'


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

___
### Bugfix
- Description
can't pull skywalking image in ci
```
Pulling skywalking (apache/skywalking-oap-server:)...
manifest for apache/skywalking-oap-server:latest not found: manifest unknown: manifest unknown
```

https://github.com/apache/apisix-dashboard/pull/1504/checks?check_run_id=1994180070#step:6:1409

- How to fix?

use the specified version of `skywalking`
