### PR TITLE
fix: cannot unmarshal array into go value of type

### DIFF
--- a/api/internal/handler/ssl/ssl_test.go
+++ b/api/internal/handler/ssl/ssl_test.go
@@ -814,7 +814,7 @@ func TestSSL_Exist(t *testing.T) {
 		{
 			caseDesc: "check SSL cert not exists for sni",
 			giveInput: &ExistCheckInput{
-				Body: []byte(`["www.route2.com"]`),
+				Hosts: []string{"www.route2.com"},
 			},
 			wantRet:   &data.SpecCodeResponse{StatusCode: http.StatusNotFound},
 			wantErr:   consts.InvalidParam("SSL cert not exists for sni：www.route2.com"),
@@ -823,7 +823,7 @@ func TestSSL_Exist(t *testing.T) {
 		{
 			caseDesc: "check SSL cert exists for sni",
 			giveInput: &ExistCheckInput{
-				Body: []byte(`["www.route.com"]`),
+				Hosts: []string{"www.route.com"},
 			},
 			wantRet:   nil,
 			getCalled: true,
@@ -831,7 +831,7 @@ func TestSSL_Exist(t *testing.T) {
 		{
 			caseDesc: "check SSL cert not exists for snis",
 			giveInput: &ExistCheckInput{
-				Body: []byte(`["test1.com","ssl_test2.com"]`),
+				Hosts: []string{"test1.com", "ssl_test2.com"},
 			},
 			wantRet:   &data.SpecCodeResponse{StatusCode: http.StatusNotFound},
 			wantErr:   consts.InvalidParam("SSL cert not exists for sni：test1.com"),
@@ -840,7 +840,7 @@ func TestSSL_Exist(t *testing.T) {
 		{
 			caseDesc: "check SSL cert exists for snis",
 			giveInput: &ExistCheckInput{
-				Body: []byte(`["ssl_test.com"]`),
+				Hosts: []string{"ssl_test.com"},
 			},
 			wantRet:   nil,
 			getCalled: true,


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

- Related issues
close #1476 
___
### Bugfix
- Description
When an api request comes in, the droplet framework will bind the parameters first, and the go array cannot be bound to the struct, which leads to this bug

- How to fix?
Change the array parameter to an object.
