### PR TITLE
fix: Add upstream_test respbody error assertion and defer resp.Body.Close ()

### DIFF
--- a/api/test/e2enew/upstream/upstream_test.go
+++ b/api/test/e2enew/upstream/upstream_test.go
@@ -331,6 +331,7 @@ var _ = ginkgo.Describe("Upstream chash remote addr", func() {
 		for i := 0; i < 18; i++ {
 			resp, err := http.DefaultClient.Do(request)
 			assert.Nil(t, err)
+			defer resp.Body.Close()
 			respBody, err := ioutil.ReadAll(resp.Body)
 			assert.Nil(t, err)
 			body := string(respBody)
@@ -339,7 +340,6 @@ var _ = ginkgo.Describe("Upstream chash remote addr", func() {
 			} else {
 				res[body]++
 			}
-			resp.Body.Close()
 		}
 		assert.Equal(t, 18, res["1982"])
 	})
@@ -403,11 +403,12 @@ var _ = ginkgo.Describe("Upstream chash remote addr", func() {
 		for i := 0; i <= 17; i++ {
 			resp, err := http.DefaultClient.Do(request)
 			assert.Nil(t, err)
+			defer resp.Body.Close()
 			respBody, err := ioutil.ReadAll(resp.Body)
+			assert.Nil(t, err)
 			if string(respBody) == "1980" {
 				count++
 			}
-			resp.Body.Close()
 		}
 		assert.Equal(t, 18, count)
 	})


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

- Related issues

___
### Bugfix
- Description

upstream_test.go Add respbody error assertion and defer resp.Body.Close ()

The old way of writing, if in resp.Body.close () trigger assertion before execution, which will cause resp.Body Not closed, resulting in a memory leak