### PR TITLE
fix: use hosts object instead of pure data

### DIFF
--- a/web/src/pages/Route/service.ts
+++ b/web/src/pages/Route/service.ts
@@ -92,7 +92,7 @@ export const fetchUpstreamItem = (sid: string) => {
 export const checkHostWithSSL = (hosts: string[]) =>
   request('/check_ssl_exists', {
     method: 'POST',
-    data: hosts,
+    data: { hosts },
   });
 
 export const fetchLabelList = () =>


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bugfix

___
### Bugfix
- Description

The API needs to receive `{ hosts }` instead of `hosts`.

### TODO
- [ ] Testcases #1542 