### PR TITLE
feat:Support duplicate one existing Route

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,8 @@ web/.nyc_output
 web/coverage
 web/cypress/screenshots/
 web/cypress/videos/
+web/cypress/downloads/
+
+# vim
+*.swp
+

--- a/.gitignore
+++ b/.gitignore
@@ -58,7 +58,10 @@ web/coverage
 web/cypress/screenshots/
 web/cypress/videos/
 web/cypress/downloads/
+web/cypress/screenshots/
+web/cypress/videos/
 
 # vim
 *.swp
+*.swo
 

--- a/api/internal/handler/route/route.go
+++ b/api/internal/handler/route/route.go
@@ -307,12 +307,6 @@ func generateLuaCode(script map[string]interface{}) (string, error) {
 
 func (h *Handler) Create(c droplet.Context) (interface{}, error) {
 	input := c.Input().(*entity.Route)
-	// check duplicate name
-	if err := h.checkDuplicateName(c, input.Name, ""); err != nil {
-		return &data.SpecCodeResponse{StatusCode: http.StatusBadRequest},
-			consts.InvalidParam(err.Error())
-	}
-
 	//check depend
 	if input.ServiceID != nil {
 		serviceID := utils.InterfaceToString(input.ServiceID)
@@ -541,28 +535,6 @@ func (h *Handler) BatchDelete(c droplet.Context) (interface{}, error) {
 	return nil, nil
 }
 
-func (h *Handler) checkDuplicateName(c droplet.Context, name, exclude string) error {
-	ret, err := h.routeStore.List(c.Context(), store.ListInput{
-		Predicate: func(obj interface{}) bool {
-			r := obj.(*entity.Route)
-			if r.Name == name && r.ID != exclude {
-				return true
-			}
-
-			return false
-		},
-		PageSize:   0,
-		PageNumber: 0,
-	})
-	if err != nil {
-		return err
-	}
-	if ret.TotalSize > 0 {
-		return fmt.Errorf("Route name %s is reduplicate", name)
-	}
-	return nil
-}
-
 type ExistCheckInput struct {
 	Name    string `auto_read:"name,query"`
 	Exclude string `auto_read:"exclude,query"`
@@ -600,9 +572,25 @@ func (h *Handler) Exist(c droplet.Context) (interface{}, error) {
 	name := input.Name
 	exclude := input.Exclude
 
-	if err := h.checkDuplicateName(c, name, exclude); err != nil {
+	ret, err := h.routeStore.List(c.Context(), store.ListInput{
+		Predicate: func(obj interface{}) bool {
+			r := obj.(*entity.Route)
+			if r.Name == name && r.ID != exclude {
+				return true
+			}
+
+			return false
+		},
+		PageSize:   0,
+		PageNumber: 0,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if ret.TotalSize > 0 {
 		return &data.SpecCodeResponse{StatusCode: http.StatusBadRequest},
-			consts.InvalidParam(err.Error())
+			consts.InvalidParam("Route name is reduplicate")
 	}
 
 	return nil, nil

--- a/web/config/routes.ts
+++ b/web/config/routes.ts
@@ -40,6 +40,10 @@ const routes = [
     component: './Route/Create',
   },
   {
+    path: '/routes/:rid/duplicate',
+    component: './Route/Create',
+  },
+  {
     path: '/ssl/:id/edit',
     component: './SSL/Create',
   },

--- a/web/cypress/integration/route/create-edit-duplicate-delete-route.spec.js
+++ b/web/cypress/integration/route/create-edit-duplicate-delete-route.spec.js
@@ -154,6 +154,7 @@ context('Create and Delete Route', () => {
     });
   });
 
+
   it('should duplicate the route', function () {
     cy.visit('/');
     cy.contains('Route').click();
@@ -188,12 +189,11 @@ context('Create and Delete Route', () => {
     const { domSelector, data } = this;
     const routeNames = [newName, duplicateNewName];
     routeNames.forEach(function (routeName) {
-      cy.get(domSelector.nameSelector).type(routeName);
+      cy.get(domSelector.name).clear().type(routeName);
       cy.contains('Search').click();
       cy.contains(routeName).siblings().contains('Delete').click();
       cy.contains('button', 'Confirm').click();
       cy.get(domSelector.notification).should('contain', data.deleteRouteSuccess);
     });
-
   });
 });

--- a/web/cypress/integration/route/create-edit-duplicate-delete-route.spec.js
+++ b/web/cypress/integration/route/create-edit-duplicate-delete-route.spec.js
@@ -191,6 +191,6 @@ context('Create and Delete Route', () => {
       cy.contains(routeName).siblings().contains('Delete').click();
       cy.contains('button', 'Confirm').click();
       cy.get(this.domSelector.notification).should('contain', this.data.deleteRouteSuccess);
-    });
+    }).bind(this);
   });
 });

--- a/web/cypress/integration/route/create-edit-duplicate-delete-route.spec.js
+++ b/web/cypress/integration/route/create-edit-duplicate-delete-route.spec.js
@@ -153,6 +153,37 @@ context('Create and Delete Route', () => {
     });
   });
 
+  it('should duplicate the route', function () {
+    cy.visit('/');
+    cy.contains('Route').click();
+
+    cy.get(this.domSelector.nameSelector).type(newName);
+    cy.contains('Search').click();
+    cy.contains(newName).siblings().contains('Duplicate').click();
+
+    const duplicateNewName = `duplicateName${new Date().valueOf()}`;
+
+    cy.get(this.domSelector.name).clear().type(duplicateNewName);
+    cy.get(this.domSelector.description).clear().type(this.data.description2);
+    cy.contains('Next').click();
+    cy.contains('Next').click();
+    cy.contains('Next').click();
+    cy.contains('Submit').click();
+    cy.contains(this.data.submitSuccess);
+    cy.contains('Goto List').click();
+    cy.url().should('contains', 'routes/list');
+    cy.contains(duplicateNewName).siblings().should('contain', this.data.description2);
+
+    // test view
+    cy.contains(duplicateNewName).siblings().contains('View').click();
+    cy.get(this.domSelector.drawer).should('be.visible');
+
+    cy.get(this.domSelector.codemirrorScroll).within(() => {
+      cy.contains('upstream').should("exist");
+      cy.contains(duplicateNewName).should('exist');
+    });
+  });
+
   it('should delete the route', function () {
     cy.visit('/routes/list');
     cy.get(this.domSelector.nameSelector).type(newName);

--- a/web/cypress/integration/route/create-edit-duplicate-delete-route.spec.js
+++ b/web/cypress/integration/route/create-edit-duplicate-delete-route.spec.js
@@ -19,6 +19,7 @@
 context('Create and Delete Route', () => {
   const name = `routeName${new Date().valueOf()}`;
   const newName = `newName${new Date().valueOf()}`;
+  const duplicateNewName = `duplicateName${new Date().valueOf()}`;
   const sleepTime = 100;
   const timeout = 5000;
 
@@ -161,8 +162,6 @@ context('Create and Delete Route', () => {
     cy.contains('Search').click();
     cy.contains(newName).siblings().contains('Duplicate').click();
 
-    const duplicateNewName = `duplicateName${new Date().valueOf()}`;
-
     cy.get(this.domSelector.name).clear().type(duplicateNewName);
     cy.get(this.domSelector.description).clear().type(this.data.description2);
     cy.contains('Next').click();
@@ -186,10 +185,12 @@ context('Create and Delete Route', () => {
 
   it('should delete the route', function () {
     cy.visit('/routes/list');
-    cy.get(this.domSelector.nameSelector).type(newName);
-    cy.contains('Search').click();
-    cy.contains(newName).siblings().contains('Delete').click();
-    cy.contains('button', 'Confirm').click();
-    cy.get(this.domSelector.notification).should('contain', this.data.deleteRouteSuccess);
+    [newName, duplicateNewName].forEach(function (routeName) {
+      cy.get(this.domSelector.nameSelector).type(routeName);
+      cy.contains('Search').click();
+      cy.contains(routeName).siblings().contains('Delete').click();
+      cy.contains('button', 'Confirm').click();
+      cy.get(this.domSelector.notification).should('contain', this.data.deleteRouteSuccess);
+    });
   });
 });

--- a/web/cypress/integration/route/create-edit-duplicate-delete-route.spec.js
+++ b/web/cypress/integration/route/create-edit-duplicate-delete-route.spec.js
@@ -185,12 +185,15 @@ context('Create and Delete Route', () => {
 
   it('should delete the route', function () {
     cy.visit('/routes/list');
-    [newName, duplicateNewName].forEach(function (routeName) {
-      cy.get(this.domSelector.nameSelector).type(routeName);
+    const { domSelector, data } = this;
+    const routeNames = [newName, duplicateNewName];
+    routeNames.forEach(function (routeName) {
+      cy.get(domSelector.nameSelector).type(routeName);
       cy.contains('Search').click();
       cy.contains(routeName).siblings().contains('Delete').click();
       cy.contains('button', 'Confirm').click();
-      cy.get(this.domSelector.notification).should('contain', this.data.deleteRouteSuccess);
-    }).bind(this);
+      cy.get(domSelector.notification).should('contain', data.deleteRouteSuccess);
+    });
+
   });
 });

--- a/web/src/locales/en-US/component.ts
+++ b/web/src/locales/en-US/component.ts
@@ -35,6 +35,7 @@ export default {
   'component.global.save': 'Save',
   'component.global.edit': 'Configure',
   'component.global.view': 'View',
+  'component.global.duplicate': 'Duplicate',
   'component.global.manage': 'Manage',
   'component.global.update': 'Update',
   'component.global.get': 'Get',

--- a/web/src/locales/zh-CN/component.ts
+++ b/web/src/locales/zh-CN/component.ts
@@ -35,6 +35,7 @@ export default {
   'component.global.save': '保存',
   'component.global.edit': '编辑',
   'component.global.view': '查看',
+  'component.global.duplicate': '复制',
   'component.global.manage': '管理',
   'component.global.update': '更新',
   'component.global.get': '获取',

--- a/web/src/pages/Route/Create.tsx
+++ b/web/src/pages/Route/Create.tsx
@@ -88,7 +88,7 @@ const Page: React.FC<Props> = (props) => {
   };
 
   useEffect(() => {
-    if (props.route.path.indexOf('edit') !== -1) {
+    if (props.route.path.indexOf('edit') !== -1 || props.route.path.indexOf('duplicate') !== -1) {
       setupRoute(props.match.params.rid);
     } else {
       onReset();
@@ -233,7 +233,7 @@ const Page: React.FC<Props> = (props) => {
             redirectOption === 'forceHttps' && filterHosts.length !== 0
               ? checkHostWithSSL(hosts)
               : Promise.resolve(),
-            checkUniqueName(value.name, (props as any).match.params.rid || ''),
+            checkUniqueName(value.name, props.route.path.indexOf('edit') > 0 ? (props as any).match.params.rid : ''),
           ]).then(() => {
             setStep(nextStep);
           });
@@ -269,9 +269,9 @@ const Page: React.FC<Props> = (props) => {
   return (
     <>
       <PageHeaderWrapper
-        title={(props as any).match.params.rid
-          ? formatMessage({ id: 'page.route.editRoute' })
-          : formatMessage({ id: 'page.route.createRoute' })}
+        title={`${
+          formatMessage({ id: `component.global.${props.route.path.split('/').slice(-1)[0]}`})
+        } ${formatMessage({ id: 'menu.routes' })}`}
       >
         <Card bordered={false}>
           <Steps current={step - 1} className={styles.steps}>

--- a/web/src/pages/Route/List.tsx
+++ b/web/src/pages/Route/List.tsx
@@ -417,6 +417,9 @@ const Page: React.FC = () => {
             }}>
               {formatMessage({ id: 'component.global.view' })}
             </Button>
+            <Button type="primary" onClick={() => history.push(`/routes/${record.id}/duplicate`)}>
+              {formatMessage({ id: 'component.global.duplicate' })}
+            </Button>
             <Popconfirm
               title={formatMessage({ id: 'component.global.popconfirm.title.delete' })}
               onConfirm={() => {


### PR DESCRIPTION
Please answer these questions before submitting a pull request

Why submit this pull request?
 - [ ] Bugfix
 - [x] New feature provided
 - [ ] Improve performance
 - [ ]  Backport patches
 - [ ] We has added two fields for upstream in APISIX.

Support duplicate one existing Route  https://github.com/apache/apisix-dashboard/issues/1487


New feature or improvement
1: duplicate button from route list
2: check duplicate name from POST route api

Describe the details and related test reports.

1:Click duplicate button from the router list, the address will be  `routes/:rid/duplicate`
![image](https://user-images.githubusercontent.com/80014017/110097045-90769d80-7dd9-11eb-9c73-52989067d690.png)


2: update the name to make sure it's no duplicated
![image](https://user-images.githubusercontent.com/80014017/110097178-b56b1080-7dd9-11eb-9509-bfe92db8eb4b.png)



3: submit data, return to the list. The new route will be there

![image](https://user-images.githubusercontent.com/80014017/110097255-c7e54a00-7dd9-11eb-9b66-7290c14f5adb.png)



