### PR TITLE
feat: disable closing plugin drawer on clicking the mask

### DIFF
--- a/web/src/components/Plugin/PluginDetail.tsx
+++ b/web/src/components/Plugin/PluginDetail.tsx
@@ -46,6 +46,7 @@ type Props = {
   pluginList: PluginComponent.Meta[];
   readonly?: boolean;
   visible: boolean;
+  maskClosable: boolean;
   onClose?: () => void;
   onChange?: (data: any) => void;
 };
@@ -83,6 +84,7 @@ const PluginDetail: React.FC<Props> = ({
   visible,
   pluginList = [],
   readonly = false,
+  maskClosable = true,
   initialData = {},
   onClose = () => {},
   onChange = () => {},
@@ -168,6 +170,7 @@ const PluginDetail: React.FC<Props> = ({
         visible={visible}
         placement="right"
         closable={false}
+        maskClosable={maskClosable}
         onClose={onClose}
         width={700}
         footer={

--- a/web/src/components/Plugin/PluginDetail.tsx
+++ b/web/src/components/Plugin/PluginDetail.tsx
@@ -46,7 +46,7 @@ type Props = {
   pluginList: PluginComponent.Meta[];
   readonly?: boolean;
   visible: boolean;
-  maskClosable: boolean;
+  maskClosable?: boolean;
   onClose?: () => void;
   onChange?: (data: any) => void;
 };

--- a/web/src/components/Plugin/PluginPage.tsx
+++ b/web/src/components/Plugin/PluginPage.tsx
@@ -241,6 +241,7 @@ const PluginPage: React.FC<Props> = ({
       visible={name !== NEVER_EXIST_PLUGIN_FLAG}
       schemaType={schemaType}
       initialData={initialData}
+      maskClosable={false}
       pluginList={pluginList}
       onClose={() => {
         setName(NEVER_EXIST_PLUGIN_FLAG);

--- a/web/src/pages/Plugin/List.tsx
+++ b/web/src/pages/Plugin/List.tsx
@@ -110,6 +110,7 @@ const Page: React.FC = () => {
       schemaType="route"
       initialData={initialData}
       pluginList={pluginList}
+      maskClosable={false}
       onClose={() => {
         setVisible(false);
       }}


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [ ] Bugfix
- [x] New feature provided
- [ ] Improve performance
- [ ] Backport patches

- Related issues
resolves #1548 

### New feature or improvement
Now, clicking on the masked area of the plugin drawer does not close it.