### PR TITLE
feat: supports changing number of executing cpu cores for manager api

### DIFF
--- a/api/conf/conf.yaml
+++ b/api/conf/conf.yaml
@@ -44,6 +44,8 @@ conf:
         logs/access.log  # supports relative path, absolute path, standard output
                          # such as: logs/access.log, /tmp/logs/access.log, /dev/stdout, /dev/stderr
                          # log example: 2020-12-09T16:38:09.039+0800	INFO	filter/logging.go:46	/apisix/admin/routes/r1	{"status": 401, "host": "127.0.0.1:9000", "query": "asdfsafd=adf&a=a", "requestId": "3d50ecb8-758c-46d1-af5b-cd9d1c820156", "latency": 0, "remoteIP": "127.0.0.1", "method": "PUT", "errs": []}
+  max_cpu: 0             # supports tweaking with the number of OS threads are going to be used for parallelism. Default value: 0 [will use max number of available cpu cores considering hyperthreading (if any)]. If the value is negative, is will not touch the existing parallelism profile.
+
 authentication:
   secret:
     secret              # secret for jwt token generation.

--- a/api/internal/conf/conf.go
+++ b/api/internal/conf/conf.go
@@ -22,6 +22,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"github.com/tidwall/gjson"
 	"gopkg.in/yaml.v2"
@@ -96,6 +97,7 @@ type Conf struct {
 	Listen    Listen
 	Log       Log
 	AllowList []string `yaml:"allow_list"`
+	MaxCpu    int `yaml:"max_cpu"`
 }
 
 type User struct {
@@ -139,14 +141,14 @@ func setConf() {
 	if configurationContent, err := ioutil.ReadFile(filePath); err != nil {
 		panic(fmt.Sprintf("fail to read configuration: %s", filePath))
 	} else {
-		//configuration := gjson.ParseBytes(configurationContent)
+		// configuration := gjson.ParseBytes(configurationContent)
 		config := Config{}
 		err := yaml.Unmarshal(configurationContent, &config)
 		if err != nil {
 			log.Printf("conf: %s, error: %v", configurationContent, err)
 		}
 
-		//listen
+		// listen
 		if config.Conf.Listen.Port != 0 {
 			ServerPort = config.Conf.Listen.Port
 		}
@@ -160,7 +162,7 @@ func setConf() {
 			initEtcdConfig(config.Conf.Etcd)
 		}
 
-		//error log
+		// error log
 		if config.Conf.Log.ErrorLog.Level != "" {
 			ErrorLogLevel = config.Conf.Log.ErrorLog.Level
 		}
@@ -187,7 +189,10 @@ func setConf() {
 
 		AllowList = config.Conf.AllowList
 
-		//auth
+		// set degree of parallelism
+		initParallelism(config.Conf.MaxCpu)
+
+		// auth
 		initAuthentication(config.Authentication)
 
 		initPlugins(config.Plugins)
@@ -247,5 +252,18 @@ func initEtcdConfig(conf Etcd) {
 		Password:  conf.Password,
 		MTLS:      conf.MTLS,
 		Prefix:    prefix,
+	}
+}
+
+// initialize parallelism settings
+func initParallelism(choiceCores int) {
+	if choiceCores < 0 {
+		return
+	}
+	maxSupportedCores := runtime.NumCPU()
+
+	runtime.GOMAXPROCS(maxSupportedCores)
+	if choiceCores < maxSupportedCores {
+		runtime.GOMAXPROCS(choiceCores)
 	}
 }

--- a/api/internal/conf/conf.go
+++ b/api/internal/conf/conf.go
@@ -257,7 +257,7 @@ func initEtcdConfig(conf Etcd) {
 
 // initialize parallelism settings
 func initParallelism(choiceCores int) {
-	if choiceCores < 0 {
+	if choiceCores < 1 {
 		return
 	}
 	maxSupportedCores := runtime.NumCPU()

--- a/api/internal/conf/conf.go
+++ b/api/internal/conf/conf.go
@@ -97,7 +97,7 @@ type Conf struct {
 	Listen    Listen
 	Log       Log
 	AllowList []string `yaml:"allow_list"`
-	MaxCpu    int `yaml:"max_cpu"`
+	MaxCpu    int      `yaml:"max_cpu"`
 }
 
 type User struct {

--- a/api/internal/conf/conf.go
+++ b/api/internal/conf/conf.go
@@ -262,8 +262,8 @@ func initParallelism(choiceCores int) {
 	}
 	maxSupportedCores := runtime.NumCPU()
 
-	runtime.GOMAXPROCS(maxSupportedCores)
-	if choiceCores < maxSupportedCores {
-		runtime.GOMAXPROCS(choiceCores)
+	if choiceCores > maxSupportedCores {
+		choiceCores = maxSupportedCores
 	}
+	runtime.GOMAXPROCS(choiceCores)
 }


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [ ] Bugfix
- [x] New feature provided
- [ ] Improve performance
- [ ] Backport patches

- Related issues
resolves #682 
___
### New feature or improvement

Supports changing the number of os threads attached to the goroutines.

For performance reason, if in the configuration file, the defined `max_cpu` is greater than the number of available cpu cores (including hyperthreading), the `manager api` will stick to the max available cores. As it has a certain limit to boost the performance since the context switching of goroutines from the same os thread is a lot faster than goroutines from different threads. 