### PR TITLE
fix: fix CYPRESS cross platform env error

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -29,9 +29,9 @@
     "start:test": "cross-env REACT_APP_ENV=test MOCK=none umi dev",
     "test:component": "umi test ./src/components",
     "tsc": "tsc",
-    "cypress:open": "CYPRESS_SERVE_ENV=test cypress open",
-    "cypress:open-dev": "CYPRESS_SERVE_ENV=dev cypress open",
-    "cypress:run-ci": "CYPRESS_SERVE_ENV=test cypress run"
+    "cypress:open": "cross-env CYPRESS_SERVE_ENV=test cypress open",
+    "cypress:open-dev": "cross-env CYPRESS_SERVE_ENV=dev cypress open",
+    "cypress:run-ci": "cross-env CYPRESS_SERVE_ENV=test cypress run"
   },
   "license": "Apache-2.0",
   "lint-staged": {


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

- Related issues

___
### Bugfix
- Description
When we run the `yarn cypress:open-dev ` on Windows, it will occur the 'CYPRESS_SERVE_ENV' is not recognized as an internal or external command error.
![image](https://user-images.githubusercontent.com/22230889/111070828-755d0980-850e-11eb-85bf-bb8cf6c38c6a.png)

- How to fix?
Add the `cross-env` in the npm script.
![image](https://user-images.githubusercontent.com/22230889/111070898-bce39580-850e-11eb-9051-18cdf594a071.png)

