### PR TITLE
feat: expose JSON Schema through API

### DIFF
--- a/api/internal/handler/schema/plugin.go
+++ b/api/internal/handler/schema/plugin.go
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package schema
+
+import (
+	"reflect"
+
+	"github.com/gin-gonic/gin"
+	"github.com/shiningrush/droplet"
+	"github.com/shiningrush/droplet/wrapper"
+	wgin "github.com/shiningrush/droplet/wrapper/gin"
+
+	"github.com/apisix/manager-api/internal/conf"
+	"github.com/apisix/manager-api/internal/handler"
+)
+
+type Handler struct {
+}
+
+func NewHandler() (handler.RouteRegister, error) {
+	return &Handler{}, nil
+}
+
+func (h *Handler) ApplyRoute(r *gin.Engine) {
+	r.GET("/apisix/admin/plugins", wgin.Wraps(h.Plugins,
+		wrapper.InputType(reflect.TypeOf(ListInput{}))))
+}
+
+type ListInput struct {
+	All bool `auto_read:"all,query"`
+}
+
+func (h *Handler) Plugins(c droplet.Context) (interface{}, error) {
+	input := c.Input().(*ListInput)
+
+	plugins := conf.Schema.Get("plugins")
+	if input.All {
+		var res []map[string]interface{}
+		list := plugins.Value().(map[string]interface{})
+		for name, conf := range list {
+			plugin := conf.(map[string]interface{})
+			plugin["name"] = name
+			if _, ok := plugin["type"]; !ok {
+				plugin["type"] = "other"
+			}
+			res = append(res, plugin)
+		}
+		return res, nil
+	}
+
+	var ret []string
+	list := plugins.Map()
+	for pluginName := range list {
+		if pluginName != "serverless-post-function" && pluginName != "serverless-pre-function" {
+			ret = append(ret, pluginName)
+		}
+	}
+
+	return ret, nil
+}

--- a/api/internal/handler/schema/plugin_test.go
+++ b/api/internal/handler/schema/plugin_test.go
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package plugin
+package schema
 
 import (
 	"encoding/json"
@@ -23,8 +23,6 @@ import (
 
 	"github.com/shiningrush/droplet"
 	"github.com/stretchr/testify/assert"
-
-	"github.com/apisix/manager-api/internal/conf"
 )
 
 func TestPlugin(t *testing.T) {
@@ -60,84 +58,9 @@ func TestPlugin(t *testing.T) {
 			basicAuthConsumerSchema = string(consumerSchemaByte)
 			assert.Nil(t, err)
 		}
-
-		assert.Contains(t, conf.Plugins, plugin["name"])
 	}
-
-	assert.Contains(t, conf.Plugins, "server-info")
-	assert.Contains(t, conf.Plugins, "traffic-split")
-	assert.NotContains(t, conf.Plugins, "dubbo-proxy")
-
 	// plugin type
 	assert.ElementsMatch(t, []string{"basic-auth", "jwt-auth", "hmac-auth", "key-auth", "wolf-rbac"}, authPlugins)
 	// consumer schema
 	assert.Equal(t, `{"additionalProperties":false,"properties":{"password":{"type":"string"},"username":{"type":"string"}},"required":["password","username"],"title":"work with consumer object","type":"object"}`, basicAuthConsumerSchema)
-
-	// schema
-	input := &GetInput{
-		Name: "limit-count",
-	}
-	ctx.SetInput(input)
-	val, _ := handler.Schema(ctx)
-	assert.NotNil(t, val)
-
-	// not exists
-	reqBody := `{
-	  "name": "not-exists"
-	}`
-	err = json.Unmarshal([]byte(reqBody), input)
-	assert.Nil(t, err)
-	ctx.SetInput(input)
-	val, _ = handler.Schema(ctx)
-	assert.Nil(t, val)
-
-	/*
-	 get plugin schema with schema_type: consumer
-	 plugin has consumer_schema
-	 return plugin`s consumer_schema
-	*/
-	reqBody = `{
-	 	"name": "jwt-auth",
-		"schema_type": "consumer"
-  	}`
-	json.Unmarshal([]byte(reqBody), input)
-	ctx.SetInput(input)
-	val, _ = handler.Schema(ctx)
-	assert.NotNil(t, val)
-
-	/*
-	 get plugin schema with schema_type: consumer
-	 plugin does not have consumer_schema
-	 return plugin`s schema
-	*/
-	reqBody = `{
-		"name": "limit-count",
-		"schema_type": "consumer"
-	}`
-	json.Unmarshal([]byte(reqBody), input)
-	ctx.SetInput(input)
-	val, _ = handler.Schema(ctx)
-	assert.NotNil(t, val)
-
-	/*
-	 get plugin schema with wrong schema_type: type,
-	 return plugin`s schema
-	*/
-	reqBody = `{
-		"name": "jwt-auth",
-		"schema_type": "type"
-  	}`
-	json.Unmarshal([]byte(reqBody), input)
-	ctx.SetInput(input)
-	val, _ = handler.Schema(ctx)
-	assert.NotNil(t, val)
-
-	// schema of dubbo-proxy
-	input = &GetInput{
-		Name: "dubbo-proxy",
-	}
-	ctx.SetInput(input)
-	val, err = handler.Schema(ctx)
-	assert.NotNil(t, val)
-	assert.Nil(t, err)
 }

--- a/api/internal/handler/schema/schema_test.go
+++ b/api/internal/handler/schema/schema_test.go
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package schema
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/shiningrush/droplet"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSchema(t *testing.T) {
+	// init
+	ctx := droplet.NewContext()
+	handler := &SchemaHandler{}
+	assert.NotNil(t, handler)
+
+	input := &SchemaInput{}
+
+	// not exists return nil
+	reqBody := `{
+		"resource": "not-exists"
+	}`
+	err := json.Unmarshal([]byte(reqBody), input)
+	assert.Nil(t, err)
+	ctx.SetInput(input)
+	val, _ := handler.Schema(ctx)
+	assert.Nil(t, val)
+
+	// route
+	reqBody = `{
+		"resource": "route"
+	}`
+	err = json.Unmarshal([]byte(reqBody), input)
+	assert.Nil(t, err)
+	ctx.SetInput(input)
+	val, _ = handler.Schema(ctx)
+	assert.NotNil(t, val)
+
+	// ----------- plugin schema  ----------
+
+	// limit-count
+	pluginInput := &PluginSchemaInput{
+		Name: "limit-count",
+	}
+	ctx.SetInput(pluginInput)
+	val, _ = handler.PluginSchema(ctx)
+	assert.NotNil(t, val)
+
+	// not exists
+	reqBody = `{
+	  "name": "not-exists"
+	}`
+	err = json.Unmarshal([]byte(reqBody), pluginInput)
+	assert.Nil(t, err)
+	ctx.SetInput(pluginInput)
+	val, _ = handler.PluginSchema(ctx)
+	assert.Nil(t, val)
+
+	/*
+	 get plugin schema with schema_type: consumer
+	 plugin has consumer_schema
+	 return plugin`s consumer_schema
+	*/
+	reqBody = `{
+	 	"name": "jwt-auth",
+		"schema_type": "consumer"
+  	}`
+	json.Unmarshal([]byte(reqBody), pluginInput)
+	ctx.SetInput(pluginInput)
+	val, _ = handler.PluginSchema(ctx)
+	assert.NotNil(t, val)
+
+	/*
+	 get plugin schema with schema_type: consumer
+	 plugin does not have consumer_schema
+	 return plugin`s schema
+	*/
+	reqBody = `{
+		"name": "limit-count",
+		"schema_type": "consumer"
+	}`
+	json.Unmarshal([]byte(reqBody), pluginInput)
+	ctx.SetInput(pluginInput)
+	val, _ = handler.PluginSchema(ctx)
+	assert.NotNil(t, val)
+
+	/*
+	 get plugin schema with wrong schema_type: type,
+	 return plugin`s schema
+	*/
+	reqBody = `{
+		"name": "jwt-auth",
+		"schema_type": "type"
+  	}`
+	json.Unmarshal([]byte(reqBody), pluginInput)
+	ctx.SetInput(pluginInput)
+	val, _ = handler.PluginSchema(ctx)
+	assert.NotNil(t, val)
+}

--- a/api/internal/route.go
+++ b/api/internal/route.go
@@ -35,10 +35,10 @@ import (
 	"github.com/apisix/manager-api/internal/handler/global_rule"
 	"github.com/apisix/manager-api/internal/handler/healthz"
 	"github.com/apisix/manager-api/internal/handler/label"
-	"github.com/apisix/manager-api/internal/handler/plugin"
 	"github.com/apisix/manager-api/internal/handler/plugin_config"
 	"github.com/apisix/manager-api/internal/handler/route"
 	"github.com/apisix/manager-api/internal/handler/route_online_debug"
+	"github.com/apisix/manager-api/internal/handler/schema"
 	"github.com/apisix/manager-api/internal/handler/server_info"
 	"github.com/apisix/manager-api/internal/handler/service"
 	"github.com/apisix/manager-api/internal/handler/ssl"
@@ -69,7 +69,8 @@ func SetUpRouter() *gin.Engine {
 		consumer.NewHandler,
 		upstream.NewHandler,
 		service.NewHandler,
-		plugin.NewHandler,
+		schema.NewHandler,
+		schema.NewSchemaHandler,
 		healthz.NewHandler,
 		authentication.NewHandler,
 		global_rule.NewHandler,

--- a/api/test/e2enew/schema/plugin_test.go
+++ b/api/test/e2enew/schema/plugin_test.go
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package schema
+
+import (
+	"net/http"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+
+	"e2enew/base"
+)
+
+var _ = ginkgo.Describe("Plugin List", func() {
+	table.DescribeTable("test plugin basic", func(testCase base.HttpTestCase) {
+		base.RunTestCase(testCase)
+	},
+		table.Entry("get all plugins", base.HttpTestCase{
+			Object:       base.ManagerApiExpect(),
+			Method:       http.MethodGet,
+			Path:         "/apisix/admin/plugins",
+			Query:        "all=true",
+			Headers:      map[string]string{"Authorization": base.GetToken()},
+			ExpectStatus: http.StatusOK,
+			ExpectBody:   []string{"request-id", "syslog", "echo", "proxy-mirror"},
+			Sleep:        base.SleepTime,
+		}),
+		table.Entry("get all plugins", base.HttpTestCase{
+			Object:       base.ManagerApiExpect(),
+			Method:       http.MethodGet,
+			Path:         "/apisix/admin/plugins",
+			Query:        "all=false",
+			Headers:      map[string]string{"Authorization": base.GetToken()},
+			ExpectStatus: http.StatusOK,
+			ExpectBody:   []string{"request-id", "syslog", "echo", "proxy-mirror"},
+			Sleep:        base.SleepTime,
+		}),
+	)
+})

--- a/api/test/e2enew/schema/schema_suite_test.go
+++ b/api/test/e2enew/schema/schema_suite_test.go
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package plugin
+package schema
 
 import (
 	"testing"
@@ -23,5 +23,5 @@ import (
 )
 
 func TestPlugin(t *testing.T) {
-	ginkgo.RunSpecs(t, "plugin suite")
+	ginkgo.RunSpecs(t, "schema suite")
 }

--- a/api/test/e2enew/schema/schema_test.go
+++ b/api/test/e2enew/schema/schema_test.go
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package plugin
+package schema
 
 import (
 	"net/http"
@@ -22,39 +22,14 @@ import (
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 
-	"github.com/apisix/manager-api/test/e2enew/base"
+	"e2enew/base"
 )
 
-var _ = ginkgo.Describe("Plugin Basic", func() {
-	table.DescribeTable("test plugin basic", func(testCase base.HttpTestCase) {
-		base.RunTestCase(testCase)
-	},
-		table.Entry("get all plugins", base.HttpTestCase{
-			Object:       base.ManagerApiExpect(),
-			Method:       http.MethodGet,
-			Path:         "/apisix/admin/plugins",
-			Query:        "all=true",
-			Headers:      map[string]string{"Authorization": base.GetToken()},
-			ExpectStatus: http.StatusOK,
-			ExpectBody:   []string{"request-id", "syslog", "echo", "proxy-mirror"},
-			Sleep:        base.SleepTime,
-		}),
-		table.Entry("get all plugins", base.HttpTestCase{
-			Object:       base.ManagerApiExpect(),
-			Method:       http.MethodGet,
-			Path:         "/apisix/admin/plugins",
-			Query:        "all=false",
-			Headers:      map[string]string{"Authorization": base.GetToken()},
-			ExpectStatus: http.StatusOK,
-			ExpectBody:   []string{"request-id", "syslog", "echo", "proxy-mirror"},
-			Sleep:        base.SleepTime,
-		}),
-	)
-
+var _ = ginkgo.Describe("Schema Test", func() {
 	table.DescribeTable("test schema basic", func(testCase base.HttpTestCase) {
 		base.RunTestCase(testCase)
 	},
-		table.Entry("get consumer schema", base.HttpTestCase{
+		table.Entry("get consumer schema of plugin", base.HttpTestCase{
 			Object:       base.ManagerApiExpect(),
 			Method:       http.MethodGet,
 			Path:         "/apisix/admin/schema/plugins/jwt-auth",
@@ -71,13 +46,23 @@ var _ = ginkgo.Describe("Plugin Basic", func() {
 				"\"required\":[\"key\"],\"type\":\"object\"}",
 			Sleep: base.SleepTime,
 		}),
-		table.Entry("get require-id plugin", base.HttpTestCase{
+		table.Entry("get schema of plugin `require-id`", base.HttpTestCase{
 			Object:       base.ManagerApiExpect(),
 			Method:       http.MethodGet,
 			Path:         "/apisix/admin/schema/plugins/jwt-auth",
 			Headers:      map[string]string{"Authorization": base.GetToken()},
 			ExpectStatus: http.StatusOK,
 			ExpectBody:   "{\"$comment\":\"this is a mark for our injected plugin schema\",\"additionalProperties\":false,\"properties\":{\"disable\":{\"type\":\"boolean\"}},\"type\":\"object\"}",
+			Sleep:        base.SleepTime,
+		}),
+
+		table.Entry("get schema of consumer", base.HttpTestCase{
+			Object:       base.ManagerApiExpect(),
+			Method:       http.MethodGet,
+			Path:         "/apisix/admin/schemas/consumer",
+			Headers:      map[string]string{"Authorization": base.GetToken()},
+			ExpectStatus: http.StatusOK,
+			ExpectBody:   `"properties":{"create_time":{"type":"integer"},"desc":{"maxLength":256,"type":"string"},"id":{"anyOf":[{"maxLength":64,"minLength":1,"pattern":"^[a-zA-Z0-9-_.]+$","type":"string"},{"minimum":1,"type":"integer"}]},"labels":{"description":"key/value pairs to specify attributes","maxProperties":16,"patternProperties":{".*":{"description":"value of label","maxLength":64,"minLength":1,"pattern":"^[a-zA-Z0-9-_.]+$","type":"string"}},"type":"object"},"plugins":{"type":"object"},"update_time":{"type":"integer"},"username":{"maxLength":32,"minLength":1,"pattern":"^[a-zA-Z0-9_]+$","type":"string"}}`,
 			Sleep:        base.SleepTime,
 		}),
 	)


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [ ] Bugfix
- [x] New feature provided
- [ ] Improve performance
- [ ] Backport patches

- Related issues
close #1450

___
### New feature or improvement
- Describe the details and related test reports.

The APISIX ingress controller needs to use the json schema (dashboard FE or other projects may also need it), and it still use the admin api interface.
At present, the manager api only supports to expose the json schema of plugins.

so we now support exposing JSON Schema of all resources and plugins through API

___
### Please add the corresponding test cases if necessary.
added.
