### PR TITLE
fix: CI failed

### DIFF
--- a/.github/workflows/make-build.yaml
+++ b/.github/workflows/make-build.yaml
@@ -41,7 +41,9 @@ jobs:
 
       - name: start dashboard
         working-directory: ./output
-        run: ./manager-api > ./api.log 2>&1 &
+        run: |
+          ./manager-api > ./api.log 2>&1 &
+          sleep 5
 
       - name: check
         run: api/test/shell/manager_smoking.sh -s true

--- a/api/internal/core/entity/entity.go
+++ b/api/internal/core/entity/entity.go
@@ -81,7 +81,7 @@ type Route struct {
 	Hosts           []string               `json:"hosts,omitempty"`
 	RemoteAddr      string                 `json:"remote_addr,omitempty"`
 	RemoteAddrs     []string               `json:"remote_addrs,omitempty"`
-	Vars            interface{}            `json:"vars,omitempty"`
+	Vars            []interface{}          `json:"vars,omitempty"`
 	FilterFunc      string                 `json:"filter_func,omitempty"`
 	Script          interface{}            `json:"script,omitempty"`
 	ScriptID        interface{}            `json:"script_id,omitempty"` // For debug and optimization(cache), currently same as Route's ID

--- a/api/test/docker/docker-compose.yaml
+++ b/api/test/docker/docker-compose.yaml
@@ -131,7 +131,7 @@ services:
       context: ../../
       dockerfile: test/docker/Dockerfile-apisix
       args:
-        - APISIX_VERSION=master
+        - APISIX_VERSION=2.4
     restart: always
     volumes:
       - ./apisix_config.yaml:/usr/local/apisix/conf/config.yaml:ro
@@ -156,7 +156,7 @@ services:
       context: ../../
       dockerfile: test/docker/Dockerfile-apisix
       args:
-        - APISIX_VERSION=master
+        - APISIX_VERSION=2.4
     restart: always
     volumes:
       - ./apisix_config2.yaml:/usr/local/apisix/conf/config.yaml:ro

--- a/api/test/docker/docker-compose.yaml
+++ b/api/test/docker/docker-compose.yaml
@@ -131,7 +131,7 @@ services:
       context: ../../
       dockerfile: test/docker/Dockerfile-apisix
       args:
-        - APISIX_VERSION=2.4
+        - APISIX_VERSION=master
     restart: always
     volumes:
       - ./apisix_config.yaml:/usr/local/apisix/conf/config.yaml:ro
@@ -156,7 +156,7 @@ services:
       context: ../../
       dockerfile: test/docker/Dockerfile-apisix
       args:
-        - APISIX_VERSION=2.4
+        - APISIX_VERSION=master
     restart: always
     volumes:
       - ./apisix_config2.yaml:/usr/local/apisix/conf/config.yaml:ro

--- a/api/test/shell/cli_test.sh
+++ b/api/test/shell/cli_test.sh
@@ -269,6 +269,7 @@ if [ ! $code -eq 403 ]; then
 fi
 
 ./manager-api stop
+sleep 6
 clean_up
 
 
@@ -411,6 +412,7 @@ if [ ! $count ] || [ $count -ne 1 ]; then
 fi
 
 ./manager-api stop
+sleep 6
 clean_up
 
 # mtls test

--- a/web/cypress/fixtures/export-route-dataset.json
+++ b/web/cypress/fixtures/export-route-dataset.json
@@ -46,8 +46,7 @@
             },
             "type": "roundrobin",
             "pass_host": "pass"
-          },
-          "x-apisix-vars": []
+          }
         }
       }
     }
@@ -99,8 +98,7 @@
             },
             "type": "roundrobin",
             "pass_host": "pass"
-          },
-          "x-apisix-vars": []
+          }
         }
       },
       "/{params}-APISIX-REPEAT-URI-2": {

--- a/web/cypress/fixtures/export-route-dataset.json
+++ b/web/cypress/fixtures/export-route-dataset.json
@@ -149,8 +149,7 @@
             },
             "type": "roundrobin",
             "pass_host": "pass"
-          },
-          "x-apisix-vars": []
+          }
         }
       }
     }


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

- Related issues

___
### Bugfix
- Description
`Vars` in  struct `Route` uses interface{} as the type, which makes it impossible to omit an empty array.

As a result, after APISIX uses the new version of `lua-resty-radixtree`, The routes with empty array `vars` cannot be matched

- How to fix?

uses []interface{} instead. and also fix some small potential unstable issues
