### PR TITLE
feat: check if the service is used by route when deleting

### DIFF
--- a/api/internal/handler/service/service.go
+++ b/api/internal/handler/service/service.go
@@ -247,7 +247,7 @@ func (h *Handler) BatchDelete(c droplet.Context) (interface{}, error) {
 			fmt.Errorf("route: %s is using this service", ret.Rows[0].(*entity.Route).Name)
 	}
 
-	if err := h.serviceStore.BatchDelete(c.Context(), strings.Split(input.IDs, ",")); err != nil {
+	if err := h.serviceStore.BatchDelete(c.Context(), ids); err != nil {
 		return handler.SpecCodeResponse(err), err
 	}
 

--- a/api/internal/handler/service/service.go
+++ b/api/internal/handler/service/service.go
@@ -38,12 +38,14 @@ import (
 type Handler struct {
 	serviceStore  store.Interface
 	upstreamStore store.Interface
+	routeStore    store.Interface
 }
 
 func NewHandler() (handler.RouteRegister, error) {
 	return &Handler{
 		serviceStore:  store.GetStore(store.HubKeyService),
 		upstreamStore: store.GetStore(store.HubKeyUpstream),
+		routeStore:    store.GetStore(store.HubKeyRoute),
 	}, nil
 }
 
@@ -218,6 +220,32 @@ type BatchDelete struct {
 
 func (h *Handler) BatchDelete(c droplet.Context) (interface{}, error) {
 	input := c.Input().(*BatchDelete)
+	ids := strings.Split(input.IDs, ",")
+	mp := make(map[string]struct{})
+	for _, id := range ids {
+		mp[id] = struct{}{}
+	}
+
+	ret, err := h.routeStore.List(c.Context(), store.ListInput{
+		Predicate: func(obj interface{}) bool {
+			route := obj.(*entity.Route)
+			if _, exist := mp[utils.InterfaceToString(route.ServiceID)]; exist {
+				return true
+			}
+
+			return false
+		},
+		PageSize:   0,
+		PageNumber: 0,
+	})
+	if err != nil {
+		return handler.SpecCodeResponse(err), err
+	}
+
+	if ret.TotalSize > 0 {
+		return &data.SpecCodeResponse{StatusCode: http.StatusBadRequest},
+			fmt.Errorf("route: %s is using this service", ret.Rows[0].(*entity.Route).Name)
+	}
 
 	if err := h.serviceStore.BatchDelete(c.Context(), strings.Split(input.IDs, ",")); err != nil {
 		return handler.SpecCodeResponse(err), err

--- a/api/internal/handler/service/service_test.go
+++ b/api/internal/handler/service/service_test.go
@@ -18,6 +18,7 @@
 package service
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"testing"
@@ -801,12 +802,15 @@ func TestService_Patch(t *testing.T) {
 
 func TestServices_Delete(t *testing.T) {
 	tests := []struct {
-		caseDesc  string
-		giveInput *BatchDelete
-		giveErr   error
-		wantInput []string
-		wantErr   error
-		wantRet   interface{}
+		caseDesc      string
+		giveInput     *BatchDelete
+		giveErr       error
+		wantInput     []string
+		wantErr       error
+		wantRet       interface{}
+		routeMockData []*entity.Route
+		routeMockErr  error
+		getCalled     bool
 	}{
 		{
 			caseDesc: "delete success",
@@ -814,6 +818,7 @@ func TestServices_Delete(t *testing.T) {
 				IDs: "s1",
 			},
 			wantInput: []string{"s1"},
+			getCalled: true,
 		},
 		{
 			caseDesc: "batch delete success",
@@ -821,6 +826,7 @@ func TestServices_Delete(t *testing.T) {
 				IDs: "s1,s2",
 			},
 			wantInput: []string{"s1", "s2"},
+			getCalled: true,
 		},
 		{
 			caseDesc: "delete failed",
@@ -831,6 +837,45 @@ func TestServices_Delete(t *testing.T) {
 			wantInput: []string{"s1"},
 			wantRet:   handler.SpecCodeResponse(fmt.Errorf("delete error")),
 			wantErr:   fmt.Errorf("delete error"),
+			getCalled: true,
+		},
+		{
+			caseDesc: "delete failed, route is using",
+			giveInput: &BatchDelete{
+				IDs: "s1",
+			},
+			wantInput: []string{"s1"},
+			routeMockData: []*entity.Route{
+				&entity.Route{
+					BaseInfo: entity.BaseInfo{
+						ID:         "r1",
+						CreateTime: 1609746531,
+					},
+					Name:       "route1",
+					Desc:       "test_route",
+					UpstreamID: "u1",
+					ServiceID:  "s1",
+					Labels: map[string]string{
+						"version": "v1",
+					},
+				},
+			},
+			routeMockErr: nil,
+			getCalled:    false,
+			wantRet:      &data.SpecCodeResponse{StatusCode: 400},
+			wantErr:      errors.New("route: route1 is using this service"),
+		},
+		{
+			caseDesc: "delete failed, route list error",
+			giveInput: &BatchDelete{
+				IDs: "s1",
+			},
+			wantInput:     []string{"s1"},
+			routeMockData: nil,
+			routeMockErr:  errors.New("route list error"),
+			wantRet:       handler.SpecCodeResponse(errors.New("route list error")),
+			wantErr:       errors.New("route list error"),
+			getCalled:     false,
 		},
 	}
 
@@ -844,11 +889,31 @@ func TestServices_Delete(t *testing.T) {
 				assert.Equal(t, tc.wantInput, input)
 			}).Return(tc.giveErr)
 
-			h := Handler{serviceStore: serviceStore}
+			routeStore := &store.MockInterface{}
+			routeStore.On("List", mock.Anything).Return(func(input store.ListInput) *store.ListOutput {
+				var returnData []interface{}
+				for _, c := range tc.routeMockData {
+					if input.Predicate(c) {
+						if input.Format == nil {
+							returnData = append(returnData, c)
+							continue
+						}
+
+						returnData = append(returnData, input.Format(c))
+					}
+				}
+
+				return &store.ListOutput{
+					Rows:      returnData,
+					TotalSize: len(returnData),
+				}
+			}, tc.routeMockErr)
+
+			h := Handler{serviceStore: serviceStore, routeStore: routeStore}
 			ctx := droplet.NewContext()
 			ctx.SetInput(tc.giveInput)
 			ret, err := h.BatchDelete(ctx)
-			assert.True(t, getCalled)
+			assert.Equal(t, tc.getCalled, getCalled)
 			assert.Equal(t, tc.wantRet, ret)
 			assert.Equal(t, tc.wantErr, err)
 		})

--- a/api/test/e2enew/service/service_test.go
+++ b/api/test/e2enew/service/service_test.go
@@ -83,9 +83,9 @@ var _ = ginkgo.Describe("create service without plugin", func() {
 			Method: http.MethodPut,
 			Path:   "/apisix/admin/routes/r1",
 			Body: `{
- 				"uri": "/server_port",
- 				"service_id": "s1"
- 			}`,
+				"uri": "/server_port",
+				"service_id": "s1"
+			}`,
 			Headers:      map[string]string{"Authorization": base.GetToken()},
 			ExpectStatus: http.StatusOK,
 			Sleep:        base.SleepTime,
@@ -183,9 +183,9 @@ var _ = ginkgo.Describe("create service with plugin", func() {
 			Method: http.MethodPut,
 			Path:   "/apisix/admin/routes/r1",
 			Body: `{
- 				"uri": "/server_port",
- 				"service_id": "s1"
- 			}`,
+				"uri": "/server_port",
+				"service_id": "s1"
+			}`,
 			Headers:      map[string]string{"Authorization": base.GetToken()},
 			ExpectStatus: http.StatusOK,
 			Sleep:        base.SleepTime,
@@ -300,9 +300,9 @@ var _ = ginkgo.Describe("create service with all options via POST method", func(
 			Method: http.MethodPut,
 			Path:   "/apisix/admin/routes/r1",
 			Body: `{
- 				"uri": "/hello",
- 				"service_id": "s2"
- 			}`,
+				"uri": "/hello",
+				"service_id": "s2"
+			}`,
 			Headers:      map[string]string{"Authorization": base.GetToken()},
 			ExpectStatus: http.StatusOK,
 			Sleep:        base.SleepTime,
@@ -534,6 +534,14 @@ var _ = ginkgo.Describe("test service delete", func() {
 			Headers:      map[string]string{"Authorization": base.GetToken()},
 			ExpectStatus: http.StatusOK,
 		}),
+		table.Entry("check route exist", base.HttpTestCase{
+			Desc:         "check route exist",
+			Object:       base.ManagerApiExpect(),
+			Method:       http.MethodDelete,
+			Path:         "/apisix/admin/routes/r1",
+			Headers:      map[string]string{"Authorization": base.GetToken()},
+			ExpectStatus: http.StatusNotFound,
+		}),
 		table.Entry("delete service success", base.HttpTestCase{
 			Desc:         "delete service success",
 			Object:       base.ManagerApiExpect(),
@@ -541,5 +549,13 @@ var _ = ginkgo.Describe("test service delete", func() {
 			Path:         "/apisix/admin/services/s1",
 			Headers:      map[string]string{"Authorization": base.GetToken()},
 			ExpectStatus: http.StatusOK,
+		}),
+		table.Entry("check the service exist", base.HttpTestCase{
+			Desc:         "check the exist",
+			Object:       base.ManagerApiExpect(),
+			Method:       http.MethodGet,
+			Path:         "/apisix/admin/services/s1",
+			Headers:      map[string]string{"Authorization": base.GetToken()},
+			ExpectStatus: http.StatusNotFound,
 		}))
 })

--- a/api/test/e2enew/service/service_test.go
+++ b/api/test/e2enew/service/service_test.go
@@ -486,23 +486,22 @@ var _ = ginkgo.Describe("test service delete", func() {
 		func(tc base.HttpTestCase) {
 			base.RunTestCase(tc)
 		},
-		table.Entry("",
-			base.HttpTestCase{
-				Desc:         "create service without plugin",
-				Object:       base.ManagerApiExpect(),
-				Method:       http.MethodPut,
-				Path:         "/apisix/admin/services/s1",
-				Headers:      map[string]string{"Authorization": base.GetToken()},
-				Body:         string(_createServiceBody),
-				ExpectStatus: http.StatusOK,
-				ExpectBody:   "\"name\":\"testservice\",\"upstream\":{\"nodes\":[{\"host\":\"" + base.UpstreamIp + "\",\"port\":1980,\"weight\":1}],\"type\":\"roundrobin\"}}",
-			},
-			base.HttpTestCase{
-				Desc:   "create route use service",
-				Object: base.ManagerApiExpect(),
-				Method: http.MethodPut,
-				Path:   "/apisix/admin/routes/r1",
-				Body: `{
+		table.Entry("create service without plugin", base.HttpTestCase{
+			Desc:         "create service without plugin",
+			Object:       base.ManagerApiExpect(),
+			Method:       http.MethodPut,
+			Path:         "/apisix/admin/services/s1",
+			Headers:      map[string]string{"Authorization": base.GetToken()},
+			Body:         string(_createServiceBody),
+			ExpectStatus: http.StatusOK,
+			ExpectBody:   "\"name\":\"testservice\",\"upstream\":{\"nodes\":[{\"host\":\"" + base.UpstreamIp + "\",\"port\":1980,\"weight\":1}],\"type\":\"roundrobin\"}}",
+		}),
+		table.Entry("create route use service s1", base.HttpTestCase{
+			Desc:   "create route use service s1",
+			Object: base.ManagerApiExpect(),
+			Method: http.MethodPut,
+			Path:   "/apisix/admin/routes/r1",
+			Body: `{
 				"id": "r1",
 				"name": "route1",
 				"uri": "/hello",
@@ -514,35 +513,33 @@ var _ = ginkgo.Describe("test service delete", func() {
 				},
 				"service_id": "s1"
 			}`,
-				Headers:      map[string]string{"Authorization": base.GetToken()},
-				ExpectStatus: http.StatusOK,
-				ExpectBody:   "\"service_id\":\"s1\"",
-			},
-			base.HttpTestCase{
-				Desc:         "delete service failed",
-				Object:       base.ManagerApiExpect(),
-				Method:       http.MethodDelete,
-				Path:         "/apisix/admin/services/s1",
-				Headers:      map[string]string{"Authorization": base.GetToken()},
-				ExpectStatus: http.StatusBadRequest,
-				ExpectBody:   "route: route1 is using this service",
-			},
-			base.HttpTestCase{
-				Desc:         "delete route first",
-				Object:       base.ManagerApiExpect(),
-				Method:       http.MethodDelete,
-				Path:         "/apisix/admin/routes/r1",
-				Headers:      map[string]string{"Authorization": base.GetToken()},
-				ExpectStatus: http.StatusOK,
-			},
-			base.HttpTestCase{
-				Desc:         "delete service success",
-				Object:       base.ManagerApiExpect(),
-				Method:       http.MethodDelete,
-				Path:         "/apisix/admin/services/s1",
-				Headers:      map[string]string{"Authorization": base.GetToken()},
-				ExpectStatus: http.StatusOK,
-			},
-		))
-},
-)
+			Headers:      map[string]string{"Authorization": base.GetToken()},
+			ExpectStatus: http.StatusOK,
+			ExpectBody:   "\"service_id\":\"s1\"",
+		}),
+		table.Entry("delete service failed", base.HttpTestCase{
+			Desc:         "delete service failed",
+			Object:       base.ManagerApiExpect(),
+			Method:       http.MethodDelete,
+			Path:         "/apisix/admin/services/s1",
+			Headers:      map[string]string{"Authorization": base.GetToken()},
+			ExpectStatus: http.StatusBadRequest,
+			ExpectBody:   "route: route1 is using this service",
+		}),
+		table.Entry("delete route first", base.HttpTestCase{
+			Desc:         "delete route first",
+			Object:       base.ManagerApiExpect(),
+			Method:       http.MethodDelete,
+			Path:         "/apisix/admin/routes/r1",
+			Headers:      map[string]string{"Authorization": base.GetToken()},
+			ExpectStatus: http.StatusOK,
+		}),
+		table.Entry("delete service success", base.HttpTestCase{
+			Desc:         "delete service success",
+			Object:       base.ManagerApiExpect(),
+			Method:       http.MethodDelete,
+			Path:         "/apisix/admin/services/s1",
+			Headers:      map[string]string{"Authorization": base.GetToken()},
+			ExpectStatus: http.StatusOK,
+		}))
+})

--- a/api/test/e2enew/service/service_test.go
+++ b/api/test/e2enew/service/service_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/apisix/manager-api/test/e2enew/base"
+	"github.com/onsi/ginkgo/extensions/table"
 )
 
 var _ = ginkgo.Describe("create service without plugin", func() {
@@ -464,39 +465,44 @@ var _ = ginkgo.Describe("service update use patch method", func() {
 })
 
 var _ = ginkgo.Describe("test service delete", func() {
-	ginkgo.It("create service without plugin", func() {
-		t := ginkgo.GinkgoT()
-		var createServiceBody map[string]interface{} = map[string]interface{}{
-			"name": "testservice",
-			"upstream": map[string]interface{}{
-				"type": "roundrobin",
-				"nodes": []map[string]interface{}{
-					{
-						"host":   base.UpstreamIp,
-						"port":   1980,
-						"weight": 1,
-					},
+	t := ginkgo.GinkgoT()
+	var createServiceBody map[string]interface{} = map[string]interface{}{
+		"name": "testservice",
+		"upstream": map[string]interface{}{
+			"type": "roundrobin",
+			"nodes": []map[string]interface{}{
+				{
+					"host":   base.UpstreamIp,
+					"port":   1980,
+					"weight": 1,
 				},
 			},
-		}
-		_createServiceBody, err := json.Marshal(createServiceBody)
-		assert.Nil(t, err)
-		base.RunTestCase(base.HttpTestCase{
-			Desc:         "create service without plugin",
-			Object:       base.ManagerApiExpect(),
-			Method:       http.MethodPut,
-			Path:         "/apisix/admin/services/s1",
-			Headers:      map[string]string{"Authorization": base.GetToken()},
-			Body:         string(_createServiceBody),
-			ExpectStatus: http.StatusOK,
-			ExpectBody:   "\"name\":\"testservice\",\"upstream\":{\"nodes\":[{\"host\":\"" + base.UpstreamIp + "\",\"port\":1980,\"weight\":1}],\"type\":\"roundrobin\"}}",
-		})
-		base.RunTestCase(base.HttpTestCase{
-			Desc:   "create route use service",
-			Object: base.ManagerApiExpect(),
-			Method: http.MethodPut,
-			Path:   "/apisix/admin/routes/r1",
-			Body: `{
+		},
+	}
+	_createServiceBody, err := json.Marshal(createServiceBody)
+	assert.Nil(t, err)
+
+	table.DescribeTable("test service delete",
+		func(tc base.HttpTestCase) {
+			base.RunTestCase(tc)
+		},
+		table.Entry("",
+			base.HttpTestCase{
+				Desc:         "create service without plugin",
+				Object:       base.ManagerApiExpect(),
+				Method:       http.MethodPut,
+				Path:         "/apisix/admin/services/s1",
+				Headers:      map[string]string{"Authorization": base.GetToken()},
+				Body:         string(_createServiceBody),
+				ExpectStatus: http.StatusOK,
+				ExpectBody:   "\"name\":\"testservice\",\"upstream\":{\"nodes\":[{\"host\":\"" + base.UpstreamIp + "\",\"port\":1980,\"weight\":1}],\"type\":\"roundrobin\"}}",
+			},
+			base.HttpTestCase{
+				Desc:   "create route use service",
+				Object: base.ManagerApiExpect(),
+				Method: http.MethodPut,
+				Path:   "/apisix/admin/routes/r1",
+				Body: `{
 				"id": "r1",
 				"name": "route1",
 				"uri": "/hello",
@@ -508,34 +514,35 @@ var _ = ginkgo.Describe("test service delete", func() {
 				},
 				"service_id": "s1"
 			}`,
-			Headers:      map[string]string{"Authorization": base.GetToken()},
-			ExpectStatus: http.StatusOK,
-			ExpectBody:   "\"service_id\":\"s1\"",
-		})
-		base.RunTestCase(base.HttpTestCase{
-			Desc:         "delete service failed",
-			Object:       base.ManagerApiExpect(),
-			Method:       http.MethodDelete,
-			Path:         "/apisix/admin/services/s1",
-			Headers:      map[string]string{"Authorization": base.GetToken()},
-			ExpectStatus: http.StatusBadRequest,
-			ExpectBody:   "route: route1 is using this service",
-		})
-		base.RunTestCase(base.HttpTestCase{
-			Desc:         "delete route first",
-			Object:       base.ManagerApiExpect(),
-			Method:       http.MethodDelete,
-			Path:         "/apisix/admin/routes/r1",
-			Headers:      map[string]string{"Authorization": base.GetToken()},
-			ExpectStatus: http.StatusOK,
-		})
-		base.RunTestCase(base.HttpTestCase{
-			Desc:         "delete service success",
-			Object:       base.ManagerApiExpect(),
-			Method:       http.MethodDelete,
-			Path:         "/apisix/admin/services/s1",
-			Headers:      map[string]string{"Authorization": base.GetToken()},
-			ExpectStatus: http.StatusOK,
-		})
-	})
-})
+				Headers:      map[string]string{"Authorization": base.GetToken()},
+				ExpectStatus: http.StatusOK,
+				ExpectBody:   "\"service_id\":\"s1\"",
+			},
+			base.HttpTestCase{
+				Desc:         "delete service failed",
+				Object:       base.ManagerApiExpect(),
+				Method:       http.MethodDelete,
+				Path:         "/apisix/admin/services/s1",
+				Headers:      map[string]string{"Authorization": base.GetToken()},
+				ExpectStatus: http.StatusBadRequest,
+				ExpectBody:   "route: route1 is using this service",
+			},
+			base.HttpTestCase{
+				Desc:         "delete route first",
+				Object:       base.ManagerApiExpect(),
+				Method:       http.MethodDelete,
+				Path:         "/apisix/admin/routes/r1",
+				Headers:      map[string]string{"Authorization": base.GetToken()},
+				ExpectStatus: http.StatusOK,
+			},
+			base.HttpTestCase{
+				Desc:         "delete service success",
+				Object:       base.ManagerApiExpect(),
+				Method:       http.MethodDelete,
+				Path:         "/apisix/admin/services/s1",
+				Headers:      map[string]string{"Authorization": base.GetToken()},
+				ExpectStatus: http.StatusOK,
+			},
+		))
+},
+)

--- a/api/test/e2enew/service/service_test.go
+++ b/api/test/e2enew/service/service_test.go
@@ -573,6 +573,14 @@ var _ = ginkgo.Describe("test service delete", func() {
 			ExpectStatus: http.StatusOK,
 			ExpectBody:   "\"service_id\":\"s1\"",
 		}),
+		table.Entry("hit route on apisix", base.HttpTestCase{
+			Object:       base.APISIXExpect(),
+			Method:       http.MethodGet,
+			Path:         "/hello",
+			ExpectStatus: http.StatusOK,
+			ExpectBody:   "hello world",
+			Sleep:        base.SleepTime,
+		}),
 		table.Entry("delete service failed", base.HttpTestCase{
 			Desc:         "delete service failed",
 			Object:       base.ManagerApiExpect(),


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [ ] Bugfix
- [x] New feature provided
- [ ] Improve performance
- [ ] Backport patches

### New feature or improvement
- Describe the details and related test reports.

Now, when deleting a service, we don't check whether there is a route using it.
This may lead to the DP error if the user deletes the service by mistake.

So, we should check if the service is using by route when deleting.
If the service is using, we return 400 to guarantee the DP works well.

___
### Please add the corresponding test cases if necessary.

Added.
___