### PR TITLE
fix: check name existed when creating or updating a resource

### DIFF
--- a/api/internal/handler/handler.go
+++ b/api/internal/handler/handler.go
@@ -35,6 +35,7 @@
 package handler
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -44,6 +45,8 @@ import (
 	"github.com/shiningrush/droplet/data"
 	"github.com/shiningrush/droplet/middleware"
 
+	"github.com/apisix/manager-api/internal/core/entity"
+	"github.com/apisix/manager-api/internal/core/store"
 	"github.com/apisix/manager-api/internal/utils"
 )
 
@@ -103,4 +106,42 @@ func IDCompare(idOnPath string, idOnBody interface{}) error {
 	}
 
 	return nil
+}
+
+func NameExistCheck(ctx context.Context, stg store.Interface, resource, name string, excludeID interface{}) (interface{}, error) {
+	ret, err := stg.List(ctx, store.ListInput{
+		Predicate: func(obj interface{}) bool {
+			var objName string
+			var objID interface{}
+			switch resource {
+			case "route":
+				objID = obj.(*entity.Route).ID
+				objName = obj.(*entity.Route).Name
+			case "service":
+				objID = obj.(*entity.Service).ID
+				objName = obj.(*entity.Service).Name
+			case "upstream":
+				objID = obj.(*entity.Upstream).ID
+				objName = obj.(*entity.Upstream).Name
+			}
+
+			if excludeID != nil && objID == excludeID {
+				return false
+			}
+			if objName == name {
+				return true
+			}
+
+			return false
+		},
+	})
+	if err != nil {
+		return &data.SpecCodeResponse{StatusCode: http.StatusInternalServerError}, err
+	}
+	if ret.TotalSize > 0 {
+		return &data.SpecCodeResponse{StatusCode: http.StatusBadRequest},
+			fmt.Errorf("%s name exists", resource)
+	}
+
+	return nil, nil
 }

--- a/api/internal/handler/handler.go
+++ b/api/internal/handler/handler.go
@@ -123,6 +123,8 @@ func NameExistCheck(ctx context.Context, stg store.Interface, resource, name str
 			case "upstream":
 				objID = obj.(*entity.Upstream).ID
 				objName = obj.(*entity.Upstream).Name
+			default:
+				panic("bad resource")
 			}
 
 			if excludeID != nil && objID == excludeID {

--- a/api/internal/handler/route/route.go
+++ b/api/internal/handler/route/route.go
@@ -18,7 +18,6 @@ package route
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -381,18 +380,12 @@ func (h *Handler) Create(c droplet.Context) (interface{}, error) {
 	}
 
 	// check name existed
-	ret, err := h.routeStore.List(c.Context(), store.ListInput{
-		Predicate: func(obj interface{}) bool {
-			return obj.(*entity.Route).Name == input.Name
-		},
-	})
+	ret, err := handler.NameExistCheck(c.Context(), h.routeStore, "route", input.Name, nil)
 	if err != nil {
-		return &data.SpecCodeResponse{StatusCode: http.StatusInternalServerError}, err
-	}
-	if ret.TotalSize > 0 {
-		return &data.SpecCodeResponse{StatusCode: http.StatusBadRequest}, errors.New("route name is existed")
+		return ret, err
 	}
 
+	// create
 	res, err := h.routeStore.Create(c.Context(), input)
 	if err != nil {
 		return handler.SpecCodeResponse(err), err
@@ -504,25 +497,12 @@ func (h *Handler) Update(c droplet.Context) (interface{}, error) {
 	}
 
 	// check name existed
-	ret, err := h.routeStore.List(c.Context(), store.ListInput{
-		Predicate: func(obj interface{}) bool {
-			// exclude the route itself
-			if obj.(*entity.Route).ID == input.ID {
-				return false
-			}
-			if obj.(*entity.Route).Name == input.Name {
-				return true
-			}
-			return false
-		},
-	})
+	ret, err := handler.NameExistCheck(c.Context(), h.routeStore, "route", input.Name, input.ID)
 	if err != nil {
-		return &data.SpecCodeResponse{StatusCode: http.StatusInternalServerError}, err
-	}
-	if ret.TotalSize > 0 {
-		return &data.SpecCodeResponse{StatusCode: http.StatusBadRequest}, errors.New("route name is existed")
+		return ret, err
 	}
 
+	// create
 	res, err := h.routeStore.Update(c.Context(), &input.Route, true)
 	if err != nil {
 		return handler.SpecCodeResponse(err), err

--- a/api/internal/handler/route/route_test.go
+++ b/api/internal/handler/route/route_test.go
@@ -50,6 +50,7 @@ type testCase struct {
 	serviceErr   error
 	upstreamRet  interface{}
 	upstreamErr  error
+	nameExistRet []interface{}
 }
 
 var DagScript = `
@@ -968,6 +969,14 @@ func TestRoute_Create(t *testing.T) {
 				assert.Equal(t, tc.mockInput, route)
 			}).Return(tc.mockRet, tc.mockErr)
 
+			mStore.On("List", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+			}).Return(func(input store.ListInput) *store.ListOutput {
+				return &store.ListOutput{
+					Rows:      tc.nameExistRet,
+					TotalSize: len(tc.nameExistRet),
+				}
+			}, nil)
+
 			svcStore := &store.MockInterface{}
 			svcStore.On("Get", mock.Anything, mock.Anything).Return(tc.serviceRet, tc.serviceErr)
 
@@ -1210,6 +1219,14 @@ func TestRoute_Update(t *testing.T) {
 				assert.Equal(t, tc.mockInput, input)
 				assert.True(t, createIfNotExist)
 			}).Return(tc.mockRet, tc.mockErr)
+
+			routeStore.On("List", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+			}).Return(func(input store.ListInput) *store.ListOutput {
+				return &store.ListOutput{
+					Rows:      tc.nameExistRet,
+					TotalSize: len(tc.nameExistRet),
+				}
+			}, nil)
 
 			serviceStore := &store.MockInterface{}
 			serviceStore.On("Get", mock.Anything, mock.Anything).Return(tc.serviceRet, tc.serviceErr)

--- a/api/internal/handler/service/service.go
+++ b/api/internal/handler/service/service.go
@@ -18,7 +18,6 @@ package service
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -169,16 +168,9 @@ func (h *Handler) Create(c droplet.Context) (interface{}, error) {
 	}
 
 	// check name existed
-	ret, err := h.serviceStore.List(c.Context(), store.ListInput{
-		Predicate: func(obj interface{}) bool {
-			return obj.(*entity.Service).Name == input.Name
-		},
-	})
+	ret, err := handler.NameExistCheck(c.Context(), h.serviceStore, "service", input.Name, nil)
 	if err != nil {
-		return &data.SpecCodeResponse{StatusCode: http.StatusInternalServerError}, err
-	}
-	if ret.TotalSize > 0 {
-		return &data.SpecCodeResponse{StatusCode: http.StatusBadRequest}, errors.New("service name is existed")
+		return ret, err
 	}
 
 	// create
@@ -220,23 +212,9 @@ func (h *Handler) Update(c droplet.Context) (interface{}, error) {
 	}
 
 	// check name existed
-	ret, err := h.serviceStore.List(c.Context(), store.ListInput{
-		Predicate: func(obj interface{}) bool {
-			// exclude the service itself
-			if obj.(*entity.Service).ID == input.ID {
-				return false
-			}
-			if obj.(*entity.Service).Name == input.Name {
-				return true
-			}
-			return false
-		},
-	})
+	ret, err := handler.NameExistCheck(c.Context(), h.serviceStore, "service", input.Name, input.ID)
 	if err != nil {
-		return &data.SpecCodeResponse{StatusCode: http.StatusInternalServerError}, err
-	}
-	if ret.TotalSize > 0 {
-		return &data.SpecCodeResponse{StatusCode: http.StatusBadRequest}, errors.New("service name is existed")
+		return ret, err
 	}
 
 	// update or create(if not exists)

--- a/api/internal/handler/service/service_test.go
+++ b/api/internal/handler/service/service_test.go
@@ -296,6 +296,7 @@ func TestService_Create(t *testing.T) {
 		upstreamInput string
 		upstreamRet   interface{}
 		upstreamErr   interface{}
+		nameExistRet  []interface{}
 	}{
 		{
 			caseDesc:  "create success",
@@ -394,6 +395,14 @@ func TestService_Create(t *testing.T) {
 				assert.Equal(t, tc.upstreamInput, id)
 			}).Return(tc.upstreamRet, tc.upstreamErr)
 
+			serviceStore.On("List", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+			}).Return(func(input store.ListInput) *store.ListOutput {
+				return &store.ListOutput{
+					Rows:      tc.nameExistRet,
+					TotalSize: len(tc.nameExistRet),
+				}
+			}, nil)
+
 			h := Handler{serviceStore: serviceStore, upstreamStore: upstreamStore}
 			ctx := droplet.NewContext()
 			ctx.SetInput(tc.giveInput)
@@ -418,6 +427,7 @@ func TestService_Update(t *testing.T) {
 		upstreamInput string
 		upstreamRet   interface{}
 		upstreamErr   interface{}
+		nameExistRet  []interface{}
 	}{
 		{
 			caseDesc:  "create success",
@@ -547,6 +557,14 @@ func TestService_Update(t *testing.T) {
 				id := args.Get(0).(string)
 				assert.Equal(t, tc.upstreamInput, id)
 			}).Return(tc.upstreamRet, tc.upstreamErr)
+
+			serviceStore.On("List", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+			}).Return(func(input store.ListInput) *store.ListOutput {
+				return &store.ListOutput{
+					Rows:      tc.nameExistRet,
+					TotalSize: len(tc.nameExistRet),
+				}
+			}, nil)
 
 			h := Handler{serviceStore: serviceStore, upstreamStore: upstreamStore}
 			ctx := droplet.NewContext()

--- a/api/internal/handler/upstream/upstream_test.go
+++ b/api/internal/handler/upstream/upstream_test.go
@@ -326,14 +326,15 @@ func TestUpstreams_List(t *testing.T) {
 
 func TestUpstream_Create(t *testing.T) {
 	tests := []struct {
-		caseDesc  string
-		getCalled bool
-		giveInput *entity.Upstream
-		giveRet   interface{}
-		giveErr   error
-		wantInput *entity.Upstream
-		wantErr   error
-		wantRet   interface{}
+		caseDesc     string
+		getCalled    bool
+		giveInput    *entity.Upstream
+		giveRet      interface{}
+		giveErr      error
+		wantInput    *entity.Upstream
+		wantErr      error
+		wantRet      interface{}
+		nameExistRet []interface{}
 	}{
 		{
 			caseDesc:  "create success",
@@ -648,6 +649,14 @@ func TestUpstream_Create(t *testing.T) {
 				assert.Equal(t, tc.wantInput, input)
 			}).Return(tc.giveRet, tc.giveErr)
 
+			upstreamStore.On("List", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+			}).Return(func(input store.ListInput) *store.ListOutput {
+				return &store.ListOutput{
+					Rows:      tc.nameExistRet,
+					TotalSize: len(tc.nameExistRet),
+				}
+			}, nil)
+
 			h := Handler{upstreamStore: upstreamStore}
 
 			ctx := droplet.NewContext()
@@ -662,14 +671,15 @@ func TestUpstream_Create(t *testing.T) {
 
 func TestUpstream_Update(t *testing.T) {
 	tests := []struct {
-		caseDesc  string
-		getCalled bool
-		giveInput *UpdateInput
-		giveErr   error
-		giveRet   interface{}
-		wantInput *entity.Upstream
-		wantErr   error
-		wantRet   interface{}
+		caseDesc     string
+		getCalled    bool
+		giveInput    *UpdateInput
+		giveErr      error
+		giveRet      interface{}
+		wantInput    *entity.Upstream
+		wantErr      error
+		wantRet      interface{}
+		nameExistRet []interface{}
 	}{
 		{
 			caseDesc:  "update success",
@@ -936,6 +946,14 @@ func TestUpstream_Update(t *testing.T) {
 				assert.Equal(t, tc.wantInput, input)
 				assert.True(t, createIfNotExist)
 			}).Return(tc.giveRet, tc.giveErr)
+
+			upstreamStore.On("List", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+			}).Return(func(input store.ListInput) *store.ListOutput {
+				return &store.ListOutput{
+					Rows:      tc.nameExistRet,
+					TotalSize: len(tc.nameExistRet),
+				}
+			}, nil)
 
 			h := Handler{upstreamStore: upstreamStore}
 			ctx := droplet.NewContext()

--- a/api/test/e2e/route_export_test.go
+++ b/api/test/e2e/route_export_test.go
@@ -1124,6 +1124,7 @@ func TestRoute_Export(t *testing.T) {
 			Method: http.MethodPut,
 			Path:   "/apisix/admin/upstreams/5",
 			Body: `{
+				"name": "upstream5",
 				"nodes": [
 					{
 						"host": "172.16.238.20",
@@ -2408,7 +2409,7 @@ func TestRoute_Export_Equal_URI(t *testing.T) {
 			Path:   "/apisix/admin/routes/r2",
 			Body: `{
 					"uris": ["/test-test"],
-					"name": "route_all",
+					"name": "route_all2",
 					"desc": "所有1",
 					"methods": ["GET"],
 					"hosts": ["test.com"],
@@ -2431,7 +2432,7 @@ func TestRoute_Export_Equal_URI(t *testing.T) {
 			Path:   "/apisix/admin/routes/r3",
 			Body: `{
 					"uris": ["/test-test"],
-					"name": "route_all",
+					"name": "route_all3",
 					"desc": "所有2",
 					"methods": ["GET"],
 					"hosts": ["test.com"],

--- a/api/test/e2e/route_export_test.go
+++ b/api/test/e2e/route_export_test.go
@@ -2330,7 +2330,7 @@ func TestRoute_Export_Equal_URI(t *testing.T) {
 			},
 			"/test-test-APISIX-REPEAT-URI-2": {
 				"get": {
-					"operationId": "route_allGET",
+					"operationId": "route_all2GET",
 					"requestBody": {},
 					"responses": {
 						"default": {
@@ -2353,7 +2353,7 @@ func TestRoute_Export_Equal_URI(t *testing.T) {
 			},
 			"/test-test-APISIX-REPEAT-URI-3": {
 				"get": {
-					"operationId": "route_allGET",
+					"operationId": "route_all3GET",
 					"requestBody": {},
 					"responses": {
 						"default": {

--- a/api/test/e2e/route_import_test.go
+++ b/api/test/e2e/route_import_test.go
@@ -395,7 +395,7 @@ func TestRoute_export_import(t *testing.T) {
 			Path:   "/apisix/admin/routes/r1",
 			Body: `{
 					"uris": ["/test-test1"],
-					"name": "route_all",
+					"name": "route_all1",
 					"desc": "所有",
 					"methods": ["GET"],
 					"hosts": ["test.com"],
@@ -418,7 +418,7 @@ func TestRoute_export_import(t *testing.T) {
 			Path:   "/apisix/admin/routes/r2",
 			Body: `{
 					"uris": ["/test-test2"],
-					"name": "route_all",
+					"name": "route_all2",
 					"desc": "所有1",
 					"methods": ["GET"],
 					"hosts": ["test.com"],
@@ -441,7 +441,7 @@ func TestRoute_export_import(t *testing.T) {
 			Path:   "/apisix/admin/routes/r3",
 			Body: `{
 					"uris": ["/test-test3"],
-					"name": "route_all",
+					"name": "route_all3",
 					"desc": "所有2",
 					"methods": ["GET"],
 					"hosts": ["test.com"],

--- a/api/test/e2e/route_with_management_fileds_test.go
+++ b/api/test/e2e/route_with_management_fileds_test.go
@@ -279,6 +279,7 @@ func TestRoute_search_by_label(t *testing.T) {
 			Path:   "/apisix/admin/routes/r2",
 			Method: http.MethodPut,
 			Body: `{
+					"name": "route2",
 					"uri": "/hello2",
 					"labels": {
 						"build":"17",

--- a/api/test/e2e/route_with_plugin_http_logger_test.go
+++ b/api/test/e2e/route_with_plugin_http_logger_test.go
@@ -102,6 +102,7 @@ func TestRoute_With_Log_Plugin(t *testing.T) {
 			Method: http.MethodPut,
 			Path:   "/apisix/admin/routes/r2",
 			Body: `{
+				"name": "route2",
 				"uri": "/hello",
 				"plugins": {
 					"http-logger": {

--- a/api/test/e2enew/route/route_test.go
+++ b/api/test/e2enew/route/route_test.go
@@ -116,7 +116,7 @@ var _ = ginkgo.Describe("Route", func() {
 				}
 			}`,
 			Headers:      map[string]string{"Authorization": base.GetToken()},
-			ExpectStatus: http.StatusBadRequest,
+			ExpectStatus: http.StatusOK,
 		}),
 		table.Entry("hit route1", base.HttpTestCase{
 			Object:       base.APISIXExpect(),

--- a/api/test/e2enew/route/route_test.go
+++ b/api/test/e2enew/route/route_test.go
@@ -35,7 +35,7 @@ var _ = ginkgo.Describe("Route", func() {
 			Method: http.MethodPut,
 			Path:   "/apisix/admin/routes/r1",
 			Body: `{
-                                "name": "route1",
+				"name": "route1",
 				"uri": "/hello_",
 				"upstream": {
 					"nodes": {
@@ -52,7 +52,7 @@ var _ = ginkgo.Describe("Route", func() {
 			Method: http.MethodPut,
 			Path:   "/apisix/admin/routes/r2",
 			Body: `{
-                                "name": "route2",
+				"name": "route2",
 				"uri": "/hello_",
 				"upstream": {
 					"nodes": {
@@ -69,7 +69,7 @@ var _ = ginkgo.Describe("Route", func() {
 			Method: http.MethodPost,
 			Path:   "/apisix/admin/routes",
 			Body: `{
-                                "name": "route2",
+				"name": "route2",
 				"uri": "/hello_",
 				"upstream": {
 					"nodes": {
@@ -80,7 +80,7 @@ var _ = ginkgo.Describe("Route", func() {
 			}`,
 			Headers:      map[string]string{"Authorization": base.GetToken()},
 			ExpectStatus: http.StatusBadRequest,
-			ExpectBody:   `route name is existed`,
+			ExpectBody:   `route name exists`,
 			Sleep:        base.SleepTime,
 		}),
 		table.Entry("update route2 failed, name existed", base.HttpTestCase{
@@ -88,7 +88,7 @@ var _ = ginkgo.Describe("Route", func() {
 			Method: http.MethodPut,
 			Path:   "/apisix/admin/routes/r2",
 			Body: `{
-                                "name": "route1",
+				"name": "route1",
 				"uri": "/hello_",
 				"upstream": {
 					"nodes": {
@@ -99,14 +99,14 @@ var _ = ginkgo.Describe("Route", func() {
 			}`,
 			Headers:      map[string]string{"Authorization": base.GetToken()},
 			ExpectStatus: http.StatusBadRequest,
-			ExpectBody:   `route name is existed`,
+			ExpectBody:   `route name exists`,
 		}),
 		table.Entry("update route2 success, name not change", base.HttpTestCase{
 			Object: base.ManagerApiExpect(),
 			Method: http.MethodPut,
 			Path:   "/apisix/admin/routes/r2",
 			Body: `{
-                                "name": "route2",
+				"name": "route2",
 				"uri": "/hello",
 				"upstream": {
 					"nodes": {

--- a/api/test/e2enew/route/route_test.go
+++ b/api/test/e2enew/route/route_test.go
@@ -129,7 +129,7 @@ var _ = ginkgo.Describe("Route", func() {
 		table.Entry("hit route2", base.HttpTestCase{
 			Object:       base.APISIXExpect(),
 			Method:       http.MethodGet,
-			Path:         "/hello_",
+			Path:         "/hello",
 			ExpectStatus: http.StatusOK,
 			ExpectBody:   "hello world",
 		}),
@@ -146,6 +146,22 @@ var _ = ginkgo.Describe("Route", func() {
 			Path:         "/apisix/admin/routes/r2",
 			Headers:      map[string]string{"Authorization": base.GetToken()},
 			ExpectStatus: http.StatusOK,
+		}),
+		table.Entry("hit route1 that just deleted", base.HttpTestCase{
+			Object:       base.APISIXExpect(),
+			Method:       http.MethodGet,
+			Path:         "/hello_",
+			ExpectStatus: http.StatusNotFound,
+			ExpectBody:   "{\"error_msg\":\"404 Route Not Found\"}",
+			Sleep:        base.SleepTime,
+		}),
+		table.Entry("hit route2 that just deleted", base.HttpTestCase{
+			Object:       base.APISIXExpect(),
+			Method:       http.MethodGet,
+			Path:         "/hello",
+			ExpectStatus: http.StatusNotFound,
+			ExpectBody:   "{\"error_msg\":\"404 Route Not Found\"}",
+			Sleep:        base.SleepTime,
 		}),
 	)
 })

--- a/api/test/e2enew/route/route_test.go
+++ b/api/test/e2enew/route/route_test.go
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package route
+
+import (
+	"net/http"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+
+	"github.com/apisix/manager-api/test/e2enew/base"
+)
+
+var _ = ginkgo.Describe("Route", func() {
+	table.DescribeTable("test route create and update",
+		func(tc base.HttpTestCase) {
+			base.RunTestCase(tc)
+		},
+		table.Entry("create route1 success", base.HttpTestCase{
+			Object: base.ManagerApiExpect(),
+			Method: http.MethodPut,
+			Path:   "/apisix/admin/routes/r1",
+			Body: `{
+                                "name": "route1",
+				"uri": "/hello_",
+				"upstream": {
+					"nodes": {
+						"` + base.UpstreamIp + `:1980": 1
+					},
+					"type": "roundrobin"
+				}
+			}`,
+			Headers:      map[string]string{"Authorization": base.GetToken()},
+			ExpectStatus: http.StatusOK,
+		}),
+		table.Entry("create route2 success", base.HttpTestCase{
+			Object: base.ManagerApiExpect(),
+			Method: http.MethodPut,
+			Path:   "/apisix/admin/routes/r2",
+			Body: `{
+                                "name": "route2",
+				"uri": "/hello_",
+				"upstream": {
+					"nodes": {
+						"` + base.UpstreamIp + `:1980": 1
+					},
+					"type": "roundrobin"
+				}
+			}`,
+			Headers:      map[string]string{"Authorization": base.GetToken()},
+			ExpectStatus: http.StatusOK,
+		}),
+		table.Entry("create route failed, name existed", base.HttpTestCase{
+			Object: base.ManagerApiExpect(),
+			Method: http.MethodPost,
+			Path:   "/apisix/admin/routes",
+			Body: `{
+                                "name": "route2",
+				"uri": "/hello_",
+				"upstream": {
+					"nodes": {
+						"` + base.UpstreamIp + `:1980": 1
+					},
+					"type": "roundrobin"
+				}
+			}`,
+			Headers:      map[string]string{"Authorization": base.GetToken()},
+			ExpectStatus: http.StatusBadRequest,
+			ExpectBody:   `route name is existed`,
+			Sleep:        base.SleepTime,
+		}),
+		table.Entry("update route2 failed, name existed", base.HttpTestCase{
+			Object: base.ManagerApiExpect(),
+			Method: http.MethodPut,
+			Path:   "/apisix/admin/routes/r2",
+			Body: `{
+                                "name": "route1",
+				"uri": "/hello_",
+				"upstream": {
+					"nodes": {
+						"` + base.UpstreamIp + `:1980": 1
+					},
+					"type": "roundrobin"
+				}
+			}`,
+			Headers:      map[string]string{"Authorization": base.GetToken()},
+			ExpectStatus: http.StatusBadRequest,
+			ExpectBody:   `route name is existed`,
+		}),
+		table.Entry("update route2 success, name not change", base.HttpTestCase{
+			Object: base.ManagerApiExpect(),
+			Method: http.MethodPut,
+			Path:   "/apisix/admin/routes/r2",
+			Body: `{
+                                "name": "route2",
+				"uri": "/hello",
+				"upstream": {
+					"nodes": {
+						"` + base.UpstreamIp + `:1980": 1
+					},
+					"type": "roundrobin"
+				}
+			}`,
+			Headers:      map[string]string{"Authorization": base.GetToken()},
+			ExpectStatus: http.StatusBadRequest,
+		}),
+		table.Entry("hit route1", base.HttpTestCase{
+			Object:       base.APISIXExpect(),
+			Method:       http.MethodGet,
+			Path:         "/hello_",
+			ExpectStatus: http.StatusOK,
+			ExpectBody:   "hello world",
+			Sleep:        base.SleepTime,
+		}),
+		table.Entry("hit route2", base.HttpTestCase{
+			Object:       base.APISIXExpect(),
+			Method:       http.MethodGet,
+			Path:         "/hello_",
+			ExpectStatus: http.StatusOK,
+			ExpectBody:   "hello world",
+		}),
+		table.Entry("delete route1", base.HttpTestCase{
+			Object:       base.ManagerApiExpect(),
+			Method:       http.MethodDelete,
+			Path:         "/apisix/admin/routes/r1",
+			Headers:      map[string]string{"Authorization": base.GetToken()},
+			ExpectStatus: http.StatusOK,
+		}),
+		table.Entry("delete route2", base.HttpTestCase{
+			Object:       base.ManagerApiExpect(),
+			Method:       http.MethodDelete,
+			Path:         "/apisix/admin/routes/r2",
+			Headers:      map[string]string{"Authorization": base.GetToken()},
+			ExpectStatus: http.StatusOK,
+		}),
+	)
+})

--- a/api/test/e2enew/route/route_with_priority_test.go
+++ b/api/test/e2enew/route/route_with_priority_test.go
@@ -60,6 +60,7 @@ var _ = ginkgo.Describe("route with priority test", func() {
 			Method: http.MethodPut,
 			Path:   "/apisix/admin/routes/r2",
 			Body: `{
+					"name": "route2",
 					"uri": "/server_port",
 					"methods": ["GET"],
 					"priority": 1,

--- a/api/test/e2enew/service/service_test.go
+++ b/api/test/e2enew/service/service_test.go
@@ -92,7 +92,7 @@ var _ = ginkgo.Describe("create service without plugin", func() {
 			Headers:      map[string]string{"Authorization": base.GetToken()},
 			Body:         string(_createServiceBody),
 			ExpectStatus: http.StatusBadRequest,
-			ExpectBody:   `service name is existed`,
+			ExpectBody:   `service name exists`,
 			Sleep:        base.SleepTime,
 		})
 	})
@@ -108,7 +108,7 @@ var _ = ginkgo.Describe("create service without plugin", func() {
 			Headers:      map[string]string{"Authorization": base.GetToken()},
 			Body:         string(_createServiceBody),
 			ExpectStatus: http.StatusBadRequest,
-			ExpectBody:   `service name is existed`,
+			ExpectBody:   `service name exists`,
 		})
 	})
 	ginkgo.It("get the service s1", func() {

--- a/api/test/e2enew/service/service_test.go
+++ b/api/test/e2enew/service/service_test.go
@@ -28,31 +28,92 @@ import (
 )
 
 var _ = ginkgo.Describe("create service without plugin", func() {
-	ginkgo.It("create service without plugin", func() {
-		t := ginkgo.GinkgoT()
-		var createServiceBody map[string]interface{} = map[string]interface{}{
-			"name": "testservice",
-			"upstream": map[string]interface{}{
-				"type": "roundrobin",
-				"nodes": []map[string]interface{}{
-					{
-						"host":   base.UpstreamIp,
-						"port":   1980,
-						"weight": 1,
-					},
-					{
-						"host":   base.UpstreamIp,
-						"port":   1981,
-						"weight": 2,
-					},
-					{
-						"host":   base.UpstreamIp,
-						"port":   1982,
-						"weight": 3,
-					},
+	var createServiceBody map[string]interface{} = map[string]interface{}{
+		"name": "testservice",
+		"upstream": map[string]interface{}{
+			"type": "roundrobin",
+			"nodes": []map[string]interface{}{
+				{
+					"host":   base.UpstreamIp,
+					"port":   1980,
+					"weight": 1,
+				},
+				{
+					"host":   base.UpstreamIp,
+					"port":   1981,
+					"weight": 2,
+				},
+				{
+					"host":   base.UpstreamIp,
+					"port":   1982,
+					"weight": 3,
 				},
 			},
-		}
+		},
+	}
+
+	ginkgo.It("create service without plugin", func() {
+		t := ginkgo.GinkgoT()
+		_createServiceBody, err := json.Marshal(createServiceBody)
+		assert.Nil(t, err)
+		base.RunTestCase(base.HttpTestCase{
+			Object:       base.ManagerApiExpect(),
+			Method:       http.MethodPut,
+			Path:         "/apisix/admin/services/s1",
+			Headers:      map[string]string{"Authorization": base.GetToken()},
+			Body:         string(_createServiceBody),
+			ExpectStatus: http.StatusOK,
+			ExpectBody:   []string{"\"id\":\"s1\"", "\"name\":\"testservice\""},
+		})
+	})
+	ginkgo.It("create service2 success", func() {
+		t := ginkgo.GinkgoT()
+		createServiceBody["name"] = "testservice2"
+		_createServiceBody, err := json.Marshal(createServiceBody)
+		assert.Nil(t, err)
+		base.RunTestCase(base.HttpTestCase{
+			Object:       base.ManagerApiExpect(),
+			Method:       http.MethodPut,
+			Path:         "/apisix/admin/services/s2",
+			Headers:      map[string]string{"Authorization": base.GetToken()},
+			Body:         string(_createServiceBody),
+			ExpectStatus: http.StatusOK,
+			ExpectBody:   []string{"\"id\":\"s1\"", "\"name\":\"testservice\""},
+		})
+	})
+	ginkgo.It("create service2 success", func() {
+		t := ginkgo.GinkgoT()
+		createServiceBody["name"] = "testservice2"
+		_createServiceBody, err := json.Marshal(createServiceBody)
+		assert.Nil(t, err)
+		base.RunTestCase(base.HttpTestCase{
+			Object:       base.ManagerApiExpect(),
+			Method:       http.MethodPut,
+			Path:         "/apisix/admin/services/s2",
+			Headers:      map[string]string{"Authorization": base.GetToken()},
+			Body:         string(_createServiceBody),
+			ExpectStatus: http.StatusOK,
+			ExpectBody:   []string{"\"id\":\"s1\"", "\"name\":\"testservice\""},
+		})
+	})
+	ginkgo.It("create service failed, name existed", func() {
+		t := ginkgo.GinkgoT()
+		createServiceBody["name"] = "testservice2"
+		_createServiceBody, err := json.Marshal(createServiceBody)
+		assert.Nil(t, err)
+		base.RunTestCase(base.HttpTestCase{
+			Object:       base.ManagerApiExpect(),
+			Method:       http.MethodPost,
+			Path:         "/apisix/admin/services",
+			Headers:      map[string]string{"Authorization": base.GetToken()},
+			Body:         string(_createServiceBody),
+			ExpectStatus: http.StatusBadRequest,
+			ExpectBody:   `service name is existed`,
+			Sleep: base.SleepTime,
+		})
+	})
+	ginkgo.It("create service without plugin", func() {
+		t := ginkgo.GinkgoT()
 		_createServiceBody, err := json.Marshal(createServiceBody)
 		assert.Nil(t, err)
 		base.RunTestCase(base.HttpTestCase{

--- a/api/test/e2enew/service/service_test.go
+++ b/api/test/e2enew/service/service_test.go
@@ -51,7 +51,6 @@ var _ = ginkgo.Describe("create service without plugin", func() {
 			},
 		},
 	}
-
 	ginkgo.It("create service without plugin", func() {
 		t := ginkgo.GinkgoT()
 		_createServiceBody, err := json.Marshal(createServiceBody)
@@ -159,6 +158,16 @@ var _ = ginkgo.Describe("create service without plugin", func() {
 			Object:       base.ManagerApiExpect(),
 			Method:       http.MethodDelete,
 			Path:         "/apisix/admin/services/s1",
+			Headers:      map[string]string{"Authorization": base.GetToken()},
+			ExpectStatus: http.StatusOK,
+			Sleep:        base.SleepTime,
+		})
+	})
+	ginkgo.It("delete service2", func() {
+		base.RunTestCase(base.HttpTestCase{
+			Object:       base.ManagerApiExpect(),
+			Method:       http.MethodDelete,
+			Path:         "/apisix/admin/services/s2",
 			Headers:      map[string]string{"Authorization": base.GetToken()},
 			ExpectStatus: http.StatusOK,
 			Sleep:        base.SleepTime,

--- a/api/test/e2enew/service/service_test.go
+++ b/api/test/e2enew/service/service_test.go
@@ -78,22 +78,7 @@ var _ = ginkgo.Describe("create service without plugin", func() {
 			Headers:      map[string]string{"Authorization": base.GetToken()},
 			Body:         string(_createServiceBody),
 			ExpectStatus: http.StatusOK,
-			ExpectBody:   []string{"\"id\":\"s1\"", "\"name\":\"testservice\""},
-		})
-	})
-	ginkgo.It("create service2 success", func() {
-		t := ginkgo.GinkgoT()
-		createServiceBody["name"] = "testservice2"
-		_createServiceBody, err := json.Marshal(createServiceBody)
-		assert.Nil(t, err)
-		base.RunTestCase(base.HttpTestCase{
-			Object:       base.ManagerApiExpect(),
-			Method:       http.MethodPut,
-			Path:         "/apisix/admin/services/s2",
-			Headers:      map[string]string{"Authorization": base.GetToken()},
-			Body:         string(_createServiceBody),
-			ExpectStatus: http.StatusOK,
-			ExpectBody:   []string{"\"id\":\"s1\"", "\"name\":\"testservice\""},
+			ExpectBody:   []string{"\"id\":\"s2\"", "\"name\":\"testservice2\""},
 		})
 	})
 	ginkgo.It("create service failed, name existed", func() {
@@ -302,7 +287,7 @@ var _ = ginkgo.Describe("create service with all options via POST method", func(
 		t := ginkgo.GinkgoT()
 		var createServiceBody map[string]interface{} = map[string]interface{}{
 			"id":   "s2",
-			"name": "testservice",
+			"name": "testservice22",
 			"desc": "testservice_desc",
 			"labels": map[string]interface{}{
 				"build":   "16",
@@ -351,7 +336,7 @@ var _ = ginkgo.Describe("create service with all options via POST method", func(
 			Path:       "/apisix/admin/services/s2",
 			Headers:    map[string]string{"Authorization": base.GetToken()},
 			ExpectCode: http.StatusOK,
-			ExpectBody: "\"name\":\"testservice\",\"desc\":\"testservice_desc\",\"upstream\":{\"nodes\":[{\"host\":\"" + base.UpstreamIp + "\",\"port\":1980,\"weight\":1}],\"type\":\"roundrobin\"},\"plugins\":{\"limit-count\":{\"count\":100,\"key\":\"remote_addr\",\"rejected_code\":503,\"time_window\":60}},\"labels\":{\"build\":\"16\",\"env\":\"production\",\"version\":\"v2\"},\"enable_websocket\":true}",
+			ExpectBody: "\"name\":\"testservice22\",\"desc\":\"testservice_desc\",\"upstream\":{\"nodes\":[{\"host\":\"" + base.UpstreamIp + "\",\"port\":1980,\"weight\":1}],\"type\":\"roundrobin\"},\"plugins\":{\"limit-count\":{\"count\":100,\"key\":\"remote_addr\",\"rejected_code\":503,\"time_window\":60}},\"labels\":{\"build\":\"16\",\"env\":\"production\",\"version\":\"v2\"},\"enable_websocket\":true}",
 			Sleep:      base.SleepTime,
 		})
 	})

--- a/api/test/e2enew/service/service_test.go
+++ b/api/test/e2enew/service/service_test.go
@@ -109,11 +109,12 @@ var _ = ginkgo.Describe("create service without plugin", func() {
 			Body:         string(_createServiceBody),
 			ExpectStatus: http.StatusBadRequest,
 			ExpectBody:   `service name is existed`,
-			Sleep: base.SleepTime,
+			Sleep:        base.SleepTime,
 		})
 	})
-	ginkgo.It("create service without plugin", func() {
+	ginkgo.It("update service failed, name existed", func() {
 		t := ginkgo.GinkgoT()
+		createServiceBody["name"] = "testservice2"
 		_createServiceBody, err := json.Marshal(createServiceBody)
 		assert.Nil(t, err)
 		base.RunTestCase(base.HttpTestCase{
@@ -122,8 +123,8 @@ var _ = ginkgo.Describe("create service without plugin", func() {
 			Path:         "/apisix/admin/services/s1",
 			Headers:      map[string]string{"Authorization": base.GetToken()},
 			Body:         string(_createServiceBody),
-			ExpectStatus: http.StatusOK,
-			ExpectBody:   []string{"\"id\":\"s1\"", "\"name\":\"testservice\""},
+			ExpectStatus: http.StatusBadRequest,
+			ExpectBody:   `service name is existed`,
 		})
 	})
 	ginkgo.It("get the service s1", func() {

--- a/api/test/e2enew/upstream/upstream_test.go
+++ b/api/test/e2enew/upstream/upstream_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 var _ = ginkgo.Describe("Upstream", func() {
-	ginkgo.It("test upstream create failed", func() {
+	ginkgo.It("create route failed, using non-existent upstream_id", func() {
 		base.RunTestCase(base.HttpTestCase{
 			Object: base.ManagerApiExpect(),
 			Method: http.MethodPut,
@@ -42,11 +42,103 @@ var _ = ginkgo.Describe("Upstream", func() {
 			ExpectStatus: http.StatusBadRequest,
 		})
 	})
-
 	ginkgo.It("create upstream success", func() {
 		t := ginkgo.GinkgoT()
 		createUpstreamBody := make(map[string]interface{})
 		createUpstreamBody["name"] = "upstream1"
+		createUpstreamBody["nodes"] = []map[string]interface{}{
+			{
+				"host":   base.UpstreamIp,
+				"port":   1980,
+				"weight": 1,
+			},
+		}
+		createUpstreamBody["type"] = "roundrobin"
+		_createUpstreamBody, err := json.Marshal(createUpstreamBody)
+		assert.Nil(t, err)
+		base.RunTestCase(base.HttpTestCase{
+			Object:       base.ManagerApiExpect(),
+			Method:       http.MethodPut,
+			Path:         "/apisix/admin/upstreams/1",
+			Body:         string(_createUpstreamBody),
+			Headers:      map[string]string{"Authorization": base.GetToken()},
+			ExpectStatus: http.StatusOK,
+		})
+	})
+	ginkgo.It("create upstream2 success", func() {
+		t := ginkgo.GinkgoT()
+		createUpstreamBody := make(map[string]interface{})
+		createUpstreamBody["name"] = "upstream2"
+		createUpstreamBody["nodes"] = []map[string]interface{}{
+			{
+				"host":   base.UpstreamIp,
+				"port":   1980,
+				"weight": 1,
+			},
+		}
+		createUpstreamBody["type"] = "roundrobin"
+		_createUpstreamBody, err := json.Marshal(createUpstreamBody)
+		assert.Nil(t, err)
+		base.RunTestCase(base.HttpTestCase{
+			Object:       base.ManagerApiExpect(),
+			Method:       http.MethodPut,
+			Path:         "/apisix/admin/upstreams/2",
+			Body:         string(_createUpstreamBody),
+			Headers:      map[string]string{"Authorization": base.GetToken()},
+			ExpectStatus: http.StatusOK,
+		})
+	})
+	ginkgo.It("create upstream failed, name existed", func() {
+		t := ginkgo.GinkgoT()
+		createUpstreamBody := make(map[string]interface{})
+		createUpstreamBody["name"] = "upstream1"
+		createUpstreamBody["nodes"] = []map[string]interface{}{
+			{
+				"host":   base.UpstreamIp,
+				"port":   1980,
+				"weight": 1,
+			},
+		}
+		createUpstreamBody["type"] = "roundrobin"
+		_createUpstreamBody, err := json.Marshal(createUpstreamBody)
+		assert.Nil(t, err)
+		base.RunTestCase(base.HttpTestCase{
+			Object:       base.ManagerApiExpect(),
+			Method:       http.MethodPost,
+			Path:         "/apisix/admin/upstreams",
+			Body:         string(_createUpstreamBody),
+			Headers:      map[string]string{"Authorization": base.GetToken()},
+			ExpectStatus: http.StatusBadRequest,
+			Sleep:        base.SleepTime,
+		})
+	})
+	ginkgo.It("update upstream failed, name existed", func() {
+		t := ginkgo.GinkgoT()
+		createUpstreamBody := make(map[string]interface{})
+		createUpstreamBody["name"] = "upstream2"
+		createUpstreamBody["nodes"] = []map[string]interface{}{
+			{
+				"host":   base.UpstreamIp,
+				"port":   1980,
+				"weight": 1,
+			},
+		}
+		createUpstreamBody["type"] = "roundrobin"
+		_createUpstreamBody, err := json.Marshal(createUpstreamBody)
+		assert.Nil(t, err)
+		base.RunTestCase(base.HttpTestCase{
+			Object:       base.ManagerApiExpect(),
+			Method:       http.MethodPut,
+			Path:         "/apisix/admin/upstreams/1",
+			Body:         string(_createUpstreamBody),
+			Headers:      map[string]string{"Authorization": base.GetToken()},
+			ExpectStatus: http.StatusBadRequest,
+		})
+	})
+	ginkgo.It("update upstream success", func() {
+		t := ginkgo.GinkgoT()
+		createUpstreamBody := make(map[string]interface{})
+		createUpstreamBody["name"] = "upstream11"
 		createUpstreamBody["nodes"] = []map[string]interface{}{
 			{
 				"host":   base.UpstreamIp,
@@ -147,6 +239,15 @@ var _ = ginkgo.Describe("Upstream", func() {
 			Object:       base.ManagerApiExpect(),
 			Method:       http.MethodDelete,
 			Path:         "/apisix/admin/upstreams/1",
+			Headers:      map[string]string{"Authorization": base.GetToken()},
+			ExpectStatus: http.StatusOK,
+		})
+	})
+	ginkgo.It("delete upstream2", func() {
+		base.RunTestCase(base.HttpTestCase{
+			Object:       base.ManagerApiExpect(),
+			Method:       http.MethodDelete,
+			Path:         "/apisix/admin/upstreams/2",
 			Headers:      map[string]string{"Authorization": base.GetToken()},
 			ExpectStatus: http.StatusOK,
 		})

--- a/api/test/e2enew/upstream/upstream_test.go
+++ b/api/test/e2enew/upstream/upstream_test.go
@@ -109,7 +109,7 @@ var _ = ginkgo.Describe("Upstream", func() {
 			Body:         string(_createUpstreamBody),
 			Headers:      map[string]string{"Authorization": base.GetToken()},
 			ExpectStatus: http.StatusBadRequest,
-			ExpectBody:   `upstream name is existed`,
+			ExpectBody:   `upstream name exists`,
 			Sleep:        base.SleepTime,
 		})
 	})
@@ -134,7 +134,7 @@ var _ = ginkgo.Describe("Upstream", func() {
 			Body:         string(_createUpstreamBody),
 			Headers:      map[string]string{"Authorization": base.GetToken()},
 			ExpectStatus: http.StatusBadRequest,
-			ExpectBody:   `upstream name is existed`,
+			ExpectBody:   `upstream name exists`,
 		})
 	})
 	ginkgo.It("update upstream success", func() {

--- a/api/test/e2enew/upstream/upstream_test.go
+++ b/api/test/e2enew/upstream/upstream_test.go
@@ -91,7 +91,7 @@ var _ = ginkgo.Describe("Upstream", func() {
 	ginkgo.It("create upstream failed, name existed", func() {
 		t := ginkgo.GinkgoT()
 		createUpstreamBody := make(map[string]interface{})
-		createUpstreamBody["name"] = "upstream1"
+		createUpstreamBody["name"] = "upstream2"
 		createUpstreamBody["nodes"] = []map[string]interface{}{
 			{
 				"host":   base.UpstreamIp,
@@ -116,7 +116,7 @@ var _ = ginkgo.Describe("Upstream", func() {
 	ginkgo.It("update upstream failed, name existed", func() {
 		t := ginkgo.GinkgoT()
 		createUpstreamBody := make(map[string]interface{})
-		createUpstreamBody["name"] = "upstream2"
+		createUpstreamBody["name"] = "upstream1"
 		createUpstreamBody["nodes"] = []map[string]interface{}{
 			{
 				"host":   base.UpstreamIp,
@@ -130,7 +130,7 @@ var _ = ginkgo.Describe("Upstream", func() {
 		base.RunTestCase(base.HttpTestCase{
 			Object:       base.ManagerApiExpect(),
 			Method:       http.MethodPut,
-			Path:         "/apisix/admin/upstreams/1",
+			Path:         "/apisix/admin/upstreams/2",
 			Body:         string(_createUpstreamBody),
 			Headers:      map[string]string{"Authorization": base.GetToken()},
 			ExpectStatus: http.StatusBadRequest,
@@ -140,7 +140,7 @@ var _ = ginkgo.Describe("Upstream", func() {
 	ginkgo.It("update upstream success", func() {
 		t := ginkgo.GinkgoT()
 		createUpstreamBody := make(map[string]interface{})
-		createUpstreamBody["name"] = "upstream11"
+		createUpstreamBody["name"] = "upstream22"
 		createUpstreamBody["nodes"] = []map[string]interface{}{
 			{
 				"host":   base.UpstreamIp,
@@ -154,7 +154,7 @@ var _ = ginkgo.Describe("Upstream", func() {
 		base.RunTestCase(base.HttpTestCase{
 			Object:       base.ManagerApiExpect(),
 			Method:       http.MethodPut,
-			Path:         "/apisix/admin/upstreams/1",
+			Path:         "/apisix/admin/upstreams/2",
 			Body:         string(_createUpstreamBody),
 			Headers:      map[string]string{"Authorization": base.GetToken()},
 			ExpectStatus: http.StatusOK,

--- a/api/test/e2enew/upstream/upstream_test.go
+++ b/api/test/e2enew/upstream/upstream_test.go
@@ -109,6 +109,7 @@ var _ = ginkgo.Describe("Upstream", func() {
 			Body:         string(_createUpstreamBody),
 			Headers:      map[string]string{"Authorization": base.GetToken()},
 			ExpectStatus: http.StatusBadRequest,
+			ExpectBody:   `upstream name is existed`,
 			Sleep:        base.SleepTime,
 		})
 	})
@@ -133,6 +134,7 @@ var _ = ginkgo.Describe("Upstream", func() {
 			Body:         string(_createUpstreamBody),
 			Headers:      map[string]string{"Authorization": base.GetToken()},
 			ExpectStatus: http.StatusBadRequest,
+			ExpectBody:   `upstream name is existed`,
 		})
 	})
 	ginkgo.It("update upstream success", func() {


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

- Related issues

#1595

___
### Bugfix
- Description

When creating route, server and upstream in the Dashboard, the FE queries whether the same name exists through API, and does not run the addition if it exists. But the backend lacks this limitation.


- How to fix?

Add a judgment on whether the name exists in the backend, if it exists, it is not allowed to create or update.

