### PR TITLE
feat: manual deletion of apisix node data

### DIFF
--- a/api/test/e2e/server_info_delete_test.go
+++ b/api/test/e2e/server_info_delete_test.go
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package e2e
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestServerInfo_delete_node_data(t *testing.T) {
+	tests := []HttpTestCase{
+		{
+			Desc:          "delete node data for apisix-server1",
+			Object:        ManagerApiExpect(t),
+			Method:        http.MethodDelete,
+			Path:          "/apisix/admin/server_info/apisix-server1",
+			Headers:       map[string]string{"Authorization": token},
+			ExpectStatus:  http.StatusOK,
+			ExpectCode:    0,
+			ExpectMessage: "Successful",
+		},
+		{
+			Desc:         "Re requesting deleting node data for apisix-server1",
+			Object:       ManagerApiExpect(t),
+			Method:       http.MethodDelete,
+			Path:         "/apisix/admin/server_info/apisix-server1",
+			Headers:      map[string]string{"Authorization": token},
+			ExpectStatus: http.StatusNotFound,
+		},
+		{
+			Desc:         "deleting arbitrary random node data",
+			Object:       ManagerApiExpect(t),
+			Method:       http.MethodDelete,
+			Path:         "/apisix/admin/server_info/apisix-server3",
+			Headers:      map[string]string{"Authorization": token},
+			ExpectStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tc := range tests {
+		testCaseCheck(tc, t)
+	}
+}


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [ ] Bugfix
- [x] New feature provided
- [ ] Improve performance
- [ ] Backport patches

- Related issues
 #1482 
___
### New feature or improvement
Manual deletion of apisix node data. Exposing a route for deleting node data.

List nodes
![Screenshot from 2021-03-18 11-57-25](https://user-images.githubusercontent.com/41498427/111586708-3fa67200-87e7-11eb-85dd-ca62e86a8797.png)
Delete
![image](https://user-images.githubusercontent.com/41498427/111587057-b2175200-87e7-11eb-942d-aac69265142d.png)
List nodes for checking
![Screenshot from 2021-03-18 11-57-51](https://user-images.githubusercontent.com/41498427/111586723-4503bc80-87e7-11eb-9d69-0175061b34ea.png)

___
### Please add the corresponding test cases if necessary.
- [x] ~To be added~
