### PR TITLE
fix: (route_online_debug)Change the appended Content-type data to overlay to ensure that the Content-type is unique

### DIFF
--- a/api/internal/handler/route_online_debug/route_online_debug.go
+++ b/api/internal/handler/route_online_debug/route_online_debug.go
@@ -118,7 +118,11 @@ func (h *HTTPProtocolSupport) RequestForwarding(c droplet.Context) (interface{},
 	req.Header.Add("Content-Type", contentType)
 	for k, v := range tempMap {
 		for _, v1 := range v {
-			req.Header.Add(k, v1)
+			if !strings.EqualFold(k, "Content-Type") {
+				req.Header.Add(k, v1)
+			} else {
+				req.Header.Set(k, v1)
+			}
 		}
 	}
 

--- a/web/cypress/integration/consumer/create_and_delete_consumer.spec.js
+++ b/web/cypress/integration/consumer/create_and_delete_consumer.spec.js
@@ -36,11 +36,11 @@ context('Create and Delete Consumer', () => {
 
     // plugin config
     cy.contains(this.domSelector.pluginCard, 'key-auth').within(() => {
-      cy.get('button').click({
-        force: true
+      cy.contains('Enable').click({
+        force: true,
       });
     });
-
+    cy.focused(this.domSelector.drawer).should('exist');
     cy.get(this.domSelector.disabledSwitcher).click();
     // edit codemirror
     cy.get(this.domSelector.codeMirror)
@@ -68,7 +68,7 @@ context('Create and Delete Consumer', () => {
     cy.get(this.domSelector.drawer).should('be.visible');
 
     cy.get(this.domSelector.codemirrorScroll).within(() => {
-      cy.contains('plugins').should("exist");
+      cy.contains('plugins').should('exist');
       cy.contains(this.data.consumerName).should('exist');
     });
   });
@@ -94,7 +94,7 @@ context('Create and Delete Consumer', () => {
     // plugin config
     cy.contains(this.domSelector.pluginCard, 'key-auth').within(() => {
       cy.get('button').click({
-        force: true
+        force: true,
       });
     });
     // edit codeMirror

--- a/web/cypress/integration/route/search-route.spec.js
+++ b/web/cypress/integration/route/search-route.spec.js
@@ -101,9 +101,7 @@ context('Create and Search Route', () => {
     // search one label
     cy.contains(data.test0).should('exist');
     cy.get(this.domSelector.labelSelect_0).click({ timeout });
-    cy.get(this.domSelector.dropdown).should('be.visible').within(() => {
-      cy.contains(data.value0).click();
-    });
+    cy.get(this.domSelector.dropdown).contains(data.value0).should('be.visible').click();
     cy.contains('Search').click();
     cy.contains(data.test0).siblings().should('contain', data.label0_value0);
     cy.contains(data.test1).should('not.exist');


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

- Related issues

___
### Bugfix
- Description
There is a bug in the use process. The user writes the `Content-type` to the `header-params` to forward the content type of the URL. The old logic uses the `req.Header.Add` method to generate multiple `Content-type` values, which leads to the failure of the forwarding request.

- How to fix?
use `req.Header.Set` To override the ·Content-type· and ensure that the value is unique。
