### PR TITLE
fix: use APISIX 2.4 to run backend E2E test

### DIFF
--- a/api/test/docker/docker-compose.yaml
+++ b/api/test/docker/docker-compose.yaml
@@ -131,7 +131,7 @@ services:
       context: ../../
       dockerfile: test/docker/Dockerfile-apisix
       args:
-        - APISIX_VERSION=master
+        - APISIX_VERSION=v2.4
     restart: always
     volumes:
       - ./apisix_config.yaml:/usr/local/apisix/conf/config.yaml:ro
@@ -156,7 +156,7 @@ services:
       context: ../../
       dockerfile: test/docker/Dockerfile-apisix
       args:
-        - APISIX_VERSION=master
+        - APISIX_VERSION=v2.4
     restart: always
     volumes:
       - ./apisix_config2.yaml:/usr/local/apisix/conf/config.yaml:ro

--- a/api/test/docker/docker-compose.yaml
+++ b/api/test/docker/docker-compose.yaml
@@ -131,7 +131,7 @@ services:
       context: ../../
       dockerfile: test/docker/Dockerfile-apisix
       args:
-        - APISIX_VERSION=v2.4
+        - APISIX_VERSION=2.4
     restart: always
     volumes:
       - ./apisix_config.yaml:/usr/local/apisix/conf/config.yaml:ro
@@ -156,7 +156,7 @@ services:
       context: ../../
       dockerfile: test/docker/Dockerfile-apisix
       args:
-        - APISIX_VERSION=v2.4
+        - APISIX_VERSION=2.4
     restart: always
     volumes:
       - ./apisix_config2.yaml:/usr/local/apisix/conf/config.yaml:ro


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches


___
### Bugfix
- Description

APISIX has remove consumer.id, see:
https://github.com/apache/apisix/pull/3868

This is an incompatible modification, causing some of the current E2E test cases to fail

- How to fix?

use APISIX 2.4 to run backend E2E test
