### PR TITLE
fix: ETCD container registry

### DIFF
--- a/api/test/docker-deploy/docker-compose.yaml
+++ b/api/test/docker-deploy/docker-compose.yaml
@@ -18,7 +18,7 @@ version: "3.6"
 
 services:
   etcd:
-    image: quay.io/coreos/etcd:v3.4.0
+    image: gcr.io/etcd-development/etcd:v3.4.0
     ports:
       - "2379:2379"
     expose:

--- a/api/test/docker/docker-compose.yaml
+++ b/api/test/docker/docker-compose.yaml
@@ -18,7 +18,7 @@ version: "3.6"
 
 services:
   node1:
-    image: quay.io/coreos/etcd:v3.4.0
+    image: gcr.io/etcd-development/etcd:v3.4.0
     ports:
       - "2379:2379"
     expose:
@@ -50,7 +50,7 @@ services:
       - docker-etcd
 
   node2:
-    image: quay.io/coreos/etcd:v3.4.0
+    image: gcr.io/etcd-development/etcd:v3.4.0
     networks:
       apisix_dashboard_e2e:
         ipv4_address: 172.16.238.11
@@ -80,7 +80,7 @@ services:
       - docker-etcd
 
   node3:
-    image: quay.io/coreos/etcd:v3.4.0
+    image: gcr.io/etcd-development/etcd:v3.4.0
     networks:
       apisix_dashboard_e2e:
         ipv4_address: 172.16.238.12


### PR DESCRIPTION
Please answer these questions before submitting a pull request, **or your PR will get closed**.

**Why submit this pull request?**

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

`quay.io/coreos/etcd` is down

uses `gcr.io/etcd-development/etcd` as  ETCD container registry, instead of `quay.io/coreos/etcd`



**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first
