### PR TITLE
fix: remove proxy-rewrite plugin out of create plugin template config view

### DIFF
--- a/web/cypress/integration/pluginTemplate/create-edit-delete-plugin-template.spec.js
+++ b/web/cypress/integration/pluginTemplate/create-edit-delete-plugin-template.spec.js
@@ -35,6 +35,10 @@ context('Create Configure and Delete PluginTemplate', () => {
 
     cy.get(this.domSelector.description).type(this.data.pluginTemplateName);
     cy.contains('Next').click();
+
+    // should not see proxy-rewrite plugin in the step2
+    cy.contains('proxy-rewrite').should('not.exist');
+
     cy.contains('Enable').click({
       force: true
     });

--- a/web/src/pages/PluginTemplate/Create.tsx
+++ b/web/src/pages/PluginTemplate/Create.tsx
@@ -112,7 +112,8 @@ const Page: React.FC = (props) => {
               initialData={plugins}
               onChange={setPlugins}
               schemaType="route"
-              referPage="route"/>
+              referPage="route"
+             />
           )}
           {step === 3 && <Preview form1={form1} plugins={plugins} />}
         </Card>

--- a/web/src/pages/PluginTemplate/Create.tsx
+++ b/web/src/pages/PluginTemplate/Create.tsx
@@ -108,7 +108,11 @@ const Page: React.FC = (props) => {
 
           {step === 1 && <Step1 form={form1} />}
           {step === 2 && (
-            <PluginPage initialData={plugins} onChange={setPlugins} schemaType="route" />
+            <PluginPage
+              initialData={plugins}
+              onChange={setPlugins}
+              schemaType="route"
+              referPage="route"/>
           )}
           {step === 3 && <Preview form1={form1} plugins={plugins} />}
         </Card>

--- a/web/src/pages/PluginTemplate/Create.tsx
+++ b/web/src/pages/PluginTemplate/Create.tsx
@@ -111,8 +111,8 @@ const Page: React.FC = (props) => {
             <PluginPage
               initialData={plugins}
               onChange={setPlugins}
-              schemaType="route"
               referPage="route"
+              schemaType="route"
              />
           )}
           {step === 3 && <Preview form1={form1} plugins={plugins} />}


### PR DESCRIPTION
Please answer these questions before submitting a pull request, **or your PR will get closed**.

**Why submit this pull request?**

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

While checking #1719 , another bug happened, `proxy-rewrite` plugin can still be configed in `plugin template` page.
Remove `proxy-rewrite` out of  create plugin template config step2 , just keep the same as the create route step3 does.


**Related issues**

fix/resolve None

**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [x] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first
