### PR TITLE
fix: inconsistent displayname of updatetime under EN locale

### DIFF
--- a/web/src/locales/en-US/component.ts
+++ b/web/src/locales/en-US/component.ts
@@ -65,7 +65,7 @@ export default {
   'component.global.sendTimeout': 'Send Timeout',
   'component.global.receiveTimeout': 'Receive Timeout',
   'component.global.name': 'Name',
-  'component.global.updateTime': 'UpdateAt',
+  'component.global.updateTime': 'Update Time',
   'component.global.form.itemExtraMessage.nameGloballyUnique': 'Name should be globally unique',
   'component.global.input.placeholder.description': 'Please enter the description for this route, max 256 characters',
   // User component

--- a/web/src/pages/Upstream/locales/en-US.ts
+++ b/web/src/pages/Upstream/locales/en-US.ts
@@ -88,7 +88,7 @@ export default {
   'page.upstream.list.name': 'Name',
   'page.upstream.list.type': 'Type',
   'page.upstream.list.description': 'Description',
-  'page.upstream.list.edit.time': 'Updated At',
+  'page.upstream.list.edit.time': 'Update Time',
   'page.upstream.list.operation': 'Operation',
   'page.upstream.list.edit': 'Configure',
   'page.upstream.list.confirm.delete': 'Are you sure to delete ?',


### PR DESCRIPTION
Signed-off-by: Eric Shen <ericshenyuhao@outlook.com>

Please answer these questions before submitting a pull request, **or your PR will get closed**.

**Why submit this pull request?**

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

There is an in inconsistent display name on the Route, Upstream and SSL pages:
* Route page
<img width="932" alt="route" src="https://user-images.githubusercontent.com/10498732/114263219-da752380-9a16-11eb-8eb7-14b4557822bc.PNG">

* Upstream page
<img width="933" alt="上游" src="https://user-images.githubusercontent.com/10498732/114263228-e3fe8b80-9a16-11eb-9a97-e585520e6127.PNG">

* SSL page
<img width="925" alt="SSL" src="https://user-images.githubusercontent.com/10498732/114263244-faa4e280-9a16-11eb-9059-a895417ddc87.PNG">

* Consumer page
<img width="938" alt="消费者" src="https://user-images.githubusercontent.com/10498732/114263258-0bedef00-9a17-11eb-8fad-dfae977831bc.PNG">

So i modified `component.global.updateTime` and `page.upstream.list.edit.time` to keep the display name align as **Update Time**.

**Related issues**

No related issue.

**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first
