### PR TITLE
fix: use image of APISIX on docker hub instead of build from dockerfile

### DIFF
--- a/api/test/docker/docker-compose.yaml
+++ b/api/test/docker/docker-compose.yaml
@@ -127,11 +127,12 @@ services:
 
   apisix:
     hostname: apisix_server1
-    build:
-      context: ../../
-      dockerfile: test/docker/Dockerfile-apisix
-      args:
-        - APISIX_VERSION=2.4
+    image: apache/apisix:2.4-alpine
+    # build:
+    #   context: ../../
+    #   dockerfile: test/docker/Dockerfile-apisix
+    #   args:
+    #     - APISIX_VERSION=2.4
     restart: always
     volumes:
       - ./apisix_config.yaml:/usr/local/apisix/conf/config.yaml:ro
@@ -152,11 +153,12 @@ services:
 
   apisix2:
     hostname: apisix_server2
-    build:
-      context: ../../
-      dockerfile: test/docker/Dockerfile-apisix
-      args:
-        - APISIX_VERSION=2.4
+    image: apache/apisix:2.4-alpine
+    # build:
+    #   context: ../../
+    #   dockerfile: test/docker/Dockerfile-apisix
+    #   args:
+    #     - APISIX_VERSION=2.4
     restart: always
     volumes:
       - ./apisix_config2.yaml:/usr/local/apisix/conf/config.yaml:ro

--- a/api/test/docker/docker-compose.yaml
+++ b/api/test/docker/docker-compose.yaml
@@ -128,11 +128,6 @@ services:
   apisix:
     hostname: apisix_server1
     image: apache/apisix:2.4-alpine
-    # build:
-    #   context: ../../
-    #   dockerfile: test/docker/Dockerfile-apisix
-    #   args:
-    #     - APISIX_VERSION=2.4
     restart: always
     volumes:
       - ./apisix_config.yaml:/usr/local/apisix/conf/config.yaml:ro
@@ -154,11 +149,6 @@ services:
   apisix2:
     hostname: apisix_server2
     image: apache/apisix:2.4-alpine
-    # build:
-    #   context: ../../
-    #   dockerfile: test/docker/Dockerfile-apisix
-    #   args:
-    #     - APISIX_VERSION=2.4
     restart: always
     volumes:
       - ./apisix_config2.yaml:/usr/local/apisix/conf/config.yaml:ro


### PR DESCRIPTION
Please answer these questions before submitting a pull request, **or your PR will get closed**.

**Why submit this pull request?**

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

Due to the unavailability of the luarocks service, the image from the dockerfile build APISIX failed, which affected the back-end e2e test. So instead use the image on the docker hub to run the e2e test environment.

