### PR TITLE
fix: add missing label in nodes component

### DIFF
--- a/web/src/components/Upstream/components/Nodes.tsx
+++ b/web/src/components/Upstream/components/Nodes.tsx
@@ -37,6 +37,7 @@ const Component: React.FC<Props> = ({ readonly }) => {
               <Row style={{ marginBottom: 10 }} gutter={16} key={index}>
                 <Col span={5}>
                   <Form.Item
+                    label={formatMessage({id: 'page.upstream.step.host'})}
                     style={{ marginBottom: 0 }}
                     name={[field.name, 'host']}
                     rules={[

--- a/web/src/pages/Upstream/locales/en-US.ts
+++ b/web/src/pages/Upstream/locales/en-US.ts
@@ -21,6 +21,7 @@ export default {
   'page.upstream.step.input.domain.name.or.ip': 'Please enter domain or IP',
   'page.upstream.step.valid.domain.name.or.ip': 'Please enter valid a domain or IP',
   'page.upstream.step.domain.name.or.ip': 'Hostname or IP',
+  'page.upstream.step.host': 'Host',
   'page.upstream.step.input.port': 'Please enter port number',
   'page.upstream.step.port': 'Port',
   'page.upstream.step.input.weight': 'Please enter weight',

--- a/web/src/pages/Upstream/locales/zh-CN.ts
+++ b/web/src/pages/Upstream/locales/zh-CN.ts
@@ -20,6 +20,7 @@ export default {
   'page.upstream.form.item-label.node.domain.or.ip': '目标节点',
   'page.upstream.step.input.domain.name.or.ip': '请输入域名或 IP',
   'page.upstream.step.domain.name.or.ip': '主机名或 IP',
+  'page.upstream.step.host': '主机名',
   'page.upstream.step.valid.domain.name.or.ip': '请输入合法的域名或 IP',
   'page.upstream.step.input.port': '请输入',
   'page.upstream.step.port': '端口',


### PR DESCRIPTION
Please answer these questions before submitting a pull request, **or your PR will get closed**.

**Why submit this pull request?**

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

On the Upstream create page, host label is missing. 

<img src="https://user-images.githubusercontent.com/10498732/115904988-09b87580-a498-11eb-8cad-269bb938b865.png" height="330" weight="495">

So i add the label of host on the page, it will look like:

<img src="https://user-images.githubusercontent.com/10498732/115905152-47b59980-a498-11eb-9127-c6af997cf373.png" height="330" weight="495">

**Related issues**

No related issue.

**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first
