### PR TITLE
fix: use remote address instead of client ip

### DIFF
--- a/api/internal/filter/ip_filter.go
+++ b/api/internal/filter/ip_filter.go
@@ -19,6 +19,7 @@ package filter
 import (
 	"net"
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 
@@ -81,7 +82,10 @@ func checkIP(ipStr string, ips map[string]bool, subnets []*subnet) bool {
 func IPFilter() gin.HandlerFunc {
 	ips, subnets := generateIPSet(conf.AllowList)
 	return func(c *gin.Context) {
-		ipStr := c.ClientIP()
+		var ipStr string
+		if ip, _, err := net.SplitHostPort(strings.TrimSpace(c.Request.RemoteAddr)); err == nil {
+			ipStr = ip
+		}
 
 		if len(conf.AllowList) < 1 {
 			c.Next()

--- a/api/internal/filter/ip_filter_test.go
+++ b/api/internal/filter/ip_filter_test.go
@@ -58,19 +58,19 @@ func TestIPFilter_Handle(t *testing.T) {
 	assert.Equal(t, 200, w.Code)
 
 	// should forbidden
-	conf.AllowList = []string{"8.8.8.8"}
+	conf.AllowList = []string{"127.0.0.1"}
 	r = gin.New()
 	r.Use(IPFilter())
 	r.GET("/test", func(c *gin.Context) {})
 
 	req := httptest.NewRequest("GET", "/test", nil)
-	req.Header.Set("X-Forwarded-For", "8.8.8.8")
+	req.Header.Set("X-Forwarded-For", "127.0.0.1")
 	w = httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 	assert.Equal(t, 403, w.Code)
 
 	req = httptest.NewRequest("GET", "/test", nil)
-	req.Header.Set("X-Real-Ip", "8.8.8.8")
+	req.Header.Set("X-Real-Ip", "127.0.0.1")
 	w = httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 	assert.Equal(t, 403, w.Code)


### PR DESCRIPTION
Please answer these questions before submitting a pull request, **or your PR will get closed**.

**Why submit this pull request?**
Now, we use the gin's context.ClientIP.This function will parse the IP from the header `X-Forwarded-For` and `X-Real-Ip`
which will bypass the ipfilter middleware.

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

Use remote address instead of client ip.


**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [x] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first
