### PR TITLE
fix: default cors plugin formdata validation error

### DIFF
--- a/web/cypress/integration/route/create-route-with-cors-form.spec.js
+++ b/web/cypress/integration/route/create-route-with-cors-form.spec.js
@@ -19,7 +19,9 @@
 context('Create and delete route with cors form', () => {
   const selector = {
     allow_credential: "#allow_credential",
-    allow_origins_by_regex: "#allow_origins_by_regex_0"
+    allow_origins_by_regex0: "#allow_origins_by_regex_0",
+    allow_origins_by_regex1: "#allow_origins_by_regex_1",
+    addButton: "[data-cy=add-allow_origins_by_regex]",
   }
 
   beforeEach(() => {
@@ -58,7 +60,54 @@ context('Create and delete route with cors form', () => {
 
     // config cors form
     cy.get(selector.allow_credential).click();
-    cy.get(selector.allow_origins_by_regex).type('.*.test.com');
+    cy.get(selector.allow_origins_by_regex0).type('.*.test.com');
+    // add allow_origins_by_regex, assert new input and minus icons exist
+    cy.get(selector.addButton).click();
+    cy.get(selector.allow_origins_by_regex1).should('exist');
+    cy.get(selector.allow_origins_by_regex0).next().should('have.class', 'anticon-minus-circle');
+    cy.get(selector.allow_origins_by_regex1).type('foo.com').next().should('have.class', 'anticon-minus-circle');
+
+    cy.get(this.domSelector.drawer).within(() => {
+      cy.contains('Submit').click({
+        force: true,
+      });
+    });
+    cy.get(this.domSelector.drawer).should('not.exist');
+
+    cy.contains('button', 'Next').click();
+    cy.contains('button', 'Submit').click();
+    cy.contains(this.data.submitSuccess);
+
+    // back to route list page
+    cy.contains('Goto List').click();
+    cy.url().should('contains', 'routes/list');
+  });
+
+  it('should edit route with cors form no allow_origins_by_regex configured', function () {
+    cy.visit('/');
+    cy.contains('Route').click();
+    cy.get(this.domSelector.name).clear().type('routeName');
+    cy.contains('Search').click();
+    cy.contains('routeName').siblings().contains('Configure').click();
+    cy.get(this.domSelector.name).should('have.value','routeName');
+    cy.contains('Next').click();
+    cy.contains('Next').click();
+
+    // config cors plugin
+    cy.contains('cors').parents(this.domSelector.pluginCardBordered).within(() => {
+      cy.get('button').click({
+        force: true
+      });
+    });
+
+    cy.get(this.domSelector.drawer).should('be.visible').within(() => {
+      cy.get(this.domSelector.disabledSwitcher).click();
+      cy.get(this.domSelector.checkedSwitcher).should('exist');
+    });
+
+    // edit allow_origins_by_regex ''
+    cy.get(selector.allow_origins_by_regex0).clear();
+    cy.get(selector.allow_origins_by_regex1).next().click();
     cy.get(this.domSelector.drawer).within(() => {
       cy.contains('Submit').click({
         force: true,
@@ -90,6 +139,6 @@ context('Create and delete route with cors form', () => {
       cy.contains('OK').click();
     });
     cy.get(domSelector.notification).should('contain', data.deleteRouteSuccess);
-    cy.get(domSelector.notificationCloseIcon).click();
+    cy.get(domSelector.notificationCloseIcon).click({ multiple: true});
   });
 });

--- a/web/src/components/Plugin/PluginDetail.tsx
+++ b/web/src/components/Plugin/PluginDetail.tsx
@@ -37,6 +37,7 @@ import { LinkOutlined } from '@ant-design/icons';
 import Ajv from 'ajv';
 import type { DefinedError } from 'ajv';
 import addFormats from 'ajv-formats';
+import { compact, omit } from 'lodash';
 
 import { fetchSchema } from './service';
 import { json2yaml, yaml2json } from '../../helpers';
@@ -121,6 +122,12 @@ const PluginDetail: React.FC<Props> = ({
     if (name === 'cors') {
       const formData = UIForm.getFieldsValue();
       const newMethods = formData.allow_methods.join(",");
+      const compactAllowRegex = compact(formData.allow_origins_by_regex);
+      // Note: default allow_origins_by_regex setted for UI is [''], but this is not allowed, omit it.
+      if (compactAllowRegex.length === 0) {
+        return omit({ ...formData, allow_methods: newMethods }, ['allow_origins_by_regex'])
+      }
+
       return { ...formData, allow_methods: newMethods };
     }
     return UIForm.getFieldsValue();

--- a/web/src/components/Plugin/UI/cors.tsx
+++ b/web/src/components/Plugin/UI/cors.tsx
@@ -158,6 +158,7 @@ const Cors: React.FC<Props> = ({ form }) => {
                 <Form.Item {...FORM_ITEM_WITHOUT_LABEL}>
                   <Button
                     type="dashed"
+                    data-cy="add-allow_origins_by_regex"
                     onClick={() => {
                       add();
                     }}


### PR DESCRIPTION
Please answer these questions before submitting a pull request, **or your PR will get closed**.

**Why submit this pull request?**

- [X] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

when I submitted default cors plugin configure in form mode, a validation error occured:

![2021-05-07 13-40-50屏幕截图](https://user-images.githubusercontent.com/2561857/117403225-6d33b000-af3a-11eb-99f2-6deb59cd432e.png)

the error shows that `allow_origins_by_regex` should have at least 1 character.

*  Reason

schema of `cors` plugin:
```json
{
    "properties": {
        ...
	"allow_origins_by_regex": {
	    "description": "you can use regex to allow specific origins when no credentials,for example use [.*\\.test.com] to allow a.test.com and b.test.com",
	    "items": {
		 "maxLength": 4096,
		 "minLength": 1,
		 "type": "string"
	    },
	    "minItems": 1,
	    "type": "array",
	    "uniqueItems": true
	},
    },
   "type": "object"
}
```
shows that `allow_origins_by_regex` is not a required item, but when it configured, it should be at least 1 character.

the default post data is:
```json
{
    "allow_credential": false
    "allow_headers": "*"
    "allow_methods": ["*"]
    "allow_origins": "*"
    "allow_origins_by_regex": [""]
    "expose_headers": "*"
    "max_age": 5
}
```
the mistake is ` "allow_origins_by_regex": [""]`, why the value is [""]? In order to make UI better to use, we set default `allow_origins_by_regex` empty to have one input box in the page.

* How to fix
omit `allow_origins_by_regex` when it is not configured

**Checklist:**

- [X] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [X] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first
