### PR TITLE
feat: additional flag to force start manager-api

### DIFF
--- a/api/cmd/root.go
+++ b/api/cmd/root.go
@@ -43,6 +43,7 @@ import (
 
 var (
 	configFile string
+	forceStart bool
 )
 
 var rootCmd = &cobra.Command{
@@ -65,6 +66,7 @@ func init() {
 
 	rootCmd.PersistentFlags().StringVarP(&configFile, "config", "c", "./conf/conf.yml", "config file")
 	rootCmd.PersistentFlags().StringVarP(&conf.WorkDir, "work-dir", "p", ".", "current work directory")
+	rootCmd.PersistentFlags().BoolVarP(&forceStart, "force", "f", false, "force start manager-api")
 
 	rootCmd.AddCommand(
 		newVersionCommand(),
@@ -86,7 +88,7 @@ func manageAPI() error {
 	conf.InitConf()
 	log.InitLogger()
 
-	if err := utils.WritePID(conf.PIDPath); err != nil {
+	if err := utils.WritePID(conf.PIDPath, forceStart); err != nil {
 		log.Errorf("failed to write pid: %s", err)
 		return err
 	}

--- a/api/internal/utils/pid.go
+++ b/api/internal/utils/pid.go
@@ -25,9 +25,13 @@ import (
 )
 
 // WritePID write pid to the given file path.
-func WritePID(filepath string) error {
-	if _, err := os.Stat(filepath); err == nil {
-		return fmt.Errorf("instance of Manager API already running: a pid file exists in %s", filepath)
+func WritePID(filepath string, forceStart bool) error {
+	if pid, err := ReadPID(filepath); err == nil {
+		if !forceStart {
+			return fmt.Errorf("Instance of Manager API maybe running with a pid %d. If not, please run Manager API with '-f' or '--force' flag\n", pid)
+		} else {
+			fmt.Printf("Force starting new instance. Another instance of Manager API maybe running with pid %d\n", pid)
+		}
 	}
 	pid := os.Getpid()
 	f, err := os.OpenFile(filepath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|os.O_CREATE, 0600)

--- a/api/internal/utils/pid.go
+++ b/api/internal/utils/pid.go
@@ -29,9 +29,8 @@ func WritePID(filepath string, forceStart bool) error {
 	if pid, err := ReadPID(filepath); err == nil {
 		if !forceStart {
 			return fmt.Errorf("Instance of Manager API maybe running with a pid %d. If not, please run Manager API with '-f' or '--force' flag\n", pid)
-		} else {
-			fmt.Printf("Force starting new instance. Another instance of Manager API maybe running with pid %d\n", pid)
 		}
+		fmt.Printf("Force starting new instance. Another instance of Manager API maybe running with pid %d\n", pid)
 	}
 	pid := os.Getpid()
 	f, err := os.OpenFile(filepath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|os.O_CREATE, 0600)


### PR DESCRIPTION
Please answer these questions before submitting a pull request, **or your PR will get closed**.

**Why submit this pull request?**

- [ ] Bugfix
- [x] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**
additional flag `-f` or `--force` to force start Manager API with different configuration maybe when a PID file is already existing.

**Related issues**

in continuation with #1814 
https://github.com/apache/apisix-dashboard/pull/1814#discussion_r627478821

**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first
