### PR TITLE
feat: separate entry in a simple function

### DIFF
--- a/api/cmd/managerapi.go
+++ b/api/cmd/managerapi.go
@@ -48,7 +48,7 @@ var (
 	service     *Service
 )
 
-func printInfo() {
+func PrintInfo() {
 	fmt.Fprint(os.Stdout, "The manager-api is running successfully!\n\n")
 	printVersion()
 	fmt.Fprintf(os.Stdout, "%-8s: %s:%d\n", "Listen", conf.ServerHost, conf.ServerPort)
@@ -184,7 +184,7 @@ func manageAPI() error {
 		}()
 	}
 
-	printInfo()
+	PrintInfo()
 
 	select {
 	case err := <-errsig:

--- a/api/main.go
+++ b/api/main.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"crypto/tls"
+	"net"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/apisix/manager-api/cmd"
+	"github.com/apisix/manager-api/internal"
+	"github.com/apisix/manager-api/internal/conf"
+	"github.com/apisix/manager-api/internal/core/storage"
+	"github.com/apisix/manager-api/internal/core/store"
+	"github.com/apisix/manager-api/internal/filter"
+	"github.com/apisix/manager-api/internal/handler"
+	"github.com/apisix/manager-api/internal/log"
+	"github.com/shiningrush/droplet"
+)
+
+func main() {
+	conf.InitConf()
+	log.InitLogger()
+
+	droplet.Option.Orchestrator = func(mws []droplet.Middleware) []droplet.Middleware {
+		var newMws []droplet.Middleware
+		// default middleware order: resp_reshape, auto_input, traffic_log
+		// We should put err_transform at second to catch all error
+		newMws = append(newMws, mws[0], &handler.ErrorTransformMiddleware{}, &filter.AuthenticationMiddleware{})
+		newMws = append(newMws, mws[1:]...)
+		return newMws
+	}
+
+	if err := storage.InitETCDClient(conf.ETCDConfig); err != nil {
+		log.Fatalf("init etcd client fail: %w", err)
+	}
+	if err := store.InitStores(); err != nil {
+		log.Fatalf("init stores fail: %w", err)
+	}
+	cmd.PrintInfo()
+	// routes
+	r := internal.SetUpRouter()
+	// HTTP
+	var server, serverSSL *http.Server
+
+	// HTTPS
+	if conf.SSLCert != "" && conf.SSLKey != "" {
+		addrSSL := net.JoinHostPort(conf.ServerHost, strconv.Itoa(conf.SSLPort))
+		serverSSL = &http.Server{
+			Addr:         addrSSL,
+			Handler:      r,
+			ReadTimeout:  time.Duration(1000) * time.Millisecond,
+			WriteTimeout: time.Duration(5000) * time.Millisecond,
+			TLSConfig: &tls.Config{
+				// Causes servers to use Go's default ciphersuite preferences,
+				// which are tuned to avoid attacks. Does nothing on clients.
+				PreferServerCipherSuites: true,
+			},
+		}
+		log.Infof("The Manager API is listening on HTTPS %s", addrSSL)
+		go func() {
+			if err := serverSSL.ListenAndServeTLS(conf.SSLCert, conf.SSLKey); err != nil && err != http.ErrServerClosed {
+				log.Fatalf("listen and serve for HTTPS failed: %s", err)
+			}
+		}()
+	}
+
+	addr := net.JoinHostPort(conf.ServerHost, strconv.Itoa(conf.ServerPort))
+	server = &http.Server{
+		Addr:         addr,
+		Handler:      r,
+		ReadTimeout:  time.Duration(1000) * time.Millisecond,
+		WriteTimeout: time.Duration(5000) * time.Millisecond,
+	}
+	log.Infof("The Manager API is listening on HTTP %s", addr)
+	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		log.Fatalf("listen and serv fail: %s", err)
+	}
+}


### PR DESCRIPTION
**Why submit this pull request?**

- [ ] Bugfix
- [x] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**Related issues**
resolve #1840 

## Hi everyone :wave: 

About the issue #1840 ,I have an idea.Maybe this is not a good idea,but I like it!Check it out:
I added a `main.go` at the root directory,and only a main function in this file,this function only do all things must be done,include init and serve.This means you can find everything at the root directory,in this single file and in this single function,**this is really simple and easy to understand**.You can pay all your attention to the logic of the service and don't need to worry about managing the service.It just a executable file and serve,you don’t need to understand what it does on your system to run,easier for users to understand.
I know this does not conform to the _standard go project layout_,but I don't think that's important.
We can also keep the entry in `cmd`,users can chose the simple version of `main.go` or the version include service mangement in `cmd`.And users can also manage the service by themselves with the simple version,like `supervisor`.
I haven't done all the jobs,I just want to hear your opinions first.
@starsz @nic-chen @juzhiyuan 


