### PR TITLE
ci: use concurrency to cancel duplicate workflow

### DIFF
--- a/.github/workflows/backend-e2e-test.yml
+++ b/.github/workflows/backend-e2e-test.yml
@@ -14,6 +14,10 @@ on:
       - 'docs/**'
       - 'web/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   backend-e2e-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-with-docker.yml
+++ b/.github/workflows/deploy-with-docker.yml
@@ -12,6 +12,10 @@ on:
     paths-ignore:
       - 'docs/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/frontend-e2e-test.yml
+++ b/.github/workflows/frontend-e2e-test.yml
@@ -11,6 +11,12 @@ on:
       - master
     paths-ignore:
       - 'docs/**'
+
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   CYPRESS_CACHE_FOLDER: cypress/cache
 defaults:

--- a/.github/workflows/frontend-e2e-test.yml
+++ b/.github/workflows/frontend-e2e-test.yml
@@ -12,7 +12,6 @@ on:
     paths-ignore:
       - 'docs/**'
 
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/frontend-plugin-e2e-test.yml
+++ b/.github/workflows/frontend-plugin-e2e-test.yml
@@ -10,6 +10,11 @@ on:
       - master
     paths-ignore:
       - 'docs/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   CYPRESS_CACHE_FOLDER: cypress/cache
 defaults:

--- a/.github/workflows/make-build.yaml
+++ b/.github/workflows/make-build.yaml
@@ -14,6 +14,10 @@ on:
     paths-ignore:
       - 'docs/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   make-build-test:
     name: make build test

--- a/.github/workflows/test-frontend-multiple-node-build.yml
+++ b/.github/workflows/test-frontend-multiple-node-build.yml
@@ -12,6 +12,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule ".github/actions/cancel-workflow-runs"]
-	path = .github/actions/cancel-workflow-runs
-	url = https://github.com/potiuk/cancel-workflow-runs
 [submodule ".github/actions/gitleaks-action"]
 	path = .github/actions/gitleaks-action
 	url = https://github.com/zricethezav/gitleaks-action


### PR DESCRIPTION
Signed-off-by: yiyiyimu <wosoyoung@gmail.com>

Please answer these questions before submitting a pull request, **or your PR will get closed**.

**Why submit this pull request?**

- [ ] Bugfix
- [x] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

Use github official argument to cancel duplicate workflows, to replace deprecated `cancel-workflow-runs`.

Tested for push and PR from [original repo](https://github.com/Yiyiyimu/GithubActionsTest/pull/8) and [forked repo](https://github.com/Yiyiyimu/GithubActionsTest/pull/9)

**Related issues**

Ref: https://github.com/apache/apisix/issues/4341

**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first
