### PR TITLE
feat: set a initial weight value for the upstream node

### DIFF
--- a/web/cypress/integration/route/import_export_route.spec.js
+++ b/web/cypress/integration/route/import_export_route.spec.js
@@ -84,7 +84,7 @@ context('import and export routes', () => {
       // input nodes_0_host, click Next
       cy.get(selector.nodes_0_host).type(data[`upstream_node0_host_${i}`]);
       cy.get(selector.nodes_0_port).type(data.port);
-      cy.get(selector.nodes_0_weight).type(data.weight);
+      cy.get(selector.nodes_0_weight).clear().type(data.weight);
       cy.contains(actionBarUS['component.actionbar.button.nextStep']).click();
       // do not config plugins, click Next
       cy.contains(actionBarUS['component.actionbar.button.nextStep']).click();

--- a/web/src/components/Upstream/components/Nodes.tsx
+++ b/web/src/components/Upstream/components/Nodes.tsx
@@ -95,6 +95,7 @@ const Component: React.FC<Props> = ({ readonly }) => {
                         message: formatMessage({ id: 'page.upstream.step.input.weight' }),
                       },
                     ]}
+                    initialValue={1}
                   >
                     <InputNumber
                       placeholder={formatMessage({ id: 'page.upstream.step.weight' })}


### PR DESCRIPTION
Please answer these questions before submitting a pull request, **or your PR will get closed**.

**Why submit this pull request?**
For most scenarios, the weight value of the upstream node is 1, so setting a initial weight value 1 can reduce user input.

- [ ] Bugfix
- [x] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

Please update this section with detailed description.

**Related issues**

fix/resolve
![image](https://user-images.githubusercontent.com/75366457/125499522-6106c0fe-1569-48c2-833c-0c9217eba829.png)

**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [x] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first
