### PR TITLE
ci: add el7 in package name

### DIFF
--- a/.github/workflows/auto-build-rpm.yml
+++ b/.github/workflows/auto-build-rpm.yml
@@ -45,7 +45,7 @@ jobs:
           if [ "$VERSION" != "merge" && "$VERSION" != "master" ];then
             export checkout=release/${VERSION}
           fi
-          make package type=rpm app=dashboard version=${VERSION} checkout=${checkout}
+          make package type=rpm app=dashboard version=${VERSION} checkout=${checkout} image_base=centos image_tag=7
 
       - name: Run centos7 docker and mapping apisix into container
         run: |
@@ -54,7 +54,7 @@ jobs:
       - name: Install rpm package
         run: |
           export VERSION=${{ steps.branch_env.outputs.version }}
-          docker exec centos7Instance bash -c "cd apisix-dashboard && yum install -y ./apisix-build-tools/output/apisix-dashboard-${VERSION}-0.x86_64.rpm"
+          docker exec centos7Instance bash -c "cd apisix-dashboard && yum install -y ./apisix-build-tools/output/apisix-dashboard-${VERSION}-0.el7.x86_64.rpm"
           docker logs centos7Instance
           # Dependencies are attached with rpm, so revert `make deps`
           docker exec centos7Instance bash -c "cd /usr/local/apisix/dashboard/ && nohup ./manager-api &"
@@ -67,4 +67,4 @@ jobs:
         uses: actions/upload-artifact@v2.2.4
         with:
           name: "rpm"
-          path: "./apisix-build-tools/output/apisix-dashboard-${{ steps.branch_env.outputs.version }}-0.x86_64.rpm"
+          path: "./apisix-build-tools/output/apisix-dashboard-${{ steps.branch_env.outputs.version }}-0.el7.x86_64.rpm"


### PR DESCRIPTION
Signed-off-by: imjoey <majunjie@apache.org>

Please answer these questions before submitting a pull request, **or your PR will get closed**.

**Why submit this pull request?**

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

The package name of apisix-dashboard in CentOS7 has been added with the OS distribution name `el7`, see https://github.com/api7/apisix-build-tools/pull/67 for details. So this PR is going to change the relevant rpm name to `apisix-dashboard-${version}-0.el7.x86_64.rpm` from the original `apisix-dashboard-${version}-0.x86_64.rpm`. This PR will also fix the CI failures due to the stale package name.

**Related issues**



**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first
