### PR TITLE
chore: Use build-tools v2.0.0 instead of master

### DIFF
--- a/.github/workflows/auto-build-rpm.yml
+++ b/.github/workflows/auto-build-rpm.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           export VERSION=${{ steps.branch_env.outputs.version }}
           sudo gem install --no-document fpm
-          git clone https://github.com/api7/apisix-build-tools.git
+          git clone -b v2.0.0 https://github.com/api7/apisix-build-tools.git
           cd apisix-build-tools
           export checkout=master
           if [ "$VERSION" != "merge" && "$VERSION" != "master" ];then


### PR DESCRIPTION
Signed-off-by: imjoey <majunjie@apache.org>

Please answer these questions before submitting a pull request, **or your PR will get closed**.

**Why submit this pull request?**

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

The apisix-dashboard CI is using the master code of apisix-build-tools for building and packaging. While this would lead to unexpected errors if anything is incompatible. In other words, we should always rely on a stable version. This PR is going to use the `v2.0.0` of apisix-build-tools, which is also heading to the same commit with the latest code of the current master branch.


**Related issues**

Related to https://github.com/api7/apisix-build-tools/issues/75.

**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first
