### PR TITLE
feat: Bump apisix-build-tools to v2.1.0

### DIFF
--- a/.github/workflows/auto-build-rpm.yml
+++ b/.github/workflows/auto-build-rpm.yml
@@ -39,13 +39,18 @@ jobs:
         run: |
           export VERSION=${{ steps.branch_env.outputs.version }}
           sudo gem install --no-document fpm
-          git clone -b v2.0.0 https://github.com/api7/apisix-build-tools.git
+          git clone -b v2.1.0 https://github.com/api7/apisix-build-tools.git
+
+          # move codes under build tool
+          mkdir ./apisix-build-tools/apisix-dashboard
+          for dir in `ls|grep -v "^apisix-build-tools$"`;do cp -r $dir ./apisix-build-tools/apisix-dashboard/;done
+
           cd apisix-build-tools
           export checkout=master
           if [ "$VERSION" != "merge" && "$VERSION" != "master" ];then
             export checkout=release/${VERSION}
           fi
-          make package type=rpm app=dashboard version=${VERSION} checkout=${checkout} image_base=centos image_tag=7
+          make package type=rpm app=dashboard version=${VERSION} checkout=${checkout} image_base=centos image_tag=7 local_code_path=./apisix-dashboard
 
       - name: Run centos7 docker and mapping apisix into container
         run: |


### PR DESCRIPTION
Signed-off-by: imjoey <majunjie@apache.org>

Please answer these questions before submitting a pull request, **or your PR will get closed**.

This PR is going to bump apisix-build-tools to v2.1.0, which makes use of the `local_code_path` param to avoid downloading the repository again remotely.

**Why submit this pull request?**

- [ ] Bugfix
- [x] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

Please update this section with detailed description.

**Related issues**


**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [x] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first
