### PR TITLE
fix: ci failure for buildx

### DIFF
--- a/.github/workflows/deploy-with-docker.yml
+++ b/.github/workflows/deploy-with-docker.yml
@@ -26,6 +26,11 @@ jobs:
           submodules: recursive
 
       - uses: docker/setup-buildx-action@v1
+        with:
+          driver: docker-container
+          driver-opts: |
+            image=moby/buildkit:master
+            network=host
 
       - uses: actions/cache@v2
         with:


### PR DESCRIPTION
Signed-off-by: imjoey <majunjie@apache.org>

Please answer these questions before submitting a pull request, **or your PR will get closed**.

After refer to https://github.com/docker/buildx/blob/master/docs/reference/buildx_create.md#driver, this PR is going to use `docker-container` driver to replace the `docker` driver, which does not support cache yet. Will fix the CI failures when running `docker buildx bake` at https://github.com/apache/apisix-dashboard/runs/3479593341. 

**Why submit this pull request?**

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

Please update this section with detailed description.

**Related issues**

Fixes #2108.

**Checklist:**

- [ ] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first
