### PR TITLE
ci: fix errors due to buildx bake with cache

### DIFF
--- a/.github/workflows/deploy-with-docker.yml
+++ b/.github/workflows/deploy-with-docker.yml
@@ -73,10 +73,14 @@ jobs:
         working-directory: ./api/test/docker-deploy
         continue-on-error: true
         run: |
+          docker buildx create --name=builderx --use \
+            --driver docker-container \
+            --driver-opt image=moby/buildkit:master,network=host
           docker buildx bake --load \
           -f docker-compose.yaml \
           --set *.cache-from=type=local,src=/tmp/.buildx-cache \
-          --set *.cache-to=type=local,dest=/tmp/.buildx-cache
+          --set *.cache-to=type=local,dest=/tmp/.buildx-cache \
+          --builder builderx
 
       - name: Run Docker Compose
         working-directory: ./api/test/docker-deploy


### PR DESCRIPTION
Signed-off-by: imjoey <majunjie@apache.org>

Please answer these questions before submitting a pull request, **or your PR will get closed**.

Since #2109 does not completely resolve #2108, this is another solution. This PR is going to create new builder, instead of the default one, to support cache and many other features. See https://docs.docker.com/engine/reference/commandline/buildx_create/ for details.

**Why submit this pull request?**

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

Please update this section with detailed description.

**Related issues**

Fixes #2108.

**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first
