### PR TITLE
ci: Disable buildx cache to fix CI failure

### DIFF
--- a/.github/workflows/deploy-with-docker.yml
+++ b/.github/workflows/deploy-with-docker.yml
@@ -26,11 +26,6 @@ jobs:
           submodules: recursive
 
       - uses: docker/setup-buildx-action@v1
-        with:
-          driver: docker-container
-          driver-opts: |
-            image=moby/buildkit:master
-            network=host
 
       - uses: actions/cache@v2
         with:
@@ -55,10 +50,6 @@ jobs:
           context: .
           build-args: |
             APISIX_DASHBOARD_VERSION=master
-          cache-from: |
-            type=local,src=/tmp/.buildx-cache
-          cache-to: |
-            type=local,dest=/tmp/.buildx-cache
 
       - name: Modify Config
         run: |
@@ -73,14 +64,8 @@ jobs:
         working-directory: ./api/test/docker-deploy
         continue-on-error: true
         run: |
-          docker buildx create --name=builderx --use \
-            --driver docker-container \
-            --driver-opt image=moby/buildkit:master,network=host
           docker buildx bake --load \
-          -f docker-compose.yaml \
-          --set *.cache-from=type=local,src=/tmp/.buildx-cache \
-          --set *.cache-to=type=local,dest=/tmp/.buildx-cache \
-          --builder builderx
+          -f docker-compose.yaml
 
       - name: Run Docker Compose
         working-directory: ./api/test/docker-deploy


### PR DESCRIPTION
Signed-off-by: imjoey <majunjie@apache.org>

Please answer these questions before submitting a pull request, **or your PR will get closed**.

Master push still has errors in https://github.com/apache/apisix-dashboard/runs/3494675500. Related to https://github.com/apache/apisix-dashboard/issues/2108. This PR is going to remove the cache during docker buildx to keep CI passed. Will resolve this in the future.

**Why submit this pull request?**

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

Please update this section with detailed description.

**Related issues**

Fixes https://github.com/apache/apisix-dashboard/issues/2108.

**Checklist:**

- [ ] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first
