### PR TITLE
ci: Bump apisix-build-tools to version v2.2.0

### DIFF
--- a/.github/workflows/auto-build-rpm.yml
+++ b/.github/workflows/auto-build-rpm.yml
@@ -35,11 +35,21 @@ jobs:
         run: |
           echo "##[set-output name=version;]$(echo ${GITHUB_REF##*/})"
 
+      - uses: docker/setup-buildx-action@v1
+
+      - uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-apisixdashboard-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-apisixdashboard-
+            ${{ runner.os }}-buildx-
+
       - name: Build rpm package
         run: |
           export VERSION=${{ steps.branch_env.outputs.version }}
           sudo gem install --no-document fpm
-          git clone -b v2.1.0 https://github.com/api7/apisix-build-tools.git
+          git clone -b v2.2.0 https://github.com/api7/apisix-build-tools.git
 
           # move codes under build tool
           mkdir ./apisix-build-tools/apisix-dashboard
@@ -50,7 +60,8 @@ jobs:
           if [ "$VERSION" != "merge" && "$VERSION" != "master" ];then
             export checkout=release/${VERSION}
           fi
-          make package type=rpm app=dashboard version=${VERSION} checkout=${checkout} image_base=centos image_tag=7 local_code_path=./apisix-dashboard
+          make package type=rpm app=dashboard version=${VERSION} checkout=${checkout} image_base=centos image_tag=7 \
+            local_code_path=./apisix-dashboard buildx=True
 
       - name: Run centos7 docker and mapping apisix into container
         run: |


### PR DESCRIPTION
Signed-off-by: imjoey <majunjie@apache.org>

Please answer these questions before submitting a pull request, **or your PR will get closed**.

**Why submit this pull request?**

- [ ] Bugfix
- [ ] New feature provided
- [x] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

The new v2.2.0 of `api7/apisix-built-tools` introduces a new argument `buildx` to significantly reduce the CI time-cost by the external cache support. This PR is going to make use of this feature for accelerating the CI of apisix-dashboard.

**Related issues**

Related to https://github.com/apache/apisix-dashboard/pull/2072, will fix https://github.com/apache/apisix-dashboard/issues/2128.

**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first
