### PR TITLE
ci: Only upload artifact at the release branch

### DIFF
--- a/.github/workflows/auto-build-rpm.yml
+++ b/.github/workflows/auto-build-rpm.yml
@@ -69,6 +69,7 @@ jobs:
           api/test/shell/manager_smoking.sh -s true
 
       - name: Publish Artifact
+        if: ${{ startsWith(github.ref, 'refs/heads/release/') }}
         uses: actions/upload-artifact@v2.2.4
         with:
           name: "rpm"


### PR DESCRIPTION
Signed-off-by: imjoey <majunjie@apache.org>

Please answer these questions before submitting a pull request, **or your PR will get closed**.

**Why submit this pull request?**

- [ ] Bugfix
- [ ] New feature provided
- [x] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

For now, every pull-request/push will trigger the upload-artifact CI action, which is actually  needed for release only. This PR is going to restrict artifact uploading to perform only on `release/**` branch.

**Related issues**


**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first
