### PR TITLE
fix: select Use the domain or IP from Node List

### DIFF
--- a/web/cypress/integration/upstream/create_and_delete_upstream.spec.js
+++ b/web/cypress/integration/upstream/create_and_delete_upstream.spec.js
@@ -307,4 +307,36 @@ context('Create and Delete Upstream', () => {
     cy.contains('button', 'Confirm').click();
     cy.get(selector.notification).should('contain', data.deleteUpstreamSuccess);
   });
+
+  it('should create upstream with Use the domain or IP from Node List', function () {
+    cy.visit('/');
+    cy.contains('Upstream').click();
+    cy.contains('Create').click();
+
+    cy.get(selector.name).type(data.upstreamName);
+    cy.get(selector.description).type(data.description);
+
+    cy.get(selector.nodes_0_host).type(data.ip1);
+    cy.get(selector.nodes_0_port).clear().type('7000');
+    cy.get(selector.nodes_0_weight).clear().type(1);
+
+    cy.get('[title="Keep the same Host from client request"]').click();
+    cy.get(selector.selectItem).within(() => {
+      cy.contains('Use the domain or IP from Node List').click();
+    });
+
+    cy.contains('Next').click();
+    cy.get(selector.input).should('be.disabled');
+    cy.contains('Submit').click();
+    cy.get(selector.notification).should('contain', data.createUpstreamSuccess);
+    cy.url().should('contains', 'upstream/list');
+  });
+
+  it('should delete the upstream', function () {
+    cy.visit('/');
+    cy.contains('Upstream').click();
+    cy.contains(data.upstreamName).siblings().contains('Delete').click();
+    cy.contains('button', 'Confirm').click();
+    cy.get(selector.notification).should('contain', data.deleteUpstreamSuccess);
+  });
 });

--- a/web/src/components/Upstream/components/PassHost.tsx
+++ b/web/src/components/Upstream/components/PassHost.tsx
@@ -87,7 +87,7 @@ const Component: React.FC<Props> = ({ form, readonly }) => {
 
           if (
             form.getFieldValue('pass_host') === 'node' &&
-            (form.getFieldValue('nodes') || []).length !== 1
+            (form.getFieldValue('submitNodes') || []).length !== 1
           ) {
             notification.warning({
               message: formatMessage({


### PR DESCRIPTION
Please answer these questions before submitting a pull request, **or your PR will get closed**.

**Why submit this pull request?**

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

When create Upstream and select `Use the domain or IP from Node List`, v2.8/v2.9.0 tip this and unable to select: 
![image](https://user-images.githubusercontent.com/75366457/136787814-3bbc3a37-2b2c-45c3-a471-d2143fcf3b8a.png)

**Related issues**

fix/resolve:
PR(2118) change `name="nodes"` to `name="submitNodes"`, so this PR sync the change in the file PassHost.tsx
![image](https://user-images.githubusercontent.com/75366457/136786830-5f646565-fe2d-492f-8a4e-02d638d8d783.png)



**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [x] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first
