### PR TITLE
Adjust the read and write timeout configuration of the http server

### DIFF
--- a/api/internal/core/server/http.go
+++ b/api/internal/core/server/http.go
@@ -50,8 +50,8 @@ func (s *server) setupAPI() {
 	s.server = &http.Server{
 		Addr:         addr,
 		Handler:      r,
-		ReadTimeout:  time.Duration(1000) * time.Millisecond,
-		WriteTimeout: time.Duration(5000) * time.Millisecond,
+		ReadTimeout:  time.Duration(5000) * time.Millisecond,
+		WriteTimeout: time.Duration(60000) * time.Millisecond,
 	}
 
 	// HTTPS
@@ -60,8 +60,8 @@ func (s *server) setupAPI() {
 		s.serverSSL = &http.Server{
 			Addr:         addrSSL,
 			Handler:      r,
-			ReadTimeout:  time.Duration(1000) * time.Millisecond,
-			WriteTimeout: time.Duration(5000) * time.Millisecond,
+			ReadTimeout:  time.Duration(5000) * time.Millisecond,
+			WriteTimeout: time.Duration(60000) * time.Millisecond,
 			TLSConfig: &tls.Config{
 				// Causes servers to use Go's default ciphersuite preferences,
 				// which are tuned to avoid attacks. Does nothing on clients.


### PR DESCRIPTION
**Why submit this pull request?**

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

Adjust the `read` and `write` timeout configuration of the http server so that the Dashboard can work normally in a slow network environment. Especially write timeout, because the Dashboard has a relatively large front-end static resource file (>2M). When the bandwidth is limited It is easy to trigger the timeout in the scene, which will cause the page display to fail.

**Related issues**

fix/resolve #2165

**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first
