### PR TITLE
fix: plugin_configs should store with etcd prefix

### DIFF
--- a/api/internal/core/store/storehub.go
+++ b/api/internal/core/store/storehub.go
@@ -194,7 +194,7 @@ func InitStores() error {
 	}
 
 	err = InitStore(HubKeyPluginConfig, GenericStoreOption{
-		BasePath: "/apisix/plugin_configs",
+		BasePath: conf.ETCDConfig.Prefix + "/plugin_configs",
 		ObjType:  reflect.TypeOf(entity.PluginConfig{}),
 		KeyFunc: func(obj interface{}) string {
 			r := obj.(*entity.PluginConfig)


### PR DESCRIPTION
Please answer these questions before submitting a pull request, **or your PR will get closed**.

**Why submit this pull request?**

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

Use etcd prefix in plugin_configs template


**Related issues**
plugin_configs miss match when the etcd prefix is not '/apisix'

```
2021/11/29 19:40:06 [error] 12464#12464: *21668 [lua] init.lua:400: http_access_phase(): failed to fetch plugin config by id: 383574139283178878, client: 30.49.4.130, server: _, request: "GET /hello HTTP/2.0", host: "xxx.com"
```

```
# etcdctl get --prefix /apisix
...
/apisix-3b5e0cc5/upstreams/383566764287460734
{...}
/apisix-3b5e0cc5/upstreams/383570406268732798
{...}
/apisix/plugin_configs/383574139283178878
{...}
...

```

**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first
