### PR TITLE
fix(username_regex): cp consumer name regx different with dp

### DIFF
--- a/web/src/pages/Consumer/components/Step1.tsx
+++ b/web/src/pages/Consumer/components/Step1.tsx
@@ -43,7 +43,7 @@ const Step1: React.FC<Props> = ({ form, disabled }) => {
         rules={[
           { required: true },
           {
-            pattern: new RegExp(/^[a-zA-Z][a-zA-Z0-9_]{0,100}$/, 'g'),
+            pattern: new RegExp(/^[a-zA-Z0-9_]+$/, 'g'),
             message: formatMessage({ id: 'page.consumer.form.itemRuleMessage.username' }),
           },
         ]}

--- a/web/src/pages/Consumer/locales/en-US.ts
+++ b/web/src/pages/Consumer/locales/en-US.ts
@@ -16,7 +16,7 @@
  */
 export default {
   'page.consumer.form.itemRuleMessage.username':
-    'Maximum length is 100, only letters, numbers and _ are supported, and can only begin with letters',
+    'Maximum length is 100, only letters, numbers and _ are supported.',
   'page.consumer.form.itemExtraMessage.username': 'Name should be unique',
   'page.consumer.notification.warning.enableAuthenticationPlugin':
     'Please enable at least one of the following authentication plugin:',

--- a/web/src/pages/Consumer/locales/zh-CN.ts
+++ b/web/src/pages/Consumer/locales/zh-CN.ts
@@ -16,7 +16,7 @@
  */
 export default {
   'page.consumer.form.itemRuleMessage.username':
-    '最大长度100，仅支持字母、数字和 _ ，且只能以字母开头',
+    '最大长度100，仅支持字母、数字和 _ 。',
   'page.consumer.form.itemExtraMessage.username': '名称需唯一',
   'page.consumer.notification.warning.enableAuthenticationPlugin': '请至少启用如下一种认证类插件：',
   'page.consumer.username': '名称',


### PR DESCRIPTION
Please answer these questions before submitting a pull request, **or your PR will get closed**.

**Why submit this pull request?**

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

APISIX support consumer name start with number, but APISIX-Dashboard does't support. Does the APISIX-Dashboard need to support consumer that start with number.
And there is the APISIX regex https://github.com/apache/apisix/blob/master/apisix/schema_def.lua#L693 

![image](https://user-images.githubusercontent.com/38528079/144344163-d18e186d-71a5-4381-b9fe-ab68f08399be.png)

After change:

<img width="1156" alt="QQ20211202-100229@2x" src="https://user-images.githubusercontent.com/38528079/144344365-98cdf30e-0b0c-4fda-a18d-c58719cdba79.png">


**Related issues**

fix/resolve #2196 

**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [x] Have you modified the corresponding document?
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first
