### PR TITLE
fix: retries field to support zero value

### DIFF
--- a/api/internal/core/entity/entity.go
+++ b/api/internal/core/entity/entity.go
@@ -163,7 +163,7 @@ type UpstreamKeepalivePool struct {
 
 type UpstreamDef struct {
 	Nodes         interface{}            `json:"nodes,omitempty"`
-	Retries       int                    `json:"retries,omitempty"`
+	Retries       *int                    `json:"retries,omitempty"`
 	Timeout       *Timeout               `json:"timeout,omitempty"`
 	Type          string                 `json:"type,omitempty"`
 	Checks        interface{}            `json:"checks,omitempty"`

--- a/api/internal/core/entity/entity.go
+++ b/api/internal/core/entity/entity.go
@@ -163,7 +163,7 @@ type UpstreamKeepalivePool struct {
 
 type UpstreamDef struct {
 	Nodes         interface{}            `json:"nodes,omitempty"`
-	Retries       *int                    `json:"retries,omitempty"`
+	Retries       *int                   `json:"retries,omitempty"`
 	Timeout       *Timeout               `json:"timeout,omitempty"`
 	Type          string                 `json:"type,omitempty"`
 	Checks        interface{}            `json:"checks,omitempty"`

--- a/api/internal/core/entity/format_test.go
+++ b/api/internal/core/entity/format_test.go
@@ -179,3 +179,28 @@ func TestNodesFormat_no_nodes(t *testing.T) {
 	jsonStr := string(res)
 	assert.Contains(t, jsonStr, `null`)
 }
+
+func TestUpstream_nil_and_zero_retries(t *testing.T) {
+	ud0 := UpstreamDef{}
+	// Unmarshal from zero value
+	err := json.Unmarshal([]byte(`{"retries":0}`), &ud0)
+	assert.Nil(t, err)
+	assert.Equal(t, *ud0.Retries, 0)
+
+	// Marshal with zero value
+	marshaled, err := json.Marshal(ud0)
+	assert.Nil(t, err)
+	assert.Contains(t, string(marshaled), `"retries":0`)
+
+	udNull := UpstreamDef{}
+
+	// Unmarshal from null value
+	err = json.Unmarshal([]byte(`{}`), &udNull)
+	assert.Nil(t, err)
+	assert.Nil(t, udNull.Retries)
+
+	// Marshal to null value
+	marshaledNull, err := json.Marshal(udNull)
+	assert.Nil(t, err)
+	assert.Equal(t, string(marshaledNull), `{}`)
+}

--- a/api/test/e2enew/upstream/upstream_retry.go
+++ b/api/test/e2enew/upstream/upstream_retry.go
@@ -60,4 +60,63 @@ var _ = ginkgo.Describe("Upstream keepalive pool", func() {
 			ExpectStatus: http.StatusOK,
 		})
 	})
+	ginkgo.It("zero retry field", func() {
+		createUpstreamBody := make(map[string]interface{})
+		createUpstreamBody["nodes"] = []map[string]interface{}{
+			{
+				"host":   base.UpstreamIp,
+				"port":   1980,
+				"weight": 1,
+			}}
+		createUpstreamBody["type"] = "roundrobin"
+		createUpstreamBody["retries"] = 0
+		createUpstreamBody["retry_timeout"] = 5.5
+		_createUpstreamBody, err := json.Marshal(createUpstreamBody)
+		gomega.Expect(err).To(gomega.BeNil())
+		base.RunTestCase(base.HttpTestCase{
+			Object:       base.ManagerApiExpect(),
+			Method:       http.MethodPut,
+			Path:         "/apisix/admin/upstreams/zero-retry",
+			Body:         string(_createUpstreamBody),
+			Headers:      map[string]string{"Authorization": base.GetToken()},
+			ExpectStatus: http.StatusOK,
+		})
+		base.RunTestCase(base.HttpTestCase{
+			Object:       base.ManagerApiExpect(),
+			Method:       http.MethodGet,
+			Path:         "/apisix/admin/upstreams/zero-retry",
+			Body:         string(_createUpstreamBody),
+			Headers:      map[string]string{"Authorization": base.GetToken()},
+			ExpectStatus: http.StatusOK,
+			ExpectBody:   `"retries":0`,
+		})
+	})
+	ginkgo.It("nil retry field", func() {
+		createUpstreamBody := make(map[string]interface{})
+		createUpstreamBody["nodes"] = []map[string]interface{}{
+			{
+				"host":   base.UpstreamIp,
+				"port":   1980,
+				"weight": 1,
+			}}
+		createUpstreamBody["type"] = "roundrobin"
+		_createUpstreamBody, err := json.Marshal(createUpstreamBody)
+		gomega.Expect(err).To(gomega.BeNil())
+		base.RunTestCase(base.HttpTestCase{
+			Object:       base.ManagerApiExpect(),
+			Method:       http.MethodPut,
+			Path:         "/apisix/admin/upstreams/zero-retry",
+			Body:         string(_createUpstreamBody),
+			Headers:      map[string]string{"Authorization": base.GetToken()},
+			ExpectStatus: http.StatusOK,
+		})
+		base.RunTestCase(base.HttpTestCase{
+			Object:       base.ManagerApiExpect(),
+			Method:       http.MethodGet,
+			Path:         "/apisix/admin/upstreams/zero-retry",
+			Headers:      map[string]string{"Authorization": base.GetToken()},
+			ExpectStatus: http.StatusOK,
+			UnexpectBody: `"retries"`,
+		})
+	})
 })

--- a/api/test/e2enew/upstream/upstream_retry.go
+++ b/api/test/e2enew/upstream/upstream_retry.go
@@ -119,4 +119,14 @@ var _ = ginkgo.Describe("Upstream keepalive pool", func() {
 			UnexpectBody: `"retries"`,
 		})
 	})
+	ginkgo.It("delete upstream", func() {
+		base.RunTestCase(base.HttpTestCase{
+			Object:       base.ManagerApiExpect(),
+			Method:       http.MethodDelete,
+			Path:         "/apisix/admin/upstreams/zero-retry",
+			Headers:      map[string]string{"Authorization": base.GetToken()},
+			ExpectStatus: http.StatusOK,
+		})
+	})
+
 })


### PR DESCRIPTION
fix issue https://github.com/apache/apisix-dashboard/issues/2297 by changing retries type int to *int

Please answer these questions before submitting a pull request, **or your PR will get closed**.

**Why submit this pull request?**

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

Change the type of the field `api/internal/core/entity/entity.go:166` retries from int to *int.

**Related issues**

[fix/resolve #0001](https://github.com/apache/apisix-dashboard/issues/2297)

**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [x] Have you added corresponding test cases?
- [x] Have you modified the corresponding document?
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first
