### PR TITLE
fix: proxy-rewrite.plugin regex_uri support empty value

### DIFF
--- a/api/test/e2enew/route/route_with_plugin_proxy_rewrite_test.go
+++ b/api/test/e2enew/route/route_with_plugin_proxy_rewrite_test.go
@@ -102,6 +102,28 @@ var _ = ginkgo.Describe("route with plugin proxy rewrite", func() {
 			ExpectBody:   "x-api-version: v2",
 			Sleep:        base.SleepTime,
 		}),
+		table.Entry("update route using empty regex_uri", base.HttpTestCase{
+        	Object: base.ManagerApiExpect(),
+        	Method: http.MethodPut,
+        	Path:   "/apisix/admin/routes/r1",
+        	Body: `{
+        		"name": "route1",
+        		"uri": "/test",
+        		"plugins": {
+        			"proxy-rewrite": {
+        				"regex_uri": ["/test", ""]
+        			}
+        		},
+        		"upstream": {
+        			"type": "roundrobin",
+        			"nodes": {
+        				"` + base.UpstreamIp + `:1982": 1
+        			}
+        		}
+        	}`,
+        	Headers:      map[string]string{"Authorization": base.GetToken()},
+        	ExpectStatus: http.StatusOK,
+        }),
 		table.Entry("update route using regex_uri", base.HttpTestCase{
 			Object: base.ManagerApiExpect(),
 			Method: http.MethodPut,

--- a/web/src/pages/Route/components/Step1/ProxyRewrite.tsx
+++ b/web/src/pages/Route/components/Step1/ProxyRewrite.tsx
@@ -78,14 +78,6 @@ const ProxyRewrite: React.FC<RouteModule.Step1PassProps> = ({ form, disabled }) 
                         label={formatMessage({ id: 'page.route.form.itemLabel.regex' })}
                         name={field.name}
                         key={field.name}
-                        rules={[
-                          {
-                            required: true,
-                            message: `${formatMessage({
-                              id: 'component.global.pleaseEnter',
-                            })} ${formatMessage({ id: 'page.route.form.itemLabel.regex' })}`,
-                          },
-                        ]}
                       >
                         <Input
                           placeholder={`${formatMessage({

--- a/web/src/pages/Route/components/Step1/ProxyRewrite.tsx
+++ b/web/src/pages/Route/components/Step1/ProxyRewrite.tsx
@@ -78,6 +78,14 @@ const ProxyRewrite: React.FC<RouteModule.Step1PassProps> = ({ form, disabled }) 
                         label={formatMessage({ id: 'page.route.form.itemLabel.regex' })}
                         name={field.name}
                         key={field.name}
+                        rules={[
+                          {
+                            required: true,
+                            message: `${formatMessage({
+                              id: 'component.global.pleaseEnter',
+                            })} ${formatMessage({ id: 'page.route.form.itemLabel.regex' })}`,
+                          },
+                        ]}
                       >
                         <Input
                           placeholder={`${formatMessage({
@@ -93,14 +101,6 @@ const ProxyRewrite: React.FC<RouteModule.Step1PassProps> = ({ form, disabled }) 
                         label={formatMessage({ id: 'page.route.form.itemLabel.template' })}
                         name={field.name}
                         key={field.name}
-                        rules={[
-                          {
-                            required: true,
-                            message: `${formatMessage({
-                              id: 'component.global.pleaseEnter',
-                            })} ${formatMessage({ id: 'page.route.form.itemLabel.template' })}`,
-                          },
-                        ]}
                       >
                         <Input
                           placeholder={`${formatMessage({


### PR DESCRIPTION
**Why submit this pull request?**
proxy-rewrtie.plugin regex_uri support empty value
- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

Please update this section with detailed description.
take out regex_uri require=true
**Related issues**

fix/resolve [#0001](https://github.com/apache/apisix-dashboard/issues/2381)

**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [x] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first
