### PR TITLE
fix: The bug of missing secret field and algorithm when creating jwt-auth has been solved

### DIFF
--- a/api/internal/handler/consumer/consumer.go
+++ b/api/internal/handler/consumer/consumer.go
@@ -17,6 +17,8 @@
 package consumer
 
 import (
+	"encoding/base64"
+	"math/rand"
 	"reflect"
 	"strings"
 	"time"
@@ -174,6 +176,12 @@ func ensurePluginsDefValue(plugins map[string]interface{}) {
 		if ok && jwtAuth["exp"] == nil {
 			jwtAuth["exp"] = 86400
 		}
+		if ok && jwtAuth["algorithm"] == nil {
+			jwtAuth["algorithm"] = "HS256"
+		}
+		if ok && jwtAuth["secret"] == nil {
+			jwtAuth["secret"] = creatSecret(32)
+		}
 	}
 }
 
@@ -189,4 +197,16 @@ func (h *Handler) BatchDelete(c droplet.Context) (interface{}, error) {
 	}
 
 	return nil, nil
+}
+
+var letterRunes = []byte("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+func creatSecret(n int) string {
+	arr := make([]byte, n)
+	length := len(letterRunes)
+	rand.Seed(time.Now().Unix())
+	for i := range arr {
+		arr[i] = letterRunes[rand.Intn(length)]
+	}
+	return base64.StdEncoding.EncodeToString(arr)
 }

--- a/api/test/e2enew/route/route_with_plugin_jwt_test.go
+++ b/api/test/e2enew/route/route_with_plugin_jwt_test.go
@@ -199,7 +199,7 @@ var _ = ginkgo.Describe("route with jwt plugin", func() {
 			Headers:      map[string]string{"Authorization": base.GetToken()},
 			ExpectStatus: http.StatusOK,
 			ExpectBody: []string{`"code":0`, `"username":"consumer_1"`,
-				`"jwt-auth":{"exp":86400,"key":"user-key","secret":"my-secret-key"}`},
+				`"jwt-auth":{"algorithm":"HS256","exp":86400,"key":"user-key","secret":"my-secret-key"}`},
 		}),
 		table.Entry("get the consumer", base.HttpTestCase{
 			Object:       base.ManagerApiExpect(),


### PR DESCRIPTION
…empty, it will be assigned as HS256. If the secret is empty, a secret will be automatically generated.

Please answer these questions before submitting a pull request, **or your PR will get closed**.

**Why submit this pull request?**

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

The bug of missing secret field and algorithm when creating jwt-auth has been solved

**Related issues**

resolve #2384

**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [x] Have you added corresponding test cases?
- [x] Have you modified the corresponding document?
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first
