### PR TITLE
fix: Fix Copyright notice

### DIFF
--- a/web/src/components/Footer/index.tsx
+++ b/web/src/components/Footer/index.tsx
@@ -20,7 +20,7 @@ import { DefaultFooter } from '@ant-design/pro-layout';
 
 export default () => (
   <DefaultFooter
-    copyright="2021 Apache APISIX"
+    copyright="2019 Apache APISIX"
     links={[
       {
         key: 'GitHub',


### PR DESCRIPTION
  From [Wikipedia](https://en.wikipedia.org/wiki/Copyright#Copyright_notice):

  1) United States law required the use of a copyright notice, consisting of the
  copyright symbol (©, the letter C inside a circle), the abbreviation "Copr.",
  or the word "Copyright", **followed by the year of the first publication** of the
  work and the name of the copyright holder.

  2) In 1989 the United States enacted the Berne Convention Implementation Act,
  amending the 1976 Copyright Act to conform to most of the provisions of the
  Berne Convention. As a result, the use of copyright notices has become
  optional to claim copyright, because the Berne Convention makes copyright
  automatic.

Please answer these questions before submitting a pull request, **or your PR will get closed**.

**Why submit this pull request?**

- [ ] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**Checklist:**

- [X] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first
