### PR TITLE
fix: correct data  type of filed Active.checks.active.https_verify_certificate

### DIFF
--- a/api/internal/core/entity/entity.go
+++ b/api/internal/core/entity/entity.go
@@ -133,7 +133,7 @@ type Active struct {
 	Host                   string       `json:"host,omitempty"`
 	Port                   int          `json:"port,omitempty"`
 	HTTPPath               string       `json:"http_path,omitempty"`
-	HTTPSVerifyCertificate string       `json:"https_verify_certificate,omitempty"`
+	HTTPSVerifyCertificate bool         `json:"https_verify_certificate,omitempty"`
 	Healthy                Healthy      `json:"healthy,omitempty"`
 	UnHealthy              UnHealthy    `json:"unhealthy,omitempty"`
 	ReqHeaders             []string     `json:"req_headers,omitempty"`

--- a/api/internal/core/entity/entity.go
+++ b/api/internal/core/entity/entity.go
@@ -133,7 +133,7 @@ type Active struct {
 	Host                   string       `json:"host,omitempty"`
 	Port                   int          `json:"port,omitempty"`
 	HTTPPath               string       `json:"http_path,omitempty"`
-	HTTPSVerifyCertificate  bool         `json:"https_verify_certificate,omitempty"`
+	HTTPSVerifyCertificate bool         `json:"https_verify_certificate,omitempty"`
 	Healthy                Healthy      `json:"healthy,omitempty"`
 	UnHealthy              UnHealthy    `json:"unhealthy,omitempty"`
 	ReqHeaders             []string     `json:"req_headers,omitempty"`

--- a/api/internal/core/entity/entity.go
+++ b/api/internal/core/entity/entity.go
@@ -133,7 +133,7 @@ type Active struct {
 	Host                   string       `json:"host,omitempty"`
 	Port                   int          `json:"port,omitempty"`
 	HTTPPath               string       `json:"http_path,omitempty"`
-	HTTPSVerifyCertificate bool         `json:"https_verify_certificate,omitempty"`
+	HTTPSVerifyCertificate  bool         `json:"https_verify_certificate,omitempty"`
 	Healthy                Healthy      `json:"healthy,omitempty"`
 	UnHealthy              UnHealthy    `json:"unhealthy,omitempty"`
 	ReqHeaders             []string     `json:"req_headers,omitempty"`


### PR DESCRIPTION
Please answer these questions before submitting a pull request, **or your PR will get closed**.

**Why submit this pull request?**

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**
i set  active health check  with https , and filed  `Active.checks.active.https_verify_certificate`  in request body  was true ( bool ).  it return error (json: cannot unmarshal bool into Go struct field Active.checks.active.https_verify_certificate of type string).   it is  filed `Active.checks.active.https_verify_certificate `in golang  that is a string ，different to  filed  `Active.checks.active.https_verify_certificate`  in request.  it  is  , alse ,  different  with   the  one  schema defined in   apisix.


Please update this section with detailed description.

**Related issues**


**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first


