### PR TITLE
fix: tmp is not writable on sandboxed environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,5 @@ web/public/monaco-editor/
 *.swp
 *.swo
 
+# tmp
+tmp/

--- a/Makefile
+++ b/Makefile
@@ -59,10 +59,10 @@ endif
 .PHONY: dag-lib
 dag-lib:
 ifeq ("$(wildcard api/dag-to-lua/dag-to-lua.lua)", "")
-	curl -Lso /tmp/v1.1.tar.gz https://github.com/api7/dag-to-lua/archive/v1.1.tar.gz
-	tar -zxvf /tmp/v1.1.tar.gz -C /tmp
+	curl -Lso ./tmp/v1.1.tar.gz https://github.com/api7/dag-to-lua/archive/v1.1.tar.gz
+	tar -zxvf ./tmp/v1.1.tar.gz -C ./tmp
 	mkdir ./api/dag-to-lua
-	cp -r /tmp/dag-to-lua-1.1/lib/* ./api/dag-to-lua
+	cp -r ./tmp/dag-to-lua-1.1/lib/* ./api/dag-to-lua
 endif
 
 

--- a/api/build.sh
+++ b/api/build.sh
@@ -36,9 +36,9 @@ rm -rf output && mkdir -p output/conf && mkdir -p output/dag-to-lua
 
 # get dag-to-lua lib
 if [[ ! -f "dag-to-lua-1.1/lib/dag-to-lua.lua" ]]; then
-    wget https://github.com/api7/dag-to-lua/archive/v1.1.tar.gz -P /tmp
-    tar -zxvf /tmp/v1.1.tar.gz -C /tmp
-    cp -r /tmp/dag-to-lua-1.1/lib/* ./output/dag-to-lua
+    wget https://github.com/api7/dag-to-lua/archive/v1.1.tar.gz -P ./tmp
+    tar -zxvf ./tmp/v1.1.tar.gz -C ./tmp
+    cp -r ./tmp/dag-to-lua-1.1/lib/* ./output/dag-to-lua
 fi
 
 # build


### PR DESCRIPTION
Please answer these questions before submitting a pull request, **or your PR will get closed**.

**Why submit this pull request?**
When building on Android termux environment, tmp is mounted as read-only volume, this pr fixes the download error on make build.

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

Please update this section with detailed description.

**Related issues**

fix/resolve #0001

**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first
