### PR TITLE
doc(csp): add correct csp rule

### DIFF
--- a/api/conf/conf.yaml
+++ b/api/conf/conf.yaml
@@ -66,8 +66,7 @@ conf:
   #   access_control_allow_headers: "Authorization"
   #   access_control-allow_methods: "*"
   #   x_frame_options: "deny"
-  #   content_security_policy: ""default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'""
-
+  #   content_security_policy: "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; frame-src xx.xx.xx.xx:3000"  # You can set frame-src to provide content for your grafana panel.
 
 authentication:
   secret:

--- a/api/conf/conf.yaml
+++ b/api/conf/conf.yaml
@@ -66,7 +66,7 @@ conf:
   #   access_control_allow_headers: "Authorization"
   #   access_control-allow_methods: "*"
   #   x_frame_options: "deny"
-  #   content_security_policy: ""default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; frame-src xx.xx.xx.xx:3000""  # You can set frame-src to provide content for your grafana panel.
+  #   content_security_policy: "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; frame-src xx.xx.xx.xx:3000"  # You can set frame-src to provide content for your grafana panel.
 
 authentication:
   secret:

--- a/api/conf/conf.yaml
+++ b/api/conf/conf.yaml
@@ -66,7 +66,7 @@ conf:
   #   access_control_allow_headers: "Authorization"
   #   access_control-allow_methods: "*"
   #   x_frame_options: "deny"
-  #   content_security_policy: "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; frame-src xx.xx.xx.xx:3000"  # You can set frame-src to provide content for your grafana panel.
+  #   content_security_policy: ""default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; frame-src xx.xx.xx.xx:3000""  # You can set frame-src to provide content for your grafana panel.
 
 authentication:
   secret:

--- a/docs/en/latest/USER_GUIDE.md
+++ b/docs/en/latest/USER_GUIDE.md
@@ -27,6 +27,8 @@ The following are parts of the modules' snapshot.
 
 We support the monitor page by referencing it in [iframe](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe). Before accessing [Grafana](https://grafana.com/), please Enable [`allow_embedding=true`](https://grafana.com/docs/grafana/latest/administration/configuration/#allow_embedding), which defaults to `false`. This causes the browser to fail to render Grafana pages properly due to security policies.
 
+Solving this problem requires you to configure some csp rules. Please check the default configuration options for details. You can refer to this [link](https://github.com/apache/apisix-dashboard/blob/master/api/conf/conf.yaml) for the recommand rule.
+
 ![Dashboard-en](https://user-images.githubusercontent.com/40708551/112922395-0eed0380-912a-11eb-8c92-4c67d2bae4a8.png)
 
 ## Route


### PR DESCRIPTION
This PR is primarily intended to address the issue of not displaying embedded Grafana dashboards properly.
The issue can be viewed in this issue #2546 .

This issue is caused by the Dashboard updating the CSP (content security policy) feature. You need to add the appropriate configuration for the Grafana dashboard to display properly. This simply adds the configuration options that have been validated and the corresponding documentation.

This PR can also be referenced by the [APISIX-Docker project](https://github.com/apache/apisix-docker/pull/340).

**Why submit this pull request?**

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

Please update this section with detailed description.

fix #2546 

**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [x] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first
