### PR TITLE
feat: allow starting error report when use systemd

### DIFF
--- a/api/cmd/root.go
+++ b/api/cmd/root.go
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package cmd
 
 import (
@@ -50,6 +51,7 @@ func init() {
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
 		_, _ = fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
 	}
 }
 

--- a/api/service/apisix-dashboard.service
+++ b/api/service/apisix-dashboard.service
@@ -4,5 +4,6 @@ Conflicts=apisix-dashboard.service
 After=network-online.target
 
 [Service]
+Type=forking
 WorkingDirectory=/usr/local/apisix-dashboard
 ExecStart=/usr/local/apisix-dashboard/manager-api -c /usr/local/apisix-dashboard/conf/conf.yaml

--- a/api/test/shell/cli_test.sh
+++ b/api/test/shell/cli_test.sh
@@ -88,6 +88,7 @@ stop_dashboard() {
   cp ./manager-api /usr/local/apisix-dashboard
 
   # create systemd service
+  sed -i '7d' ./service/apisix-dashboard.service
   cp ./service/apisix-dashboard.service /usr/lib/systemd/system/${SERVICE_NAME}.service
   run systemctl daemon-reload
   [ "$status" -eq 0 ]


### PR DESCRIPTION
Please answer these questions before submitting a pull request, **or your PR will get closed**.

**Why submit this pull request?**

- [ ] Bugfix
- [ ] New feature provided
- [x] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

Currently, when users use systemd, if manager-api fails to start, users will not receive a report and need to check it themselves using `systemctl status`. This PR improves this problem, when `systemctl start`, it will block and wait for the startup to complete, when the startup fails, the user will receive the report immediately.

**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first
