### PR TITLE
feat(route): make front-end adapt `route` v3 api modification

### DIFF
--- a/web/cypress/support/commands.js
+++ b/web/cypress/support/commands.js
@@ -26,7 +26,7 @@ Cypress.Commands.add('login', () => {
     username: 'user',
     password: 'user',
   }).then((res) => {
-    expect(res.body.code).to.equal(0);
+    expect(res.body.success).is.true;
     localStorage.setItem('token', res.body.data.token);
     // set default language
     localStorage.setItem('umi_locale', 'en-US');
@@ -153,7 +153,7 @@ Cypress.Commands.add('requestWithToken', ({ method, url, payload }) => {
     body: payload,
     headers: { Authorization: localStorage.getItem('token') },
   }).then((res) => {
-    expect(res.body.code).to.equal(0);
+    expect(res.body.success).to.true;
     return res;
   });
 });

--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -96,8 +96,8 @@ export const request: RequestConfig = {
       }
 
       const data = await res.json();
-      const { code = -1 } = data as Res<any>;
-      if (code !== 0) {
+      const { success = false } = data as Res<any>;
+      if (!success) {
         // eslint-disable-next-line
         return Promise.reject({ response: res, data });
       }

--- a/web/src/pages/Route/List.tsx
+++ b/web/src/pages/Route/List.tsx
@@ -364,7 +364,7 @@ const Page: React.FC = () => {
           .filter((item) => item !== 'API_VERSION')
           .map((item) => (
             <Tag key={Math.random().toString(36).slice(2)}>
-              {item}:{record.labels[item]}
+              {item}:{record.labels?.[item]}
             </Tag>
           ));
       },
@@ -412,7 +412,7 @@ const Page: React.FC = () => {
       render: (_, record) => {
         return Object.keys(record.labels || {})
           .filter((item) => item === 'API_VERSION')
-          .map((item) => record.labels[item]);
+          .map((item) => record.labels?.[item]);
       },
       renderFormItem: (_, { type }) => {
         if (type === 'form') {
@@ -549,7 +549,8 @@ const Page: React.FC = () => {
         tableAlertRender={() => (
           <Space size={24}>
             <span>
-            {formatMessage({ id: 'page.route.chosen' })} {selectedRowKeys.length} {formatMessage({ id: 'page.route.item' })}
+              {formatMessage({ id: 'page.route.chosen' })} {selectedRowKeys.length}{' '}
+              {formatMessage({ id: 'page.route.item' })}
             </span>
           </Space>
         )}
@@ -557,16 +558,17 @@ const Page: React.FC = () => {
           return (
             <Space size={16}>
               <Button
-               onClick={async () => {
-               await remove(selectedRowKeys).then(() => {
-                handleTableActionSuccessResponse(
-                  `${formatMessage({ id: 'component.global.delete.routes.success' })}`,
-                );
-               });
-               ref.current?.reloadAndRest?.();
-             }}>
-             {formatMessage({ id: 'page.route.batchDeletion' })}
-             </Button>
+                onClick={async () => {
+                  await remove(selectedRowKeys).then(() => {
+                    handleTableActionSuccessResponse(
+                      `${formatMessage({ id: 'component.global.delete.routes.success' })}`,
+                    );
+                  });
+                  ref.current?.reloadAndRest?.();
+                }}
+              >
+                {formatMessage({ id: 'page.route.batchDeletion' })}
+              </Button>
             </Space>
           );
         }}

--- a/web/src/pages/Route/typing.d.ts
+++ b/web/src/pages/Route/typing.d.ts
@@ -67,21 +67,21 @@ declare namespace RouteModule {
 
   // Request Body or Response Data for API
   type Body = {
-    id?: number;
+    id?: string;
     status: number;
-    name: string;
-    labels: Record<string, string>;
-    desc: string;
+    name?: string;
+    labels?: Record<string, string>;
+    desc?: string;
     priority?: number;
     methods: HttpMethod[];
     uri?: string;
-    uris: string[];
+    uris?: string[];
     host?: string;
     hosts?: string[];
     remote_addr?: string;
     remote_addrs?: string[];
     upstream: UpstreamComponent.ResponseData;
-    vars: VarTuple[];
+    vars?: VarTuple[];
     upstream_path?: {
       type?: string;
       from?: string;
@@ -90,7 +90,7 @@ declare namespace RouteModule {
     upstream_id?: string;
     plugins: Record<string, any>;
     plugin_config_id?: string;
-    script: Record<string, any>;
+    script?: Record<string, any>;
     url?: string;
     enable_websocket?: boolean;
     service_id?: string;
@@ -190,30 +190,40 @@ declare namespace RouteModule {
   };
 
   type ResponseBody = {
-    id: string;
-    methods: HttpMethod[];
-    name: string;
-    remote_addrs: string[];
-    script: any;
-    desc?: string;
-    labels: Record<string, string>;
-    upstream: {
-      checks: UpstreamModule.HealthCheck;
-      create_time: number;
-      id: string;
-      nodes: {
-        port: number;
-      }[];
-      timeout: UpstreamModule.Timeout;
-      type: UpstreamModule.Type;
-    };
-    uri: string;
-    uris?: string[];
-    host: string;
-    hosts?: string[];
     create_time: number;
     update_time: number;
+    id: string;
+    methods: HttpMethod[];
+    name?: string;
+    desc?: string;
+    host?: string;
+    hosts?: string[];
+    plugins: Plugins;
+    priority: number;
     status: number;
+    upstream: Upstream;
+    uri?: string;
+    uris?: string[];
+    labels?: Record<string, string>;
+    vars?: VarTuple[];
+    script?: Record<string, unknown>;
+    remote_addr?: string;
+    remote_addrs?: string[];
+    upstream_id?: string;
+    plugin_config_id?: string;
+    service_id?: string;
+    enable_websocket?: boolean;
+  };
+
+  type Plugins = Record<keyof any, Record<string, unknown>>[];
+
+  type Upstream = {
+    hash_on: string;
+    nodes: Record<string, number>;
+    pass_host: string;
+    scheme: string;
+    type: string;
+    upstream_id?: string;
   };
 
   type RouteStatus = 0 | 1;

--- a/web/src/typings.d.ts
+++ b/web/src/typings.d.ts
@@ -56,15 +56,19 @@ declare const REACT_APP_ENV: 'test' | 'dev' | 'pre' | false;
 type PageMode = 'CREATE' | 'EDIT' | 'VIEW';
 
 type Res<T> = {
-  code: number;
   message: string;
-  request_id: string;
+  success: boolean;
   data: T;
 };
 
 type ResListData<T> = {
-  rows: T[];
-  total_size: number;
+  list: T[];
+  total: number;
+};
+
+type ResKeyValue<T> = {
+  key: string;
+  value: T;
 };
 
 type HttpMethod =


### PR DESCRIPTION
Please answer these questions before submitting a pull request, **or your PR will get closed**.

**Why submit this pull request?**

- [ ] Bugfix
- [x] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

Adapt the route part of the front-end for the v3 API interface.

It seems that `/labels/route` is missing in v3. This spawns Network Error notification which prevents tests from passing. Should I query all route data and collect the labels?

Tests of `route` fails due to:

- create process depends on other modules, like `upstream` which haven't been adapted yet
- missing apis in v3

I have modified some of the frontend code using the info in the Postman api docs. Tell me if I could do better.

### Code that block tests

- `batch-delete-route` test

  - `/labels/route` notification prevents cy from clicking the button
  - missing api

- `create-route-*` test

  - create process depends on `upstream`

- `data-loader-import` test

  - missing api

- `search-route` test

  - depends on create process

- `table-auto-jump-when-no-data` test

  - `/labels/route` notification prevents cy from clicking the button


**Related issues**

fix/resolve #2636 

**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first
