### PR TITLE
fix: bump go version to 1.16

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/apisix/manager-api
 
-go 1.15
+go 1.16
 
 require (
 	github.com/coreos/go-oidc/v3 v3.3.0

--- a/docs/en/latest/install.md
+++ b/docs/en/latest/install.md
@@ -75,7 +75,7 @@ Before using source codes to build, make sure that the following dependencies ar
 
 For `manager-api`:
 
-1. [Golang](https://golang.org/dl/) 1.13+
+1. [Golang](https://golang.org/dl/) 1.16+
 
 > Tip: For users in mainland China, you can use the following command to speed up the module downloads.
 


### PR DESCRIPTION
Please answer these questions before submitting a pull request, **or your PR will get closed**.

**Why submit this pull request?**

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

User who install apisix-dashboard from source will know go version need 1.16+

**Related issues**

https://github.com/apache/apisix-dashboard/issues/2673#issuecomment-1333524852

because of etcd client v3.5.5 require `io/fs`, then we need upgrade go version to 1.16+

**Checklist:**

- [ ] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first
