### PR TITLE
chore: optimize "allow_origins_by_regex tooltip" description

### DIFF
--- a/web/src/components/Plugin/locales/en-US.ts
+++ b/web/src/components/Plugin/locales/en-US.ts
@@ -49,7 +49,7 @@ export default {
   'component.pluginForm.cors.allow_origins_by_metadata.tooltip':
     'Match which origin is allowed to enable CORS by referencing allow_origins set in plugin metadata.',
   'component.pluginForm.cors.allow_origins_by_regex.tooltip':
-    'Use regex expressions to match which origin is allowed to enable CORS, for example, [".*.test.com"] can use to match all subdomain of test.com.',
+    'Use regex expressions to match which origin is allowed to enable CORS. Each form can only be configured with a single, standalone regular expression, such as ".*.test.com" which can match any subdomain of test.com.',
 
   // referer-restriction
   'component.pluginForm.referer-restriction.whitelist.tooltip':

--- a/web/src/components/Plugin/locales/en-US.ts
+++ b/web/src/components/Plugin/locales/en-US.ts
@@ -49,7 +49,7 @@ export default {
   'component.pluginForm.cors.allow_origins_by_metadata.tooltip':
     'Match which origin is allowed to enable CORS by referencing allow_origins set in plugin metadata.',
   'component.pluginForm.cors.allow_origins_by_regex.tooltip':
-    'Use regex expressions to match which origin is allowed to enable CORS. Each form can only be configured with a single, standalone regular expression, such as ".*.test.com" which can match any subdomain of test.com.',
+    'Use regex expressions to match which origin is allowed to enable CORS. Each input box can only be configured with a single, standalone regular expression, such as ".*.test.com" which can match any subdomain of test.com.',
 
   // referer-restriction
   'component.pluginForm.referer-restriction.whitelist.tooltip':

--- a/web/src/components/Plugin/locales/tr-TR.ts
+++ b/web/src/components/Plugin/locales/tr-TR.ts
@@ -49,7 +49,7 @@ export default {
   'component.pluginForm.cors.allow_origins_by_metadata.tooltip':
     'Eklenti meta verilerindeki allow_origins kümesine başvurarak CORSu etkinleştirmek için hangi Origine izin verildiğini eşleştirin.',
   'component.pluginForm.cors.allow_origins_by_regex.tooltip':
-    'CORSu etkinleştirmek için hangi Origine izin verildiğini eşleştirmek için normal ifade ifadeleri kullanın, örneğin, [".*.test.com"], test.comun tüm alt alan adlarını eşleştirmek için kullanabilir.',
+    'CORSu etkinleştirmek için izin verilen kaynakları eşleştirmek için regex ifadelerini kullanın. Her form sadece tek bir, bağımsız düzenli ifadeyle yapılandırılabilir, örneğin ".*.test.com" gibi, test.com\'un her alt etki alanını eşleştirebilir.',
   // referer-restriction
   'component.pluginForm.referer-restriction.whitelist.tooltip':
     'Whiteliste alınacak ana bilgisayar adı listesi. Ana bilgisayar adı, joker karakter olarak * ile başlatılabilir.',

--- a/web/src/components/Plugin/locales/tr-TR.ts
+++ b/web/src/components/Plugin/locales/tr-TR.ts
@@ -49,7 +49,7 @@ export default {
   'component.pluginForm.cors.allow_origins_by_metadata.tooltip':
     'Eklenti meta verilerindeki allow_origins kümesine başvurarak CORSu etkinleştirmek için hangi Origine izin verildiğini eşleştirin.',
   'component.pluginForm.cors.allow_origins_by_regex.tooltip':
-    'CORSu etkinleştirmek için izin verilen kaynakları eşleştirmek için regex ifadelerini kullanın. Her form sadece tek bir, bağımsız düzenli ifadeyle yapılandırılabilir, örneğin ".*.test.com" gibi, test.com\'un her alt etki alanını eşleştirebilir.',
+    'CORSu etkinleştirmek için izin verilen kaynakları eşleştirmek için regex ifadelerini kullanın. Her giriş kutusu yalnızca bir bağımsız normal ifade ile yapılandırılabilir, örneğin ".*.test.com" gibi, test.com\'un her alt etki alanını eşleştirebilir.',
   // referer-restriction
   'component.pluginForm.referer-restriction.whitelist.tooltip':
     'Whiteliste alınacak ana bilgisayar adı listesi. Ana bilgisayar adı, joker karakter olarak * ile başlatılabilir.',

--- a/web/src/components/Plugin/locales/zh-CN.ts
+++ b/web/src/components/Plugin/locales/zh-CN.ts
@@ -48,7 +48,7 @@ export default {
   'component.pluginForm.cors.allow_origins_by_metadata.tooltip':
     '通过引用插件元数据的 allow_origins 配置允许跨域访问的 Origin。',
   'component.pluginForm.cors.allow_origins_by_regex.tooltip':
-    '使用正则表达式来匹配允许跨域访问的 Origin, 每一个表单仅可以配置一个独立的正则表达式，如".*.test.com" 可以匹配任何test.com的子域名 * 。',
+    '使用正则表达式来匹配允许跨域访问的 Origin, 每一个输入框仅可以配置一个独立的正则表达式，如".*.test.com" 可以匹配任何test.com的子域名 * 。',
 
   // referer-restriction
   'component.pluginForm.referer-restriction.whitelist.tooltip':

--- a/web/src/components/Plugin/locales/zh-CN.ts
+++ b/web/src/components/Plugin/locales/zh-CN.ts
@@ -48,7 +48,7 @@ export default {
   'component.pluginForm.cors.allow_origins_by_metadata.tooltip':
     '通过引用插件元数据的 allow_origins 配置允许跨域访问的 Origin。',
   'component.pluginForm.cors.allow_origins_by_regex.tooltip':
-    '使用正则表达式数组来匹配允许跨域访问的 Origin, 如[".*.test.com"] 可以匹配任何test.com的子域名 * 。',
+    '使用正则表达式来匹配允许跨域访问的 Origin, 每一个表单仅可以配置一个独立的正则表达式，如".*.test.com" 可以匹配任何test.com的子域名 * 。',
 
   // referer-restriction
   'component.pluginForm.referer-restriction.whitelist.tooltip':


### PR DESCRIPTION
On the Cors plugin config page, the allow_origins_by_regex help message is misleading the user.

This PR optimize "allow_origins_by_regex tooltip" description。

**Related issues**

fix/resolve #2669

