### PR TITLE
fix: Plugin disable invalid in API /plugin?all=true

### DIFF
--- a/api/internal/handler/schema/plugin.go
+++ b/api/internal/handler/schema/plugin.go
@@ -51,8 +51,11 @@ func (h *Handler) Plugins(c droplet.Context) (interface{}, error) {
 	if input.All {
 		var res []map[string]interface{}
 		list := plugins.Value().(map[string]interface{})
-		for name, conf := range list {
-			plugin := conf.(map[string]interface{})
+		for name, schemaConfig := range list {
+			if enable, ok := conf.Plugins[name]; !ok || !enable {
+				continue
+			}
+			plugin := schemaConfig.(map[string]interface{})
 			plugin["name"] = name
 			if _, ok := plugin["type"]; !ok {
 				plugin["type"] = "other"
@@ -65,7 +68,7 @@ func (h *Handler) Plugins(c droplet.Context) (interface{}, error) {
 	var ret []string
 	list := plugins.Map()
 	for pluginName := range list {
-		if res, ok := conf.Plugins[pluginName]; !ok || !res {
+		if enable, ok := conf.Plugins[pluginName]; !ok || !enable {
 			continue
 		}
 

--- a/api/test/e2e/route/route_with_plugin_jwt_test.go
+++ b/api/test/e2e/route/route_with_plugin_jwt_test.go
@@ -311,6 +311,13 @@ var _ = Describe("route with jwt plugin", func() {
 			Headers:      map[string]string{"Authorization": base.GetToken()},
 			ExpectStatus: http.StatusOK,
 		}),
+		Entry("delete the route", base.HttpTestCase{
+			Object:       base.ManagerApiExpect(),
+			Method:       http.MethodDelete,
+			Path:         "/apisix/admin/routes/jwt-sign",
+			Headers:      map[string]string{"Authorization": base.GetToken()},
+			ExpectStatus: http.StatusOK,
+		}),
 		Entry("verify the deleted route", base.HttpTestCase{
 			Object:       base.APISIXExpect(),
 			Method:       http.MethodGet,


### PR DESCRIPTION

**Why submit this pull request?**

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

I tried to disable the plugin in the configuration plugins content of `conf.yaml` when answering the issue question and it didn't work. After reading the code in the plugin section, I found that in a previously submitted PR https://github.com/apache/apisix-dashboard/pull/1592, the judgment of whether the plugin is enabled or not was removed. So this PR I fixes the problem and support disabling plugins in `conf.yaml` plugins.


**Related issues**

fix/resolve #2735

**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first
