### PR TITLE
fix: locked input to a min of "0" for Retries

### DIFF
--- a/web/src/components/Upstream/components/Retries.tsx
+++ b/web/src/components/Upstream/components/Retries.tsx
@@ -30,7 +30,7 @@ const Component: React.FC<Props> = ({ readonly }) => {
       tooltip={formatMessage({ id: 'component.upstream.fields.retries.tooltip' })}
       name="retries"
     >
-      <InputNumber disabled={readonly} />
+      <InputNumber disabled={readonly} min={0} />
     </Form.Item>
   );
 };


### PR DESCRIPTION
**Why submit this pull request?**

- [x] Bugfix
- [x] Improve performance ?

**What changes will this PR take into?**

In the Apisix dashboard, in the inputfield of `Retries` under [Services](https://apisix-dashboard.apiseven.com/service/create), we cannot set a negative value as of currently it doesn't supports it. Hence the up/down arrows have no function if the value is in the negative range.

RE: Primarily we can apply a `visibility: hidden` for `.ant-input-number-handler-wrap`, but I think the better way is to not remove those ` up/down ` arrows and instead, we can lock the input to a *minimum value of* **0**.

**Related issues**

resolves #2775

**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first

cc: @Baoyuantop, @freemankevin
