### PR TITLE
feat: allow to use env variables in config

### DIFF
--- a/api/internal/conf/conf.go
+++ b/api/internal/conf/conf.go
@@ -186,14 +186,14 @@ func InitConf() {
 	initSchema()
 }
 
-func unmarshalConfig() *Config {
+func unmarshalConfig() (*Config, error) {
 	config := Config{}
 	err := viper.Unmarshal(&config, viper.DecodeHook(substituteEnvironmentVariables()))
 	if err != nil {
-		panic(fmt.Sprintf("fail to unmarshal configuration: %s, err: %s", ConfigFile, err.Error()))
+		return nil, err
 	}
 
-	return &config
+	return &config, nil
 }
 
 func setupConfig() {
@@ -216,7 +216,10 @@ func setupConfig() {
 	}
 
 	// unmarshal config
-	config := unmarshalConfig()
+	config, err := unmarshalConfig()
+	if err != nil {
+		panic(fmt.Sprintf("fail to unmarshal configuration: %s, err: %s", ConfigFile, err.Error()))
+	}
 
 	// listen
 	if config.Conf.Listen.Port != 0 {
@@ -259,7 +262,7 @@ func setupConfig() {
 		if strings.HasPrefix(ErrorLogPath, "winfile") {
 			return
 		}
-		ErrorLogPath, err := filepath.Abs(filepath.Join(WorkDir, ErrorLogPath))
+		ErrorLogPath, err = filepath.Abs(filepath.Join(WorkDir, ErrorLogPath))
 		if err != nil {
 			panic(err)
 		}
@@ -271,7 +274,7 @@ func setupConfig() {
 		if strings.HasPrefix(AccessLogPath, "winfile") {
 			return
 		}
-		AccessLogPath, err := filepath.Abs(filepath.Join(WorkDir, AccessLogPath))
+		AccessLogPath, err = filepath.Abs(filepath.Join(WorkDir, AccessLogPath))
 		if err != nil {
 			panic(err)
 		}

--- a/api/internal/conf/conf_test.go
+++ b/api/internal/conf/conf_test.go
@@ -1,9 +1,12 @@
 package conf
 
 import (
+	"bytes"
 	"encoding/json"
+	"os"
 	"testing"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -58,6 +61,63 @@ func Test_mergeSchema(t *testing.T) {
 			err = json.Unmarshal(tt.wantRes, &wantMap)
 			assert.NoError(t, err)
 			assert.Equal(t, wantMap, gotMap)
+		})
+	}
+}
+
+func Test_unmarshalConfig(t *testing.T) {
+	tests := []struct {
+		name   string
+		init   func()
+		config []byte
+		assert func(*Config, *testing.T)
+	}{
+		{
+			name:   "should correctly parse config without environment variables",
+			init:   func() {},
+			config: []byte("conf:\n  listen:\n    port: \"9000\""),
+			assert: func(config *Config, t *testing.T) {
+				assert.Equal(t, 9000, config.Conf.Listen.Port)
+			},
+		},
+		{
+			name: "should correctly substitute int port from environment variables",
+			init: func() {
+				os.Setenv("PORT", "8080")
+			},
+			config: []byte("conf:\n  listen:\n    port: \"$PORT\""),
+			assert: func(config *Config, t *testing.T) {
+				assert.Equal(t, 8080, config.Conf.Listen.Port)
+			},
+		},
+		{
+			name: "should correctly substitute string etcd endpoint from environment variables",
+			init: func() {
+				os.Setenv("ETCD_ENDPOINT", "127.0.0.1:2379")
+			},
+			config: []byte("conf:\n  etcd:\n    endpoints:\n      - $ETCD_ENDPOINT"),
+			assert: func(config *Config, t *testing.T) {
+				assert.Equal(t, "127.0.0.1:2379", config.Conf.Etcd.Endpoints[0])
+			},
+		},
+	}
+
+	for _, tt := range tests {
+
+		t.Run(tt.name, func(t *testing.T) {
+			viper.SetConfigType("yaml")
+			viper.AutomaticEnv()
+
+			tt.init()
+
+			err := viper.ReadConfig(bytes.NewBuffer(tt.config))
+			if err != nil {
+				t.Errorf("unable to read config: %v", err)
+				return
+			}
+			config := unmarshalConfig()
+
+			tt.assert(config, t)
 		})
 	}
 }

--- a/api/internal/conf/conf_test.go
+++ b/api/internal/conf/conf_test.go
@@ -115,7 +115,11 @@ func Test_unmarshalConfig(t *testing.T) {
 				t.Errorf("unable to read config: %v", err)
 				return
 			}
-			config := unmarshalConfig()
+			config, err := unmarshalConfig()
+			if err != nil {
+				t.Errorf("unable to unmarshall config: %v", err)
+				return
+			}
 
 			tt.assert(config, t)
 		})


### PR DESCRIPTION
**Why submit this pull request?**

- [ ] Bugfix
- [x] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

This ticket adds an ability to use environment variables in the dashboard configuration using viper decode hooks. Such change is required to simplify dashboard configuration based on the environment type. For example can be useful to provide dashboard users and their passwords.

**Related issues**

https://github.com/apache/apisix-dashboard/issues/2818

**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [x] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [x] Is this PR backward compatible?
