### PR TITLE
fix upstream discovery args metadata field caused crash.

### DIFF
--- a/api/internal/core/entity/entity.go
+++ b/api/internal/core/entity/entity.go
@@ -171,7 +171,7 @@ type UpstreamDef struct {
 	Key           string                 `json:"key,omitempty"`
 	Scheme        string                 `json:"scheme,omitempty"`
 	DiscoveryType string                 `json:"discovery_type,omitempty"`
-	DiscoveryArgs map[string]string      `json:"discovery_args,omitempty"`
+	DiscoveryArgs map[string]interface{} `json:"discovery_args,omitempty"`
 	PassHost      string                 `json:"pass_host,omitempty"`
 	UpstreamHost  string                 `json:"upstream_host,omitempty"`
 	Name          string                 `json:"name,omitempty"`


### PR DESCRIPTION
Please answer these questions before submitting a pull request, **or your PR will get closed**.

**Why submit this pull request?**

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

Apisix and Apisix-seed support configuration of auto-discovery via Nacos with metadata field, which is an object instead of string, thus adding metadata field to discovery_args will cause apisix-dashboard to crash and unable to restart.
Error log message:
ERROR   store/store.go:405      json unmarshal failed: json: cannot unmarshal object into Go struct field Upstream.discovery_args of type string

**Related issues**

None.

**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [] Have you modified the corresponding document?
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first
