### PR TITLE
fix: reset submit status when upstream data invalid

### DIFF
--- a/web/src/pages/Upstream/Create.tsx
+++ b/web/src/pages/Upstream/Create.tsx
@@ -58,6 +58,7 @@ const Page: React.FC = (props) => {
         notification.error({
           message: formatMessage({ id: 'page.upstream.other.configuration.invalid' }),
         });
+        setSubmitLoading(false);
         return;
       }
 


### PR DESCRIPTION
When the upstream data is invalid, click submit button will notice error, but the submit button still show loading, user can not  resubmit after correct the data. So it needs to reset loading after notice error.

**Why submit this pull request?**

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

Create or update upstream with invalid data, the frontend will notice error and reset submit loading status.

**Related issues**

NA

**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first
