### PR TITLE
docs: support the command systemctl enable apisix-dashboard

### DIFF
--- a/docs/en/latest/install.md
+++ b/docs/en/latest/install.md
@@ -151,7 +151,10 @@ After=network-online.target
 
 [Service]
 WorkingDirectory=/usr/local/apisix-dashboard
-ExecStart=/usr/local/apisix-dashboard/manager-api -c /usr/local/apisix-dashboard/conf/conf.yaml" > /usr/lib/systemd/system/apisix-dashboard.service
+ExecStart=/usr/local/apisix-dashboard/manager-api -c /usr/local/apisix-dashboard/conf/conf.yaml
+
+[Install]
+WantedBy=multi-user.target" > /usr/lib/systemd/system/apisix-dashboard.service
 ```
 
 3. Manage service


### PR DESCRIPTION
Please answer these questions before submitting a pull request, **or your PR will get closed**.

**Why submit this pull request?**

- [ ] Bugfix
- [x] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

Add the following configuration to the document:

```
[Install]
WantedBy=multi-user.target
```

**Related issues**

We cannot use the command systemctl enable apisix-dashboard to configure startup

**Test case**

```
echo "[Unit]
Description=apisix-dashboard
Conflicts=apisix-dashboard.service
After=network-online.target

[Service]
WorkingDirectory=/usr/local/apisix-dashboard
ExecStart=/usr/local/apisix-dashboard/manager-api -c /usr/local/apisix-dashboard/conf/conf.yaml

[Install]
WantedBy=multi-user.target" > /usr/lib/systemd/system/apisix-dashboard.service
systemctl daemon-reload
systemctl enable apisix-dashboard
```

**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [x] Have you added corresponding test cases?
- [x] Have you modified the corresponding document?
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first
