### PR TITLE
 i18n: Need more language support #1407 

### DIFF
--- a/web/src/components/ActionBar/locales/fr-Fr.ts
+++ b/web/src/components/ActionBar/locales/fr-Fr.ts
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export default {
+  'component.actionbar.button.preStep': 'Précédent',
+  'component.actionbar.button.nextStep': 'Suivant',
+};

--- a/web/src/components/Plugin/locales/fr-Fr.ts
+++ b/web/src/components/Plugin/locales/fr-Fr.ts
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export default {
+  'component.plugin.tip1':
+    'NOTE : Après avoir personnalisé le plugin, vous devez mettre à jour schema.json.',
+  'component.plugin.tip2': 'Comment mettre à jour ?',
+  'component.select.pluginTemplate': 'Sélectionnez un modèle de plugin',
+  'component.step.select.pluginTemplate.select.option': 'Personnalisé',
+  'component.plugin.pluginTemplate.tip1':
+    "1. Lorsqu'une route a déjà le champ plugins configuré, les plugins dans le modèle de plugin seront fusionnés avec celui-ci.",
+  'component.plugin.pluginTemplate.tip2':
+    '2. Le même plugin dans le modèle de plugin remplacera celui dans les plugins.',
+  'component.plugin.enable': 'Activer',
+  'component.plugin.disable': 'Modifier',
+  'component.plugin.authentication': 'Authentification',
+  'component.plugin.security': 'Sécurité',
+  'component.plugin.traffic': 'Contrôle du trafic',
+  'component.plugin.serverless': 'Serverless',
+  'component.plugin.observability': 'Observabilité',
+  'component.plugin.other': 'Autre',
+  'component.plugin.all': 'Tout',
+  // cors
+  'component.pluginForm.cors.allow_origins.tooltip':
+    "Quelles origines sont autorisées à activer CORS, au format : scheme://host:port, par exemple : https://somehost.com:8081. Utilisez , pour séparer plusieurs origines. Lorsque allow_credential est false, vous pouvez utiliser * pour indiquer d'autoriser n'importe quelle origine. Vous pouvez également autoriser toutes les origines de force en utilisant ** même si allow_credential est déjà activé, mais cela présentera des risques de sécurité.",
+  'component.pluginForm.cors.allow_origins.extra': 'Par exemple : https://somehost.com:8081',
+  'component.pluginForm.cors.allow_methods.tooltip':
+    "Quelles méthodes sont autorisées à activer CORS, telles que : GET, POST, etc. Utilisez , pour séparer plusieurs méthodes. Lorsque allow_credential est false, vous pouvez utiliser * pour indiquer d'autoriser toutes les méthodes. Vous pouvez également autoriser n'importe quelle méthode de force en utilisant ** même si allow_credential est déjà activé, mais cela présentera des risques de sécurité.",
+  'component.pluginForm.cors.allow_headers.tooltip':
+    "Quels en-têtes sont autorisés à définir dans la demande lors de l'accès à une ressource en cross-origin. Utilisez , pour séparer plusieurs valeurs. Lorsque allow_credential est false, vous pouvez utiliser * pour indiquer d'autoriser tous les en-têtes de demande. Vous pouvez également autoriser n'importe quel en-tête de force en utilisant ** même si allow_credential est déjà activé, mais cela présentera des risques de sécurité.",
+  'component.pluginForm.cors.expose_headers.tooltip':
+    "Quels en-têtes sont autorisés à définir dans la réponse lors de l'accès à une ressource en cross-origin. Utilisez , pour séparer plusieurs valeurs. Lorsque allow_credential est false, vous pouvez utiliser * pour indiquer d'autoriser n'importe quel en-tête. Vous pouvez également autoriser n'importe quel en-tête de force en utilisant ** même si allow_credential est déjà activé, mais cela présentera des risques de sécurité.",
+  'component.pluginForm.cors.max_age.tooltip':
+    'Nombre maximal de secondes pendant lesquelles les résultats peuvent être mis en cache. Pendant cette période, le navigateur réutilisera le dernier résultat de vérification. -1 signifie pas de mise en cache. Veuillez noter que la valeur maximale dépend du navigateur, veuillez vous référer à MDN pour plus de détails.',
+  'component.pluginForm.cors.allow_credential.tooltip':
+    "Si vous définissez cette option sur true, vous ne pouvez pas utiliser '*' pour les autres options.",
+  'component.pluginForm.cors.allow_origins_by_metadata.tooltip':
+    'Correspondance avec quelle origine est autorisée à activer CORS en référençant allow_origins défini dans les métadonnées du plugin.',
+  'component.pluginForm.cors.allow_origins_by_regex.tooltip':
+    'Utilisez des expressions regex pour correspondre à quelle origine est autorisée à activer CORS. Chaque champ de saisie ne peut être configuré qu\'avec une seule expression régulière autonome, par exemple ".*.test.com" qui peut correspondre à n\'importe quel sous-domaine de test.com.',
+  // referer-restriction
+  'component.pluginForm.referer-restriction.whitelist.tooltip':
+    "Liste des noms d'hôte à autoriser. Le nom d'hôte peut commencer par * comme joker.",
+  'component.pluginForm.referer-restriction.blacklist.tooltip':
+    "Liste des noms d'hôte à mettre sur liste noire. Le nom d'hôte peut commencer par * comme joker.",
+  'component.pluginForm.referer-restriction.listEmpty.tooltip': 'Liste vide',
+  'component.pluginForm.referer-restriction.bypass_missing.tooltip':
+    "Indique s'il faut contourner la vérification lorsque l'en-tête Referer est manquant ou mal formé.",
+  'component.pluginForm.referer-restriction.message.tooltip':
+    "Message renvoyé en cas d'accès non autorisé.",
+  // api-breaker
+  'component.pluginForm.api-breaker.break_response_code.tooltip':
+    "Code d'erreur renvoyé en cas de problème de santé.",
+  'component.pluginForm.api-breaker.break_response_body.tooltip':
+    "Corps du message de réponse lorsque l'amont est en mauvais état de santé.",
+  'component.pluginForm.api-breaker.break_response_headers.tooltip':
+    'En-têtes renvoyés en cas de problème de santé.',
+  'component.pluginForm.api-breaker.max_breaker_sec.tooltip':
+    'Temps maximal du disjoncteur (en secondes).',
+  'component.pluginForm.api-breaker.unhealthy.http_statuses.tooltip':
+    "Codes d'état en cas de problème de santé.",
+  'component.pluginForm.api-breaker.unhealthy.failures.tooltip':
+    "Nombre de demandes d'erreur consécutives qui ont déclenché un état de santé défavorable.",
+  'component.pluginForm.api-breaker.healthy.http_statuses.tooltip': "Codes d'état en cas de santé.",
+  'component.pluginForm.api-breaker.healthy.successes.tooltip':
+    'Nombre de demandes normales consécutives qui déclenchent un état de santé.',
+  // proxy-mirror
+  'component.pluginForm.proxy-mirror.host.tooltip':
+    "Spécifiez une adresse de service miroir, par exemple http://127.0.0.1:9797 (l'adresse doit contenir un schéma : http ou https, pas de partie URI)",
+  'component.pluginForm.proxy-mirror.host.extra': 'Par exemple : http://127.0.0.1:9797',
+  'component.pluginForm.proxy-mirror.host.ruletip':
+    "l'adresse doit contenir un schéma : http ou https, pas de partie URI",
+  'component.pluginForm.proxy-mirror.path.tooltip':
+    'Spécifiez la partie chemin de la demande miroir. Sans cela, le chemin actuel sera utilisé.',
+  'component.pluginForm.proxy-mirror.path.ruletip':
+    'Veuillez saisir le chemin correct, par exemple /path',
+  'component.pluginForm.proxy-mirror.sample_ratio.tooltip':
+    "le taux d'échantillonnage pour lequel les demandes seront miroitées.",
+  // limit-conn
+  'component.pluginForm.limit-conn.conn.tooltip':
+    'le nombre maximum de demandes simultanées autorisées. Les demandes dépassant ce ratio (et en dessous de conn + burst) seront retardées (la latence est configurée par défaut par default_conn_delay) pour se conformer à ce seuil.',
+  'component.pluginForm.limit-conn.burst.tooltip':
+    'le nombre de demandes simultanées excessives (ou de connexions) autorisées à être retardées.',
+  'component.pluginForm.limit-conn.default_conn_delay.tooltip':
+    'la latence des secondes de la demande lorsque les demandes simultanées dépassent conn mais sont en dessous de (conn + burst).',
+  'component.pluginForm.limit-conn.key_type.tooltip':
+    'Le type de clé, supporte : "var" (variable unique) et "var_combination" (combinaison de variable)',
+  'component.pluginForm.limit-conn.key.tooltip':
+    "pour limiter le niveau de concurrence. Par exemple, on peut utiliser le nom d'hôte (ou la zone du serveur) comme clé afin de limiter la concurrence par nom d'hôte. Sinon, on peut également utiliser l'adresse client comme clé afin d'éviter qu'un seul client n'inonde notre service de trop de connexions ou de demandes parallèles.",
+  'component.pluginForm.limit-conn.rejected_code.tooltip':
+    'retourné lorsque la demande dépasse conn + burst sera rejetée.',
+  'component.pluginForm.limit-conn.rejected_msg.tooltip':
+    'le corps de la réponse retourné lorsque la demande dépasse conn + burst sera rejetée.',
+  'component.pluginForm.limit-conn.only_use_default_delay.tooltip':
+    'activez le mode strict des secondes de latence. Si vous définissez cette option sur true, il fonctionnera strictement selon les secondes de latence que vous avez définies sans logique de calcul supplémentaire.',
+  'component.pluginForm.limit-conn.allow_degradation.tooltip':
+    "Indiquez s'il faut activer la dégradation du plugin lorsque la fonction limit-conn est temporairement indisponible. Autorisez les demandes à continuer lorsque la valeur est définie sur true, par défaut false.",
+  // limit-req
+  'component.pluginForm.limit-req.rate.tooltip':
+    'Le taux de demande spécifié (nombre par seconde) seuil. Les demandes dépassant ce taux (et en dessous de burst) seront retardées pour se conformer au taux.',
+  'component.pluginForm.limit-req.burst.tooltip':
+    'Le nombre de demandes excessives par seconde autorisées à être retardées. Les demandes dépassant cette limite dure seront rejetées immédiatement.',
+  'component.pluginForm.limit-req.key_type.tooltip':
+    'Le type de clé, supporte : "var" (variable unique) et "var_combination" (combinaison de variable)',
+  'component.pluginForm.limit-req.key.tooltip':
+    "La clé spécifiée par l'utilisateur pour limiter le taux.",
+  'component.pluginForm.limit-req.rejected_code.tooltip':
+    "Le code d'état HTTP renvoyé lorsque la demande dépasse le seuil est rejeté.",
+  'component.pluginForm.limit-req.rejected_msg.tooltip':
+    'Le corps de la réponse renvoyé lorsque la demande dépasse le seuil est rejeté.',
+  'component.pluginForm.limit-req.nodelay.tooltip':
+    'Si le drapeau nodelay est true, les demandes en rafale ne seront pas retardées.',
+  'component.plugin.form': 'Formulaire',
+  'component.plugin.format-codes.disable': 'Formater les données JSON ou YAML',
+  'component.plugin.editor': 'Éditeur de plugin',
+  'component.plugin.noConfigurationRequired': "N'a pas besoin de configuration",
+  // limit-count
+  'component.pluginForm.limit-count.count.tooltip': 'Le nombre spécifié de seuil de demandes.',
+  'component.pluginForm.limit-count.time_window.tooltip':
+    'La fenêtre de temps en secondes avant que le nombre de demandes ne soit réinitialisé.',
+  'component.pluginForm.limit-count.key_type.tooltip':
+    'Le type de clé, supporte : "var" (variable unique) et "var_combination" (combinaison de variable)',
+  'component.pluginForm.limit-count.key.tooltip':
+    "La clé spécifiée par l'utilisateur pour limiter le nombre.",
+  'component.pluginForm.limit-count.rejected_code.tooltip':
+    "Le code d'état HTTP renvoyé lorsque la demande dépasse le seuil est rejeté, par défaut 503.",
+  'component.pluginForm.limit-count.rejected_msg.tooltip':
+    'Le corps de la réponse renvoyé lorsque la demande dépasse le seuil est rejeté.',
+  'component.pluginForm.limit-count.policy.tooltip':
+    "Les politiques de limitation de débit à utiliser pour récupérer et incrémenter les limites. Les valeurs disponibles sont local(les compteurs seront stockés localement en mémoire sur le nœud) et redis(les compteurs sont stockés sur un serveur Redis et seront partagés entre les nœuds, l'utiliser généralement pour faire la limite de vitesse globale) et redis-cluster(la même fonction que redis, utilisez uniquement le modèle de cluster Redis).",
+  'component.pluginForm.limit-count.allow_degradation.tooltip':
+    "Indiquez s'il faut activer la dégradation du plugin lorsque la fonction limit-count est temporairement indisponible (par exemple, délai d'attente de redis). Autorisez les demandes à continuer lorsque la valeur est définie sur true",
+  'component.pluginForm.limit-count.show_limit_quota_header.tooltip':
+    "Indiquez s'il faut afficher X-RateLimit-Limit et X-RateLimit-Remaining (ce qui signifie le nombre total de demandes et le nombre restant de demandes qui peuvent être envoyées) dans l'en-tête de réponse",
+  'component.pluginForm.limit-count.group.tooltip':
+    'La route configurée avec le même groupe partagera le même compteur',
+  'component.pluginForm.limit-count.redis_host.tooltip':
+    "Lors de l'utilisation de la politique redis, cette propriété spécifie l'adresse du serveur Redis.",
+  'component.pluginForm.limit-count.redis_port.tooltip':
+    "Lors de l'utilisation de la politique redis, cette propriété spécifie le port du serveur Redis.",
+  'component.pluginForm.limit-count.redis_password.tooltip':
+    "Lors de l'utilisation de la politique redis, cette propriété spécifie le mot de passe du serveur Redis.",
+  'component.pluginForm.limit-count.redis_database.tooltip':
+    "Lors de l'utilisation de la politique redis, cette propriété spécifie la base de données que vous avez sélectionnée du serveur Redis, et uniquement pour le mode non cluster Redis (mode instance unique ou service cloud public Redis qui fournit une seule entrée).",
+  'component.pluginForm.limit-count.redis_timeout.tooltip':
+    "Lors de l'utilisation de la politique redis, cette propriété spécifie le délai en millisecondes de toute commande soumise au serveur Redis.",
+  'component.pluginForm.limit-count.redis_cluster_nodes.tooltip':
+    "Lors de l'utilisation de la politique redis-cluster, cette propriété est une liste d'adresses des nœuds de service Redis cluster (au moins deux nœuds).",
+  'component.pluginForm.limit-count.redis_cluster_name.tooltip':
+    "Lors de l'utilisation de la politique redis-cluster, cette propriété est le nom des nœuds de service Redis cluster.",
+  'component.pluginForm.limit-count.atLeast2Characters.rule':
+    'Veuillez entrer au moins 2 caractères',
+};

--- a/web/src/components/PluginFlow/locales/fr-Fr.ts
+++ b/web/src/components/PluginFlow/locales/fr-Fr.ts
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export default {
+  'component.plugin-flow.text.condition.required': 'Configurer la règle',
+  'component.plugin-flow.text.condition': 'Règle',
+  'component.plugin-flow.text.condition2': 'Condition',
+  'component.plugin-flow.text.condition.placeholder': 'Veuillez saisir la règle',
+  'component.plugin-flow.text.without-data': 'Noeud trouvé sans configuration',
+  'component.plugin-flow.text.plugin-without-data.description': 'Veuillez configurer le plugin : ',
+  'component.plugin-flow.text.no-start-node': 'Veuillez connecter le noeud de départ',
+  'component.plugin-flow.text.no-root-node': 'Noeud racine non trouvé',
+  'component.plugin-flow.text.start-node': 'Démarrer',
+  'component.plugin-flow.text.general': 'Général',
+  'component.plugin-flow.text.nodes-area': 'Noeuds disponibles',
+  'component.plugin-flow.text.nodes.not-found': 'Non trouvé',
+  'component.plugin-flow.text.search-nodes.placeholder': 'Rechercher un plugin par nom',
+  'component.plugin-flow.text.condition-rule.tooltip':
+    'La condition de jugement du noeud. Exemple : code == 503',
+  'component.plugin-flow.text.line': 'Ligne',
+  'component.plugin-flow.text.grid': 'Grille',
+  'component.plugin-flow.text.background': 'Arrière-plan',
+  'component.plugin-flow.text.node': 'Noeud',
+  'component.plugin-flow.text.text': 'Texte',
+  'component.plugin-flow.text.condition-without-configuration':
+    'Veuillez vérifier les données de tous les noeuds de condition',
+  'component.plugin-flow.text.preview.readonly':
+    'REMARQUE : vos actions sur le tiroir suivant ne seront pas préservées.',
+  'component.plugin-flow.text.both-modes-exist':
+    "La configuration du mode d'orchestration remplacera la configuration du mode normal, êtes-vous sûr de vouloir continuer ?",
+  'component.plugin-flow.text.both-modes-exist.title': 'Attention',
+};

--- a/web/src/components/RawDataEditor/locales/fr-FR.ts
+++ b/web/src/components/RawDataEditor/locales/fr-FR.ts
@@ -1,0 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export default {
+  'component.rawDataEditor.tip': 'Mode édition actuellement non pris en charge',
+};

--- a/web/src/components/Upstream/locales/fr-FR.ts
+++ b/web/src/components/Upstream/locales/fr-FR.ts
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export default {
+  'component.upstream.fields.tls.client_key': 'Clé du client',
+  'component.upstream.fields.tls.client_key.required': 'Veuillez entrer la clé du client',
+  'component.upstream.fields.tls.client_cert': 'Certificat du client',
+  'component.upstream.fields.tls.client_cert.required': 'Veuillez entrer le certificat du client',
+  'component.upstream.fields.upstream_type': "Type d'amont",
+  'component.upstream.fields.upstream_type.node': 'Noeud',
+  'component.upstream.fields.upstream_type.service_discovery': 'Découverte de service',
+  'component.upstream.fields.discovery_type': 'Type de découverte',
+  'component.upstream.fields.discovery_type.tooltip': 'Type de découverte',
+  'component.upstream.fields.discovery_type.placeholder':
+    'Veuillez sélectionner le type de découverte',
+  'component.upstream.fields.discovery_type.type.dns': 'DNS',
+  'component.upstream.fields.discovery_type.type.consul': 'Consul',
+  'component.upstream.fields.discovery_type.type.consul_kv': 'Consul KV',
+  'component.upstream.fields.discovery_type.type.nacos': 'Nacos',
+  'component.upstream.fields.discovery_type.type.eureka': 'Eureka',
+  'component.upstream.fields.discovery_type.type.kubernetes': 'Kubernetes',
+  'component.upstream.fields.discovery_args.group_name': 'Nom du groupe',
+  'component.upstream.fields.discovery_args.group_name.tooltip': 'Nom du groupe',
+  'component.upstream.fields.discovery_args.group_name.placeholder':
+    'Veuillez entrer le nom du groupe',
+  'component.upstream.fields.discovery_args.namespace_id': "ID de l'espace de noms",
+  'component.upstream.fields.discovery_args.namespace_id.tooltip': "ID de l'espace de noms",
+  'component.upstream.fields.discovery_args.namespace_id.placeholder':
+    "Veuillez entrer l'ID de l'espace de noms",
+  'component.upstream.fields.service_name': 'Nom du service',
+  'component.upstream.fields.service_name.tooltip': 'Nom du service',
+  'component.upstream.fields.service_name.placeholder': 'Veuillez entrer le nom du service',
+  'component.upstream.fields.scheme.tooltip.stream':
+    'Ce type est utilisé uniquement pour Stream Route, qui est un proxy de la couche 4. Référence: https://apisix.apache.org/docs/apisix/stream-proxy/',
+  'component.upstream.fields.scheme.tooltip.pubsub':
+    'Ce type est utilisé uniquement dans la publication-abonnement. Référence: https://apisix.apache.org/docs/apisix/pubsub/',
+  'component.upstream.fields.tls': 'TLS',
+  'component.upstream.fields.tls.tooltip': 'Certificat TLS',
+  'component.upstream.fields.hash_on': 'Hash sur',
+  'component.upstream.fields.hash_on.tooltip': 'Ce qui doit être utilisé comme entrée de hachage',
+  'component.upstream.fields.key': 'Clé',
+  'component.upstream.fields.key.tooltip': "Clé en tant qu'entrée de hachage",
+  'component.upstream.fields.retries': 'Réessais',
+  'component.upstream.fields.retries.tooltip':
+    'Le mécanisme de réessai envoie la demande au nœud amont suivant. Une valeur de 0 désactive le mécanisme de réessai et laisse la table vide pour utiliser le nombre de nœuds backend disponibles.',
+  'component.upstream.fields.retry_timeout': 'Délai de réessai',
+  'component.upstream.fields.retry_timeout.tooltip':
+    'Configurer un nombre pour limiter la durée en secondes pendant laquelle les réessais peuvent se poursuivre, et ne pas continuer les réessais si la demande précédente et les réessais ont pris trop de temps. 0 signifie désactiver le mécanisme de délai de réessai.',
+  'component.upstream.fields.keepalive_pool': 'Pool Keepalive',
+  'component.upstream.fields.keepalive_pool.tooltip':
+    "Définir un pool Keepalive indépendant pour l'amont",
+  'component.upstream.fields.keepalive_pool.size': 'Taille',
+  'component.upstream.fields.keepalive_pool.size.placeholder': 'Veuillez entrer la taille',
+  'component.upstream.fields.keepalive_pool.idle_timeout': "Délai d'inactivité",
+  'component.upstream.fields.keepalive_pool.idle_timeout.placeholder':
+    "Veuillez entrer le délai d'inactivité",
+  'component.upstream.fields.keepalive_pool.requests': 'Demandes',
+  'component.upstream.fields.keepalive_pool.requests.placeholder': 'Veuillez entrer les demandes',
+  'component.upstream.fields.checks.active.type': 'Type',
+  'component.upstream.fields.checks.active.type.tooltip':
+    "Indiquez s'il faut effectuer des vérifications de santé actives à l'aide d'HTTP ou HTTPS, ou simplement tenter une connexion TCP.",
+  'component.upstream.fields.checks.active.concurrency': 'Concurrence',
+  'component.upstream.fields.checks.active.concurrency.tooltip':
+    'Nombre de cibles à vérifier simultanément dans les vérifications de santé actives.',
+  'component.upstream.fields.checks.active.host': 'Hôte',
+  'component.upstream.fields.checks.active.host.required': "Veuillez entrer le nom d'hôte",
+  'component.upstream.fields.checks.active.host.tooltip':
+    "Le nom d'hôte de la requête HTTP utilisé pour effectuer la vérification de santé active",
+  'component.upstream.fields.checks.active.host.scope':
+    'Seules les lettres, les chiffres et . sont pris en charge',
+  'component.upstream.fields.checks.active.port': 'Port',
+  'component.upstream.fields.checks.active.http_path': 'Chemin HTTP',
+  'component.upstream.fields.checks.active.http_path.tooltip':
+    "Le chemin qui doit être utilisé lors de l'émission de la requête GET HTTP à la cible. La valeur par défaut est /.",
+  'component.upstream.fields.checks.active.http_path.placeholder':
+    'Veuillez entrer le chemin de la requête HTTP',
+  'component.upstream.fields.checks.active.https_verify_certificate':
+    'Vérifier le certificat HTTPs',
+  'component.upstream.fields.checks.active.https_verify_certificate.tooltip':
+    "Indique s'il faut vérifier la validité du certificat SSL de l'hôte distant lors de la réalisation de vérifications de santé actives à l'aide de HTTPS.",
+  'component.upstream.fields.checks.active.req_headers': 'En-têtes de la demande',
+  'component.upstream.fields.checks.active.req_headers.tooltip':
+    'En-têtes de demande supplémentaires, exemple: User-Agent: curl/7.29.0',
+  'component.upstream.fields.checks.active.healthy.interval': 'Intervalle',
+  'component.upstream.fields.checks.active.healthy.interval.tooltip':
+    'Intervalle entre les vérifications des cibles saines (en secondes)',
+  'component.upstream.fields.checks.active.healthy.successes': 'Réussites',
+  'component.upstream.fields.checks.active.healthy.successes.tooltip':
+    'Nombre de succès pour considérer une cible comme saine',
+  'component.upstream.fields.checks.active.healthy.successes.required':
+    'Veuillez entrer le nombre de réussites',
+  'component.upstream.fields.checks.active.healthy.http_statuses': 'Statuts HTTP',
+  'component.upstream.fields.checks.active.healthy.http_statuses.tooltip':
+    "Un tableau de statuts HTTP à considérer comme un succès, indiquant la santé, lorsqu'il est renvoyé par une sonde dans les vérifications de santé actives.",
+  'component.upstream.fields.checks.active.unhealthy.timeouts': 'Délais dépassés',
+  'component.upstream.fields.checks.active.unhealthy.timeouts.tooltip':
+    'Nombre de délais dépassés dans les sondes actives pour considérer une cible comme non saine.',
+  'component.upstream.fields.checks.active.unhealthy.http_failures': 'Échecs HTTP',
+  'component.upstream.fields.checks.active.unhealthy.http_failures.tooltip':
+    "Nombre d'échecs HTTP pour considérer une cible comme non saine",
+  'component.upstream.fields.checks.active.unhealthy.http_failures.required':
+    'Veuillez entrer les échecs HTTP',
+  'component.upstream.fields.checks.active.unhealthy.tcp_failures': 'Échecs TCP',
+  'component.upstream.fields.checks.active.unhealthy.tcp_failures.tooltip':
+    "Nombre d'échecs TCP pour considérer une cible comme non saine",
+  'component.upstream.fields.checks.active.unhealthy.tcp_failures.required':
+    'Veuillez entrer les échecs TCP',
+  'component.upstream.fields.checks.active.unhealthy.interval': 'Intervalle',
+  'component.upstream.fields.checks.active.unhealthy.interval.tooltip':
+    'Intervalle entre les vérifications de santé actives pour les cibles non saines (en secondes). Une valeur de zéro indique que les sondes actives pour les cibles saines ne doivent pas être effectuées.',
+  'component.upstream.fields.checks.active.unhealthy.required':
+    "Veuillez entrer l'intervalle non sain",
+  'component.upstream.fields.checks.passive.healthy.successes': 'Réussites',
+  'component.upstream.fields.checks.passive.healthy.successes.tooltip':
+    'Nombre de succès pour considérer une cible comme saine',
+  'component.upstream.fields.checks.passive.healthy.successes.required':
+    'Veuillez entrer le nombre de réussites',
+  'component.upstream.fields.checks.passive.unhealthy.timeouts': 'Délais dépassés',
+  'component.upstream.fields.checks.passive.unhealthy.timeouts.tooltip':
+    "Nombre de délais dépassés dans le trafic proxy pour considérer une cible comme non saine, tel qu'observé par les vérifications de santé passives.",
+  'component.upstream.other.none': 'Aucun (Disponible uniquement lors de la liaison du service)',
+  'component.upstream.other.pass_host-with-multiple-nodes.title':
+    'Veuillez vérifier la configuration du nœud cible',
+  'component.upstream.other.pass_host-with-multiple-nodes':
+    "Lors de l'utilisation d'un nom d'hôte ou d'une adresse IP dans la liste des nœuds cibles, assurez-vous qu'il n'y a qu'un seul nœud cible",
+  'component.upstream.other.health-check.passive-only':
+    'Lorsque la vérification de santé passive est activée, la vérification de santé active doit également être activée.',
+  'component.upstream.other.health-check.invalid':
+    'Veuillez vérifier la configuration de la vérification de santé',
+};

--- a/web/src/locales/fr-FR.ts
+++ b/web/src/locales/fr-FR.ts
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ActionBarEnUS } from '@/components/ActionBar';
+
+import Plugin from '../components/Plugin/locales/fr-Fr';
+import PluginFlow from '../components/PluginFlow/locales/fr-Fr';
+import RawDataEditor from '../components/RawDataEditor/locales/fr-FR';
+import UpstreamComponent from '../components/Upstream/locales/fr-FR';
+import component from './fr-FR/component';
+import globalHeader from './fr-FR/globalHeader';
+import menu from './fr-FR/menu';
+import other from './fr-FR/other';
+import pwa from './fr-FR/pwa';
+import settings from './fr-FR/setting';
+import settingDrawer from './fr-FR/settingDrawer';
+
+export default {
+  'navBar.lang': 'Langues',
+  'layout.user.link.help': 'Aide',
+  'layout.user.link.privacy': 'Confidentialité',
+  'layout.user.link.terms': 'Termes',
+  'app.preview.down.block': 'Téléchargez cette page sur votre projet local',
+  ...globalHeader,
+  ...menu,
+  ...settingDrawer,
+  ...settings,
+  ...pwa,
+  ...component,
+  ...other,
+  ...ActionBarEnUS,
+  ...Plugin,
+  ...PluginFlow,
+  ...RawDataEditor,
+  ...UpstreamComponent,
+};

--- a/web/src/locales/fr-FR/component.ts
+++ b/web/src/locales/fr-FR/component.ts
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export default {
+  'component.tagSelect.expand': 'Développer',
+  'component.tagSelect.collapse': 'Réduire',
+  'component.tagSelect.all': 'Tous',
+  'component.global.search': 'Rechercher',
+  'component.global.reset': 'Réinitialiser',
+  'component.global.confirm': 'Confirmer',
+  'component.global.format': 'Format',
+  'component.global.document': 'Document',
+  'component.global.enable': 'Activer',
+  'component.global.disable': 'Désactiver',
+  'component.global.scope': 'Portée',
+  'component.global.example': 'Exemple',
+  'component.global.data.editor': 'Éditeur de données brutes',
+  'component.global.delete': 'Supprimer',
+  'component.global.cancel': 'Annuler',
+  'component.global.submit': 'Soumettre',
+  'component.global.create': 'Créer',
+  'component.global.add': 'Ajouter',
+  'component.global.save': 'Enregistrer',
+  'component.global.edit': 'Configurer',
+  'component.global.view': 'Afficher',
+  'component.global.duplicate': 'Dupliquer',
+  'component.global.manage': 'Gérer',
+  'component.global.update': 'Mettre à jour',
+  'component.global.get': 'Obtenir',
+  'component.global.edit.plugin': 'Configurer le plugin',
+  'component.global.loading': 'Chargement',
+  'component.global.list': 'Liste',
+  'component.global.description': 'Description',
+  'component.global.description.required': 'Veuillez entrer la description',
+  'component.global.labels': 'Étiquettes',
+  'component.global.version': 'Version',
+  'component.global.operation': 'Opération',
+  'component.status.success': 'Succès',
+  'component.status.fail': 'Échec',
+  'component.global.popconfirm.title.delete':
+    'Êtes-vous sûr de vouloir supprimer cet enregistrement ?',
+  'component.global.notification.success.message.deleteSuccess': 'Supprimé avec succès',
+  'component.global.create.consumer.success': 'Création du consommateur réussie',
+  'component.global.delete.consumer.success': 'Suppression du consommateur réussie',
+  'component.global.delete.routes.success': 'Suppression de la route réussie',
+  'component.global.edit.consumer.success': 'Modification du consommateur réussie',
+  'component.global.steps.stepTitle.basicInformation': 'Informations de base',
+  'component.global.steps.stepTitle.preview': 'Aperçu',
+  'component.global.steps.stepTitle.pluginConfig': 'Configuration du plugin',
+  'component.global.pleaseEnter': 'Veuillez entrer',
+  'component.global.pleaseChoose': 'Veuillez choisir',
+  'component.global.pleaseCheck': 'Veuillez cocher',
+  'component.global.input.ruleMessage.name':
+    "Seules les lettres, les chiffres, - et _ sont autorisés, et le nom ne peut commencer qu'avec des lettres",
+  'component.global.connectionTimeout': 'Délai de connexion',
+  'component.global.sendTimeout': "Délai d'envoi",
+  'component.global.receiveTimeout': 'Délai de réception',
+  'component.global.name': 'Nom',
+  'component.global.id': 'ID',
+  'component.global.updateTime': 'Heure de mise à jour',
+  'component.global.form.itemExtraMessage.nameGloballyUnique':
+    'Le nom doit être globalement unique',
+  'component.global.input.placeholder.description':
+    'Veuillez entrer la description de cette route, maximum 256 caractères',
+  // User component
+  'component.user.loginByPassword': "Nom d'utilisateur & Mot de passe",
+  'component.user.login': 'Connexion',
+  'component.document': 'Document',
+  'component.label-manager': "Gestionnaire d'étiquettes",
+  'component.global.noConfigurationRequired': 'Aucune configuration requise',
+  'component.global.copy': 'Copier',
+  'component.global.copySuccess': 'Copie réussie ',
+  'component.global.copyFail': 'Échec de la copie',
+  'component.global.invalidYaml': 'Données Yaml invalides',
+  'component.global.invalidJson': 'Données Json invalides',
+};

--- a/web/src/locales/fr-FR/globalHeader.ts
+++ b/web/src/locales/fr-FR/globalHeader.ts
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export default {
+  'component.globalHeader.search': 'Rechercher',
+  'component.globalHeader.search.example1': 'Exemple de recherche 1',
+  'component.globalHeader.search.example2': 'Exemple de recherche 2',
+  'component.globalHeader.search.example3': 'Exemple de recherche 3',
+  'component.globalHeader.help': 'Aide',
+  'component.globalHeader.notification': 'Notification',
+  'component.globalHeader.notification.empty': 'Vous avez consulté toutes les notifications.',
+  'component.globalHeader.message': 'Message',
+  'component.globalHeader.message.empty': 'Vous avez consulté tous les messages.',
+  'component.globalHeader.event': 'Événement',
+  'component.globalHeader.event.empty': 'Vous avez consulté tous les événements.',
+  'component.noticeIcon.clear': 'Effacer',
+  'component.noticeIcon.cleared': 'Effacé',
+  'component.noticeIcon.empty': 'Aucune notification',
+  'component.noticeIcon.view-more': 'Voir plus',
+};

--- a/web/src/locales/fr-FR/menu.ts
+++ b/web/src/locales/fr-FR/menu.ts
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export default {
+  'menu.more-blocks': 'Plus de blocs',
+  'menu.home': 'Accueil',
+  'menu.admin': 'Administration',
+  'menu.admin.sub-page': 'Sous-page',
+  'menu.login': 'Connexion',
+  'menu.register': "S'inscrire",
+  'menu.register.result': "Résultat de l'inscription",
+  'menu.dashboard': 'Tableau de bord',
+  'menu.dashboard.analysis': 'Analyse',
+  'menu.dashboard.monitor': 'Moniteur',
+  'menu.dashboard.workplace': 'Espace de travail',
+  'menu.exception.403': '403',
+  'menu.exception.404': '404',
+  'menu.exception.500': '500',
+  'menu.form': 'Formulaire',
+  'menu.form.basic-form': 'Formulaire de base',
+  'menu.form.step-form': 'Formulaire étape par étape',
+  'menu.form.step-form.info': 'Formulaire étape par étape (écrire les informations de transfert)',
+  'menu.form.step-form.confirm':
+    'Formulaire étape par étape (confirmer les informations de transfert)',
+  'menu.form.step-form.result': 'Formulaire étape par étape (terminé)',
+  'menu.form.advanced-form': 'Formulaire avancé',
+  'menu.list': 'Liste',
+  'menu.list.table-list': 'Tableau de recherche',
+  'menu.list.basic-list': 'Liste de base',
+  'menu.list.card-list': 'Liste de cartes',
+  'menu.list.search-list': 'Liste de recherche',
+  'menu.list.search-list.articles': 'Liste de recherche (articles)',
+  'menu.list.search-list.projects': 'Liste de recherche (projets)',
+  'menu.list.search-list.applications': 'Liste de recherche (applications)',
+  'menu.profile': 'Profil',
+  'menu.profile.basic': 'Profil de base',
+  'menu.profile.advanced': 'Profil avancé',
+  'menu.result': 'Résultat',
+  'menu.result.success': 'Succès',
+  'menu.result.fail': 'Échec',
+  'menu.exception': 'Exception',
+  'menu.exception.not-permission': '403',
+  'menu.exception.not-find': '404',
+  'menu.exception.server-error': '500',
+  'menu.exception.trigger': 'Déclencheur',
+  'menu.account': 'Compte',
+  'menu.account.center': 'Centre de compte',
+  'menu.account.trigger': 'Déclencher une erreur',
+  'menu.account.logout': 'Déconnexion',
+  'menu.editor': 'Éditeur graphique',
+  'menu.editor.flow': 'Éditeur de flux',
+  'menu.editor.mind': 'Éditeur de mental',
+  'menu.editor.koni': 'Éditeur Koni',
+  'menu.routes': 'Route',
+  'menu.pluginTemplate': 'Modèle de plugin',
+  'menu.ssl': 'SSL',
+  'menu.upstream': 'Amont',
+  'menu.consumer': 'Consommateur',
+  'menu.plugin': 'Plugin',
+  'menu.service': 'Service',
+  'menu.proto': 'Protocole Buffers',
+  'menu.setting': 'Paramètres',
+  'menu.serverinfo': 'Informations système',
+  'menu.advanced-feature': 'Avancé',
+  'menu.more': 'Plus',
+  'menu.close': 'Fermer',
+};

--- a/web/src/locales/fr-FR/other.ts
+++ b/web/src/locales/fr-FR/other.ts
@@ -1,0 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export default {
+  'other.global': 'Global',
+};

--- a/web/src/locales/fr-FR/pwa.ts
+++ b/web/src/locales/fr-FR/pwa.ts
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export default {
+  'app.pwa.offline': 'Vous êtes actuellement hors ligne',
+  'app.pwa.serviceworker.updated': 'Un nouveau contenu est disponible',
+  'app.pwa.serviceworker.updated.hint':
+    'Veuillez appuyer sur le bouton "Actualiser" pour recharger la page actuelle',
+  'app.pwa.serviceworker.updated.ok': 'Actualiser',
+};

--- a/web/src/locales/fr-FR/setting.ts
+++ b/web/src/locales/fr-FR/setting.ts
@@ -1,0 +1,17 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export default {};

--- a/web/src/locales/fr-FR/settingDrawer.ts
+++ b/web/src/locales/fr-FR/settingDrawer.ts
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export default {
+  'app.setting.pagestyle': 'Réglage du style de page',
+  'app.setting.pagestyle.dark': 'Style sombre',
+  'app.setting.pagestyle.light': 'Style clair',
+  'app.setting.content-width': 'Largeur du contenu',
+  'app.setting.content-width.fixed': 'Fixe',
+  'app.setting.content-width.fluid': 'Fluide',
+  'app.setting.themecolor': 'Couleur du thème',
+  'app.setting.themecolor.dust': 'Rouge poussière',
+  'app.setting.themecolor.volcano': 'Volcan',
+  'app.setting.themecolor.sunset': 'Orange coucher de soleil',
+  'app.setting.themecolor.cyan': 'Cyan',
+  'app.setting.themecolor.green': 'Vert polaire',
+  'app.setting.themecolor.daybreak': 'Bleu aube (par défaut)',
+  'app.setting.themecolor.geekblue': 'Bleu geek',
+  'app.setting.themecolor.purple': 'Violet doré',
+  'app.setting.navigationmode': 'Mode de navigation',
+  'app.setting.sidemenu': 'Disposition du menu latéral',
+  'app.setting.topmenu': 'Disposition du menu supérieur',
+  'app.setting.fixedheader': 'En-tête fixe',
+  'app.setting.fixedsidebar': 'Barre latérale fixe',
+  'app.setting.fixedsidebar.hint': 'Fonctionne avec la disposition du menu latéral',
+  'app.setting.hideheader': "Masquer l'en-tête lors du défilement",
+  'app.setting.hideheader.hint': "Fonctionne lorsque l'en-tête masqué est activé",
+  'app.setting.othersettings': 'Autres paramètres',
+  'app.setting.weakmode': 'Mode faible',
+  'app.setting.copy': 'Copier les paramètres',
+  'app.setting.copyinfo':
+    'Copie réussie, veuillez remplacer defaultSettings dans src/models/setting.js',
+  'app.setting.production.hint':
+    "Le panneau de réglage n'apparaît que dans l'environnement de développement, veuillez le modifier manuellement",
+};

--- a/web/src/pages/Consumer/locales/fr-FR.ts
+++ b/web/src/pages/Consumer/locales/fr-FR.ts
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export default {
+  'page.consumer.form.itemRuleMessage.username':
+    'La longueur maximale est de 100 caractères, seuls les lettres, les chiffres et _ sont autorisés.',
+  'page.consumer.form.itemExtraMessage.username': 'Le nom doit être unique',
+  'page.consumer.username': 'Nom',
+  'page.consumer.username.required': 'Veuillez entrer le nom du consommateur',
+  'page.consumer.updateTime': 'Heure de mise à jour',
+  'page.consumer.list': 'Liste des consommateurs',
+  'page.consumer.description':
+    "Les consommateurs sont les utilisateurs des routes, par exemple les développeurs, les utilisateurs finaux, les appels d'API, etc.",
+  'page.consumer.create': 'Créer un consommateur',
+  'page.consumer.configure': 'Configurer le consommateur',
+};

--- a/web/src/pages/Dashboard/locales/fr-FR.ts
+++ b/web/src/pages/Dashboard/locales/fr-FR.ts
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export default {
+  'page.dashboard.empty.description.grafanaNotConfig': "Vous n'avez pas configuré Grafana",
+  'page.dashboard.button.grafanaConfig': 'Configurer',
+  'page.dashboard.tip':
+    "Utilisez le localStorage du navigateur pour stocker l'URL de la page de surveillance, uniquement en local.",
+};

--- a/web/src/pages/Plugin/locales/fr-FR.ts
+++ b/web/src/pages/Plugin/locales/fr-FR.ts
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export default {
+  'page.plugin.drawer.popconfirm.title.delete': 'Êtes-vous sûr de vouloir supprimer cet élément ?',
+  'page.plugin.list': 'Liste des plugins',
+  'page.plugin.list.enabled': 'Liste des plugins activés',
+  'page.plugin.market.config': 'Liste globale des plugins',
+  'page.plugin.edit': 'Configurer le plugin avec succès',
+  'page.plugin.delete': 'Supprimer le plugin avec succès',
+};

--- a/web/src/pages/Proto/locales/fr-FR.ts
+++ b/web/src/pages/Proto/locales/fr-FR.ts
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export default {
+  'page.proto.list': 'Liste des protos',
+  'page.proto.list.description':
+    "Les protocoles buffers sont le mécanisme de sérialisation des données structurées de Google, neutre par rapport au langage et à la plateforme. Vous définissez une fois la structure de vos données, puis vous pouvez utiliser du code source généré spécialement pour écrire et lire facilement vos données structurées depuis et vers divers flux de données et en utilisant divers langages. La liste des protocoles buffers contient les fichiers proto créés. Lorsque le plug-in de transcodage grpc est activé, l'ID peut être configuré pour lire le contenu des fichiers proto correspondants.",
+  'page.proto.list.edit': 'Configurer',
+  'page.proto.list.confirm.delete': 'Êtes-vous sûr de vouloir supprimer ?',
+  'page.proto.list.confirm': 'Confirmer',
+  'page.proto.list.cancel': 'Annuler',
+  'page.proto.list.delete.successfully': 'Supprimer le proto avec succès',
+  'page.proto.list.delete': 'Supprimer',
+  'page.proto.id.tooltip': 'ID du fichier .proto',
+  'page.proto.desc': 'Description',
+  'page.proto.desc.tooltip': 'Description du fichier .proto',
+  'page.proto.content': 'Contenu',
+  'page.proto.content.tooltip': 'Contenu du fichier .proto',
+  'page.proto.drawer.create': 'Créer un proto',
+  'page.proto.drawer.edit': 'Configurer un proto',
+  'page.proto.drawer.create.successfully': 'Créer un proto avec succès',
+  'page.proto.drawer.edit.successfully': 'Configurer un proto avec succès',
+  'page.proto.drawer.delete.successfully': 'Supprimer le proto avec succès',
+};

--- a/web/src/pages/Route/locales/fr-FR.ts
+++ b/web/src/pages/Route/locales/fr-FR.ts
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export default {
+  'page.route.button.returnList': 'Aller à la liste',
+  'page.route.button.send': 'Envoyer',
+  'page.route.onlineDebug': 'Débogage en ligne',
+  'page.route.pluginTemplateConfig': 'Configuration du modèle de plugin',
+  'page.route.parameterPosition': 'Position du paramètre',
+  'page.route.httpRequestHeader': 'En-tête de requête HTTP',
+  'page.route.requestParameter': 'Paramètre de requête',
+  'page.route.postRequestParameter': 'Paramètre de requête POST',
+  'page.route.builtinParameter': 'Paramètre intégré',
+  'page.route.parameterName': 'Nom du paramètre',
+  'page.route.operationalCharacter': 'Caractère opérationnel',
+  'page.route.equal': 'Égal(==)',
+  'page.route.unequal': 'Différent(~=)',
+  'page.route.greaterThan': 'Supérieur à(>)',
+  'page.route.lessThan': 'Inférieur à(<)',
+  'page.route.regexMatch': 'Correspondance regex(~~)',
+  'page.route.caseInsensitiveRegexMatch': 'Correspondance regex insensible à la casse(~*)',
+  'page.route.in': 'DANS',
+  'page.route.has': 'A',
+  'page.route.reverse': 'Inverser le résultat(!)',
+  'page.route.rule': 'Règle',
+  'page.route.httpHeaderName': "Nom de l'en-tête de requête HTTP",
+  'page.route.service': 'Service',
+  'page.route.instructions': 'Instructions',
+  'page.route.import': 'Importer',
+  'page.route.createRoute': 'Créer une route',
+  'page.route.editRoute': 'Configurer la route',
+  'page.route.batchDeletion': 'Suppression en lot des routes',
+  'page.route.unSelect': 'Désélectionner',
+  'page.route.item': 'éléments',
+  'page.route.chosen': 'choisis',
+  'page.route.input.placeholder.parameterNameHttpHeader':
+    "Nom de l'en-tête de requête, par exemple : HOST",
+  'page.route.input.placeholder.parameterNameRequestParameter':
+    'Nom du paramètre, par exemple : id',
+  'page.route.input.placeholder.requestUrl': "Veuillez saisir l'URL de requête valide",
+  'page.route.input.placeholder.paramKey': 'Clé du paramètre',
+  'page.route.input.placeholder.paramValue': 'Valeur du paramètre',
+  'page.route.input.placeholder.paramType': 'Type de paramètre',
+  'page.route.form.itemRulesRequiredMessage.parameterName':
+    'Seules les lettres et les chiffres sont autorisés, et le nom doit commencer par une lettre',
+  'page.route.value': 'Valeur du paramètre',
+  'page.route.panelSection.title.advancedMatchRule':
+    'Conditions avancées de correspondance des routes',
+  'page.route.panelSection.title.nameDescription': 'Nom et description',
+  'page.route.form.itemRulesPatternMessage.apiNameRule':
+    'La longueur maximale doit être de 100 seulement',
+  'page.route.panelSection.title.requestConfigBasicDefine': 'Définition de base de la requête',
+  'page.route.form.itemLabel.httpMethod': 'Méthode HTTP',
+  'page.route.form.itemLabel.scheme': 'Schéma',
+  'page.route.form.itemLabel.priority': 'Priorité',
+  'page.route.form.itemLabel.redirect': 'Redirection',
+  'page.route.select.option.enableHttps': 'Activer HTTPS',
+  'page.route.select.option.configCustom': 'Personnalisé',
+  'page.route.select.option.forbidden': 'Interdit',
+  'page.route.form.itemLabel.redirectCustom': 'Redirection personnalisée',
+  'page.route.input.placeholder.redirectCustom': 'Par exemple: /foo/index.html',
+  'page.route.select.option.redirect301': '301 (Redirection permanente)',
+  'page.route.select.option.redirect302': '302 (Redirection temporaire)',
+  'page.route.form.itemLabel.username': "Nom d'utilisateur",
+  'page.route.form.itemLabel.password': 'Mot de passe',
+  'page.route.form.itemLabel.token': 'Jeton',
+  'page.route.form.itemLabel.apikey': 'Clé API',
+  'page.route.form.itemExtraMessage.domain':
+    'Nom de domaine ou IP, prise en charge du nom de domaine générique, par exemple : *.test.com',
+  'page.route.form.itemRulesPatternMessage.domain':
+    'Seules les lettres, les chiffres, -,_ et * sont pris en charge, mais * doit être au début.',
+  'page.route.form.itemExtraMessage1.path':
+    'Chemin de la requête HTTP, par exemple : /foo/index.html, prend en charge le préfixe du chemin de la requête /foo/* ; /* représente tous les chemins',
+  'page.route.form.itemRulesPatternMessage.remoteAddrs':
+    'Veuillez saisir une adresse IP valide, par exemple : 192.168.1.101, 192.168.1.0/24, ::1, fe80::1, fe80::1/64',
+  'page.route.form.itemExtraMessage1.remoteAddrs':
+    'Adresse IP client, par exemple : 192.168.1.101, 192.168.1.0/24, ::1, fe80::1, fe80::1/64',
+  'page.route.httpAction': 'Action',
+  'page.route.httpOverrideOrCreate': 'Remplacer/Créer',
+  'page.route.panelSection.title.httpOverrideRequestHeader': "Remplacer l'en-tête de requête HTTP",
+  'page.route.status': 'Statut',
+  'page.route.groupName': 'Nom du groupe',
+  'page.route.offline': 'Hors ligne',
+  'page.route.publish': 'Publier',
+  'page.route.published': 'Publié',
+  'page.route.unpublished': 'Non publié',
+  'page.route.select.option.inputManually': 'Entrée manuelle',
+  'page.route.select.option.methodRewriteNone': 'Ne pas modifier',
+  'page.route.form.itemLabel.domainNameOrIp': 'Nom de domaine/IP',
+  'page.route.form.itemExtraMessage.domainNameOrIp':
+    "Lors de l'utilisation du nom de domaine, il analysera le fichier local: /etc/resolv.conf par défaut",
+  'page.route.portNumber': 'Numéro de port',
+  'page.route.weight': 'Poids',
+  'page.route.radio.staySame': 'Rester identique',
+  'page.route.form.itemLabel.newPath': 'Nouveau chemin',
+  'page.route.form.itemLabel.newHost': 'Nouveau hôte',
+  'page.route.form.itemLabel.regex': 'Expression régulière',
+  'page.route.form.itemLabel.template': 'Modèle',
+  'page.route.form.itemLabel.URIRewriteType': "Remplacement de l'URI",
+  'page.route.form.itemLabel.hostRewriteType': "Remplacement de l'hôte",
+  'page.route.form.itemLabel.methodRewrite': 'Remplacement de la méthode',
+  'page.route.form.itemLabel.redirectURI': 'URI de redirection',
+  'page.route.input.placeholder.newPath': 'Par exemple : /foo/bar/index.html',
+  'page.route.steps.stepTitle.defineApiRequest': 'Définir la requête API',
+  'page.route.steps.stepTitle.defineApiBackendServe': 'Définir le serveur backend API',
+  'page.route.popconfirm.title.offline': 'Êtes-vous sûr de mettre cette route hors ligne?',
+  'page.route.radio.static': 'Statique',
+  'page.route.radio.regex': 'Regex',
+  'page.route.form.itemLabel.from': 'De',
+  'page.route.form.itemHelp.status':
+    'Indique si une route peut être utilisée après sa création, la valeur par défaut est false.',
+  'page.route.host': 'Hôte',
+  'page.route.path': 'Chemin',
+  'page.route.remoteAddrs': 'Adresses distantes',
+  'page.route.PanelSection.title.defineRequestParams': 'Définir les paramètres de requête',
+  'page.route.PanelSection.title.responseResult': 'Résultat de la réponse',
+  'page.route.debug.showResultAfterSendRequest': "Afficher le résultat après l'envoi de la requête",
+  'page.route.TabPane.queryParams': 'Paramètres de requête',
+  'page.route.TabPane.bodyParams': 'Paramètres du corps',
+  'page.route.TabPane.headerParams': "Paramètres d'en-tête",
+  'page.route.TabPane.authentication': 'Authentification',
+  'page.route.TabPane.response': 'Réponse',
+  'page.route.TabPane.header': 'En-tête de réponse',
+  'page.route.debugWithoutAuth': "Cette requête n'utilise aucune autorisation.",
+  'page.route.button.exportOpenApi': 'Exporter OpenAPI',
+  'page.route.exportRoutesTips': 'Veuillez choisir le type de fichier que vous souhaitez exporter',
+  'page.route.button.importOpenApi': 'Importer OpenAPI',
+  'page.route.button.selectFile': 'Veuillez sélectionner le fichier',
+  'page.route.list': 'Routes',
+  'page.route.panelSection.title.requestOverride': 'Remplacement de la requête',
+  'page.route.form.itemLabel.headerRewrite': "Remplacement de l'en-tête",
+  'page.route.tooltip.pluginOrchOnlySupportChrome':
+    "L'orchestration de plugin prend en charge uniquement Chrome.",
+  'page.route.tooltip.pluginOrchWithoutProxyRewrite':
+    "Le mode d'orchestration de plugin ne peut pas être utilisé lorsque le remplacement de requête est configuré à l'étape 1.",
+  'page.route.tooltip.pluginOrchWithoutRedirect':
+    "Le mode d'orchestration de plugin ne peut pas être utilisé lorsque la redirection à l'étape 1 est activée pour activer HTTPS.",
+  'page.route.tabs.normalMode': 'Normal',
+  'page.route.tabs.orchestration': 'Orchestration',
+  'page.route.list.description':
+    "La route est le point d'entrée d'une requête, qui définit les règles de correspondance entre une requête client et un service. Une route peut être associée à un service (Service), à un amont (Upstream), un service pouvant correspondre à un ensemble de routes et une route pouvant correspondre à un objet amont (un ensemble de nœuds de service backend), de sorte que chaque requête correspondant à une route sera relayée par la passerelle vers le service amont lié à la route.",
+  'page.route.configuration.name.rules.required.description': 'Veuillez saisir le nom de la route',
+  'page.route.configuration.name.placeholder': 'Veuillez saisir le nom de la route',
+  'page.route.configuration.desc.tooltip': 'Veuillez saisir la description de la route',
+  'page.route.configuration.publish.tooltip':
+    'Utilisé pour contrôler si une route est publiée sur la passerelle immédiatement après sa création',
+  'page.route.configuration.version.placeholder':
+    'Veuillez saisir le numéro de version de la route',
+  'page.route.configuration.version.tooltip': 'Numéro de version de la route, par exemple V1',
+  'page.route.configuration.normal-labels.tooltip':
+    'Ajoutez des étiquettes personnalisées aux routes pouvant être utilisées pour le regroupement des routes.',
+  'page.route.configuration.path.rules.required.description':
+    'Veuillez saisir un chemin de requête HTTP valide',
+  'page.route.configuration.path.placeholder': 'Veuillez saisir le chemin de requête HTTP',
+  'page.route.configuration.remote_addrs.placeholder': "Veuillez saisir l'adresse client",
+  'page.route.configuration.host.placeholder': "Veuillez saisir le nom d'hôte de la requête HTTP",
+  'page.route.service.none': 'Aucun',
+  'page.route.rule.create': 'Créer une règle',
+  'page.route.rule.edit': 'Configurer une règle',
+  'page.route.advanced-match.operator.sample.IN':
+    'Veuillez entrer un tableau, par exemple ["1", "2"]',
+  'page.route.advanced-match.operator.sample.~~':
+    'Veuillez entrer une expression régulière, par exemple [a-z]+',
+  'page.route.fields.service_id.invalid':
+    'Veuillez vérifier la configuration de liaison du service',
+  'page.route.fields.service_id.without-upstream':
+    "Si vous ne liez pas le service, vous devez définir l'amont (Étape 2)",
+  'page.route.advanced-match.tooltip':
+    'Il prend en charge la correspondance de route via les en-têtes de requête, les paramètres de requête et les cookies, et peut être appliqué à des scénarios tels que la publication en niveaux de gris et les tests bleu-vert.',
+  'page.route.advanced-match.message': 'Conseils',
+  'page.route.advanced-match.tips.requestParameter': 'Paramètre de requête : Requête URL',
+  'page.route.advanced-match.tips.postRequestParameter':
+    'Paramètre de requête POST : Prise en charge du formulaire x-www-form-urlencoded',
+  'page.route.advanced-match.tips.builtinParameter':
+    'Paramètre intégré : Paramètres internes de Nginx',
+  'page.route.fields.custom.redirectOption.tooltip': 'Cela concerne le plugin de redirection',
+  'page.route.fields.service_id.tooltip':
+    "Associez l'objet Service pour réutiliser leur configuration.",
+  'page.route.fields.vars.invalid':
+    'Veuillez vérifier la configuration de la condition de correspondance avancée',
+  'page.route.fields.vars.in.invalid':
+    "Lors de l'utilisation de l'opérateur IN, entrez les valeurs des paramètres au format tableau.",
+  'page.route.data_loader.import': 'Importer',
+  'page.route.data_loader.import_panel': 'Importer des données',
+  'page.route.data_loader.types.openapi3': 'OpenAPI 3',
+  'page.route.data_loader.types.openapi_legacy': 'OpenAPI 3 Legacy',
+  'page.route.data_loader.labels.loader_type': 'Type de chargeur de données',
+  'page.route.data_loader.labels.task_name': 'Nom de la tâche',
+  'page.route.data_loader.labels.upload': 'Télécharger',
+  'page.route.data_loader.labels.openapi3_merge_method': 'Fusionner les méthodes HTTP',
+  'page.route.data_loader.tips.select_type': 'Veuillez sélectionner le chargeur de données',
+  'page.route.data_loader.tips.input_task_name': "Veuillez saisir le nom de la tâche d'importation",
+  'page.route.data_loader.tips.click_upload': 'Cliquez pour télécharger',
+  'page.route.data_loader.tips.openapi3_merge_method':
+    'Permet de fusionner plusieurs méthodes HTTP dans le chemin OpenAPI en une seule route. Lorsque vous avez plusieurs méthodes HTTP dans votre chemin avec une configuration différente (par exemple, securitySchema), vous pouvez désactiver cette option pour les générer en plusieurs routes.',
+};

--- a/web/src/pages/SSL/locales/fr-FR.ts
+++ b/web/src/pages/SSL/locales/fr-FR.ts
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export default {
+  'page.ssl.form.itemLabel.expireTime': "Date d'expiration",
+  'page.ssl.form.itemLabel.cert': 'Contenu du certificat',
+  'page.ssl.form.itemRuleMessage.certValueLength':
+    'Le contenu du certificat doit comporter au moins 128 caractères',
+  'page.ssl.form.itemLabel.privateKey': 'Clé privée',
+  'page.ssl.form.itemRuleMessage.privateKeyLength':
+    'La clé privée doit comporter au moins 128 caractères',
+  'page.ssl.button.uploadCert': 'Télécharger le certificat',
+  'page.ssl.form.itemLabel.way': 'Méthode',
+  'page.ssl.select.placeholder.selectCreateWays': 'Veuillez sélectionner la méthode de création',
+  'page.ssl.selectOption.input': 'Saisir',
+  'page.ssl.upload': 'Télécharger',
+  'page.ssl.notification.updateCertEnableStatusSuccessfully':
+    "Mise à jour de l'état d'activation du certificat réussie",
+  'page.ssl.list': 'Liste SSL',
+  'page.ssl.list.expirationTime': "Date d'expiration",
+  'page.ssl.list.ifEnable': 'Actif',
+  'page.ssl.list.periodOfValidity': 'Période de validité',
+  'page.ssl.steps.stepTitle.completeCertInfo': 'Compléter les informations du certificat',
+  'component.ssl.removeSSLSuccess': 'Suppression du SSL cible réussie',
+  'component.ssl.removeSSLItemModalContent': 'Vous êtes sur le point de supprimer cet élément !',
+  'component.ssl.description':
+    "Le certificat est utilisé par la passerelle pour traiter les demandes chiffrées, qui seront associées au SNI et liées au nom d'hôte dans la route.",
+  'component.ssl.fields.cert.required': 'Veuillez entrer le certificat',
+  'component.ssl.fields.key.required': 'Veuillez entrer la clé',
+};

--- a/web/src/pages/ServerInfo/locales/fr-FR.ts
+++ b/web/src/pages/ServerInfo/locales/fr-FR.ts
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export default {
+  'page.systemStatus.pageContainer.title': 'Informations système',
+  'page.systemStatus.select.placeholder': 'Veuillez sélectionner un nœud Apache APISIX',
+  'page.systemStatus.desc':
+    'Le plugin correspondant doit être activé pour signaler les informations du serveur.',
+  'page.systemStatus.link': 'Comment activer?',
+  'page.systemStatus.dashboardInfo': 'Tableau de bord',
+  'page.systemStatus.nodeInfo': 'Nœuds APISIX',
+};

--- a/web/src/pages/Service/locales/fr-FR.ts
+++ b/web/src/pages/Service/locales/fr-FR.ts
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export default {
+  'page.service.steps.stepTitle.basicInformation': 'Informations de base',
+  'page.service.steps.stepTitle.pluginConfig': 'Configuration du plugin',
+  'page.service.steps.stepTitle.preview': 'Aperçu',
+  'page.service.list': 'Liste des services',
+  'page.service.description':
+    "Un service est constitué d'une combinaison de configuration de plugin public et d'informations sur la cible amont dans une route. Les services sont associés aux routes et aux amonts, et un service peut correspondre à un ensemble de nœuds amont et peut être lié à plusieurs routes.",
+  'page.service.fields.name.required': 'Veuillez saisir le nom du service',
+  'page.service.fields.hosts': 'Hôtes',
+  'page.service.fields.hosts.placeholder': 'Veuillez saisir les hôtes du service',
+  'page.service.create': 'Créer un service',
+  'page.service.configure': 'Configurer le service',
+};

--- a/web/src/pages/Setting/locales/fr-FR.ts
+++ b/web/src/pages/Setting/locales/fr-FR.ts
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export default {
+  'page.setting.notification.update.configuration.successfully':
+    'Mise à jour de la configuration réussie',
+  'page.setting.pageContainer.title': 'Paramètres',
+  'page.setting.form.item.grafanaURL': 'Adresse Grafana',
+  'page.setting.form.item.grafanaURL.inputHelpMessage':
+    "L'adresse Grafana doit commencer par HTTP ou HTTPS",
+  'page.setting.form.item.grafanaURL.inputErrorMessage': "L'adresse n'est pas valide",
+};

--- a/web/src/pages/Upstream/locales/fr-FR.ts
+++ b/web/src/pages/Upstream/locales/fr-FR.ts
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export default {
+  'page.upstream.step.select.upstream': 'Amont',
+  'page.upstream.step.select.upstream.select.option': 'Personnalisé',
+  'page.upstream.step.select.upstream.select.option.serviceSelected':
+    'Personnalisé (La configuration actuelle remplacera le service lié)',
+  'page.upstream.step.select.upstream.select.none': 'Aucun',
+  'page.upstream.step.backend.server.domain.or.ip': 'Hôte/IP du serveur backend',
+  'page.upstream.form.item-label.node.domain.or.ip': 'Cibles',
+  'page.upstream.step.input.domain.name.or.ip': "Veuillez entrer le domaine ou l'IP",
+  'page.upstream.step.valid.domain.name.or.ip': 'Veuillez entrer un domaine ou une IP valide',
+  'page.upstream.step.domain.name.or.ip': "Nom d'hôte ou IP",
+  'page.upstream.step.host': 'Hôte',
+  'page.upstream.step.input.port': 'Veuillez entrer le numéro de port',
+  'page.upstream.step.port': 'Port',
+  'page.upstream.step.input.weight': 'Veuillez entrer le poids',
+  'page.upstream.step.weight': 'Poids',
+  'page.upstream.step.create': 'Créer',
+  'page.upstream.step.name': 'Nom',
+  'page.upstream.step.name.should.unique': 'Le nom doit être unique',
+  'page.upstream.step.input.upstream.name': "Veuillez entrer le nom de l'amont",
+  'page.upstream.step.description': 'Description',
+  'page.upstream.step.input.description': "Veuillez entrer la description de l'amont",
+  'page.upstream.step.type': 'Algorithme',
+  'page.upstream.step.pass-host': "Nom d'hôte",
+  'page.upstream.step.pass-host.pass': 'Conserver le même hôte de la demande client',
+  'page.upstream.step.pass-host.node': "Utiliser le domaine ou l'IP de la liste des nœuds",
+  'page.upstream.step.pass-host.rewrite': "Hôte personnalisé (Sera obsolète à l'avenir)",
+  'page.upstream.step.pass-host.upstream_host': 'Hôte personnalisé',
+  'page.upstream.step.connect.timeout': 'Délai de connexion',
+  'page.upstream.step.connect.timeout.desc':
+    "Délai d'établissement d'une connexion de la demande au serveur amont",
+  'page.upstream.step.input.connect.timeout': 'Veuillez entrer le délai de connexion',
+  'page.upstream.step.send.timeout': "Délai d'envoi",
+  'page.upstream.step.send.timeout.desc': "Délai d'envoi des données aux serveurs amont",
+  'page.upstream.step.input.send.timeout': "Veuillez entrer le délai d'envoi",
+  'page.upstream.step.read.timeout': 'Délai de lecture',
+  'page.upstream.step.read.timeout.desc': 'Délai de réception des données des serveurs amont',
+  'page.upstream.step.input.read.timeout': 'Veuillez entrer le délai de lecture',
+  'page.upstream.step.healthyCheck.healthy.check': 'Vérification de santé',
+  'page.upstream.step.healthyCheck.healthy': 'Sain',
+  'page.upstream.step.healthyCheck.unhealthy': 'Malsain',
+  'page.upstream.step.healthyCheck.healthy.status': 'État sain',
+  'page.upstream.step.healthyCheck.unhealthyStatus': 'État malsain',
+  'page.upstream.step.healthyCheck.active': 'Actif',
+  'page.upstream.step.healthyCheck.active.timeout': 'Délai',
+  'page.upstream.step.input.healthyCheck.active.timeout': 'Veuillez entrer le délai',
+  'page.upstream.step.input.healthyCheck.activeInterval': "Veuillez entrer l'intervalle",
+  'page.upstream.step.input.healthyCheck.active.req_headers':
+    'Veuillez entrer les en-têtes de demande',
+  'page.upstream.step.healthyCheck.passive': 'Passif',
+  'page.upstream.step.healthyCheck.passive.http_statuses': 'Statuts HTTP',
+  'page.upstream.step.input.healthyCheck.passive.http_statuses': 'Veuillez entrer le statut HTTP',
+  'page.upstream.step.healthyCheck.passive.tcp_failures': 'Échecs TCP',
+  'page.upstream.step.input.healthyCheck.passive.tcp_failures': 'Veuillez entrer les échecs TCP',
+  'page.upstream.step.keepalive_pool': 'Pool de maintien de la connexion',
+  'page.upstream.notificationMessage.enableHealthCheckFirst':
+    "Veuillez d'abord activer la vérification de santé.",
+  'page.upstream.upstream_host.required': "Veuillez entrer l'hôte personnalisé",
+  'page.upstream.create': "Créer l'amont",
+  'page.upstream.configure': "Configurer l'amont",
+  'page.upstream.create.upstream.successfully': "Création de l'amont réussie",
+  'page.upstream.edit.upstream.successfully': "Configuration de l'amont réussie",
+  'page.upstream.create.basic.info': 'Informations de base',
+  'page.upstream.create.preview': 'Aperçu',
+  'page.upstream.list.id': 'ID',
+  'page.upstream.list.name': 'Nom',
+  'page.upstream.list.type': 'Type',
+  'page.upstream.list.description': 'Description',
+  'page.upstream.list.edit.time': 'Heure de mise à jour',
+  'page.upstream.list.operation': 'Opération',
+  'page.upstream.list.edit': 'Configurer',
+  'page.upstream.list.confirm.delete': 'Êtes-vous sûr de vouloir supprimer ?',
+  'page.upstream.list.confirm': 'Confirmer',
+  'page.upstream.list.cancel': 'Annuler',
+  'page.upstream.list.delete.successfully': "Suppression de l'amont réussie",
+  'page.upstream.list.delete': 'Supprimer',
+  'page.upstream.list': 'Liste des amonts',
+  'page.upstream.list.input': 'Veuillez entrer',
+  'page.upstream.list.create': 'Créer',
+  'page.upstream.type.roundrobin': 'Round Robin',
+  'page.upstream.type.chash': 'CHash',
+  'page.upstream.type.ewma': 'EWMA',
+  'page.upstream.type.least_conn': 'Moins de conn',
+  'page.upstream.list.content':
+    "La liste des amonts contient les services amonts créés (c'est-à-dire, les services backend) et permet l'équilibrage de charge et la vérification de l'état de plusieurs nœuds cibles des services amonts.",
+  'page.upstream.checks.active.timeout.description':
+    'Délai de socket pour les vérifications actives (en secondes)',
+  'page.upstream.checks.active.unhealthy.interval.description':
+    'Intervalle entre les vérifications des cibles malsaines (en secondes)',
+  'page.upstream.checks.passive.healthy.http_statuses.description':
+    'Quels statuts HTTP considérer comme un succès',
+  'page.upstream.checks.passive.unhealthy.http_statuses.description':
+    'Quels statuts HTTP considérer comme un échec',
+  'page.upstream.checks.passive.unhealthy.http_failures.description':
+    "Nombre d'échecs HTTP à considérer comme une cible malsaine",
+  'page.upstream.checks.passive.unhealthy.tcp_failures.description':
+    "Nombre d'échecs TCP à considérer comme une cible malsaine",
+  'page.upstream.scheme': 'Schéma',
+  'page.upstream.other.configuration.invalid': "Veuillez vérifier la configuration de l'amont",
+};

--- a/web/src/pages/User/locales/fr-FR.ts
+++ b/web/src/pages/User/locales/fr-FR.ts
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export default {
+  'component.user.login': 'Connexion',
+  'component.user.loginMethodPassword': "Nom d'utilisateur & Mot de passe",
+  'component.user.loginMethodPassword.username': "Nom d'utilisateur",
+  'component.user.loginMethodPassword.password': 'Mot de passe',
+  'component.user.loginMethodPassword.inputUsername': "Veuillez saisir le nom d'utilisateur",
+  'component.user.loginMethodPassword.inputPassword': 'Veuillez saisir le mot de passe',
+  'component.user.loginMethodPassword.incorrectPassword':
+    "Nom d'utilisateur ou mot de passe incorrect",
+  'component.user.loginMethodPassword.fieldInvalid':
+    "Veuillez vérifier le nom d'utilisateur et le mot de passe",
+  'component.user.loginMethodPassword.success': 'Connexion réussie',
+  'component.user.loginMethodPassword.changeDefaultAccount':
+    "Comment mettre à jour le nom d'utilisateur/mot de passe?",
+  'component.user.loginMethodPassword.modificationMethod':
+    'Veuillez modifier le champ "users" dans le fichier /api/conf/conf.yaml',
+};


### PR DESCRIPTION
### Issue
Resolves [#1407](https://github.com/apache/apisix-dashboard/issues/1407)

### Summary
This merge request addresses the internationalization (i18n) enhancement request to add French language support to APISIX Dashboard.

### Changes Made

1. **Global Locales:** Added French translations to the global locales file located at _src/locales._
2. **Page-Specific Locales**: Modified the French translations for each page in their respective locale files under _src/pages/$PAGE/locales._
3. **Component-Specific Locales:** Updated the Component's locale file with French translations under _src/components/$COMPONENT/locales._

### Implementation Details
Utilized key-based translation for consistency across all locales.

### Additional Notes:
Please review and provide feedback on the implementation of French language support.
Ensure that the changes align with the project's coding standards and best practices.

### Reference:
Utilized guidelines from [User Guide](https://github.com/apache/apisix-dashboard/blob/a34317193cece2532ed333aaaacfd3a6af7328c4/docs/I18N_USER_GUIDE.md) for making these changes.

### Conclusion
This merge request contributes to enhancing the APISIX Dashboard's internationalization capabilities, specifically by introducing French language support. The changes are comprehensive.


