### PR TITLE
feat: disable editing of IDs while editing

### DIFF
--- a/src/components/form-slice/FormPartCredential.tsx
+++ b/src/components/form-slice/FormPartCredential.tsx
@@ -19,16 +19,11 @@ import { useTranslation } from 'react-i18next';
 import { FormItemPlugins } from './FormItemPlugins';
 import { FormPartBasic } from './FormPartBasic';
 import { FormSection } from './FormSection';
-import {
-  FormSectionGeneral,
-  type FormSectionGeneralProps,
-} from './FormSectionGeneral';
 
-export const FormPartCredential = (props: FormSectionGeneralProps) => {
+export const FormPartCredential = () => {
   const { t } = useTranslation();
   return (
     <>
-      <FormSectionGeneral showDate={false} {...props} />
       <FormPartBasic showName={false} />
       <FormSection legend={t('form.plugins.label')}>
         <FormItemPlugins name="plugins" schema="consumer_schema" />

--- a/src/components/form-slice/FormPartGlobalRules.tsx
+++ b/src/components/form-slice/FormPartGlobalRules.tsx
@@ -18,15 +18,11 @@ import { t } from 'i18next';
 
 import { FormItemPlugins } from './FormItemPlugins';
 import { FormSection } from './FormSection';
-import { FormSectionGeneral } from './FormSectionGeneral';
 
 export const FormPartGlobalRules = () => {
   return (
-    <>
-      <FormSectionGeneral showDate={false} />
-      <FormSection legend={t('form.plugins.label')}>
-        <FormItemPlugins name="plugins" />
-      </FormSection>
-    </>
+    <FormSection legend={t('form.plugins.label')}>
+      <FormItemPlugins name="plugins" />
+    </FormSection>
   );
 };

--- a/src/components/form-slice/FormPartPluginConfig.tsx
+++ b/src/components/form-slice/FormPartPluginConfig.tsx
@@ -16,21 +16,15 @@
  */
 import { FormPartBasic, type FormPartBasicProps } from './FormPartBasic';
 import { FormSectionPluginsOnly } from './FormPartConsumer';
-import {
-  FormSectionGeneral,
-  type FormSectionGeneralProps,
-} from './FormSectionGeneral';
 
 export const FormPartPluginConfig = (
   props: {
     basicProps?: FormPartBasicProps;
-    generalProps?: FormSectionGeneralProps;
   } = {}
 ) => {
-  const { generalProps, basicProps } = props;
+  const { basicProps } = props;
   return (
     <>
-      <FormSectionGeneral {...generalProps} />
       <FormPartBasic {...basicProps} />
       <FormSectionPluginsOnly />
     </>

--- a/src/components/form-slice/FormSectionGeneral.tsx
+++ b/src/components/form-slice/FormSectionGeneral.tsx
@@ -46,7 +46,7 @@ const FormItemID = () => {
 };
 
 export type FormSectionGeneralProps = {
-  /** will be default to `!readOnly` */
+  /** will be default to `readOnly` */
   showDate?: boolean;
   showID?: boolean;
   readOnly?: boolean;

--- a/src/components/form-slice/FormSectionGeneral.tsx
+++ b/src/components/form-slice/FormSectionGeneral.tsx
@@ -53,7 +53,7 @@ export type FormSectionGeneralProps = {
 };
 
 export const FormSectionGeneral = (props: FormSectionGeneralProps) => {
-  const { showDate = !props.readOnly, showID = true, readOnly = false } = props;
+  const { showDate = props.readOnly, showID = true, readOnly = false } = props;
   const { t } = useTranslation();
   // we use fieldset disabled to show readonly state
   // because mantine readOnly style looks like we can edit

--- a/src/components/form-slice/FormSectionGeneral.tsx
+++ b/src/components/form-slice/FormSectionGeneral.tsx
@@ -46,13 +46,14 @@ const FormItemID = () => {
 };
 
 export type FormSectionGeneralProps = {
+  /** will be default to `!readOnly` */
   showDate?: boolean;
   showID?: boolean;
   readOnly?: boolean;
 };
 
 export const FormSectionGeneral = (props: FormSectionGeneralProps) => {
-  const { showDate = true, showID = true, readOnly = false } = props;
+  const { showDate = !props.readOnly, showID = true, readOnly = false } = props;
   const { t } = useTranslation();
   // we use fieldset disabled to show readonly state
   // because mantine readOnly style looks like we can edit

--- a/src/routes/consumer_groups/add.tsx
+++ b/src/routes/consumer_groups/add.tsx
@@ -26,6 +26,7 @@ import { putConsumerGroupReq } from '@/apis/consumer_groups';
 import { FormSubmitBtn } from '@/components/form/Btn';
 import { FormPartPluginConfig } from '@/components/form-slice/FormPartPluginConfig';
 import { FormTOCBox } from '@/components/form-slice/FormSection';
+import { FormSectionGeneral } from '@/components/form-slice/FormSectionGeneral';
 import PageHeader from '@/components/page/PageHeader';
 import { req } from '@/config/req';
 import { APISIX, type APISIXType } from '@/types/schema/apisix';
@@ -67,10 +68,8 @@ const ConsumerGroupAddForm = () => {
           putConsumerGroup.mutateAsync(pipeProduce()(d))
         )}
       >
-        <FormPartPluginConfig
-          generalProps={{ showDate: false }}
-          basicProps={{ showName: false }}
-        />
+        <FormSectionGeneral />
+        <FormPartPluginConfig basicProps={{ showName: false }} />
         <FormSubmitBtn>{t('form.btn.add')}</FormSubmitBtn>
       </form>
     </FormProvider>

--- a/src/routes/consumer_groups/add.tsx
+++ b/src/routes/consumer_groups/add.tsx
@@ -68,7 +68,7 @@ const ConsumerGroupAddForm = () => {
           putConsumerGroup.mutateAsync(pipeProduce()(d))
         )}
       >
-        <FormSectionGeneral showDate={false} />
+        <FormSectionGeneral />
         <FormPartPluginConfig basicProps={{ showName: false }} />
         <FormSubmitBtn>{t('form.btn.add')}</FormSubmitBtn>
       </form>

--- a/src/routes/consumer_groups/add.tsx
+++ b/src/routes/consumer_groups/add.tsx
@@ -68,7 +68,7 @@ const ConsumerGroupAddForm = () => {
           putConsumerGroup.mutateAsync(pipeProduce()(d))
         )}
       >
-        <FormSectionGeneral />
+        <FormSectionGeneral showDate={false} />
         <FormPartPluginConfig basicProps={{ showName: false }} />
         <FormSubmitBtn>{t('form.btn.add')}</FormSubmitBtn>
       </form>

--- a/src/routes/consumer_groups/detail.$id.tsx
+++ b/src/routes/consumer_groups/detail.$id.tsx
@@ -33,6 +33,7 @@ import { getConsumerGroupQueryOptions } from '@/apis/hooks';
 import { FormSubmitBtn } from '@/components/form/Btn';
 import { FormPartPluginConfig } from '@/components/form-slice/FormPartPluginConfig';
 import { FormTOCBox } from '@/components/form-slice/FormSection';
+import { FormSectionGeneral } from '@/components/form-slice/FormSectionGeneral';
 import { DeleteResourceBtn } from '@/components/page/DeleteResourceBtn';
 import PageHeader from '@/components/page/PageHeader';
 import { API_CONSUMER_GROUPS } from '@/config/constant';
@@ -87,10 +88,8 @@ const ConsumerGroupDetailForm = (props: Props) => {
           putConsumerGroup.mutateAsync(pipeProduce()({ ...d, id }))
         )}
       >
-        <FormPartPluginConfig
-          generalProps={{ showDate: true }}
-          basicProps={{ showName: false }}
-        />
+        <FormSectionGeneral readOnly />
+        <FormPartPluginConfig basicProps={{ showName: false }} />
         {!readOnly && (
           <Group>
             <FormSubmitBtn>{t('form.btn.save')}</FormSubmitBtn>

--- a/src/routes/consumers/detail.$username/credentials/add.tsx
+++ b/src/routes/consumers/detail.$username/credentials/add.tsx
@@ -26,6 +26,7 @@ import { putCredentialReq } from '@/apis/credentials';
 import { FormSubmitBtn } from '@/components/form/Btn';
 import { FormPartCredential } from '@/components/form-slice/FormPartCredential';
 import { FormTOCBox } from '@/components/form-slice/FormSection';
+import { FormSectionGeneral } from '@/components/form-slice/FormSectionGeneral';
 import PageHeader from '@/components/page/PageHeader';
 import { DetailCredentialsTabs } from '@/components/page-slice/consumers/DetailCredentialsTabs';
 import { req } from '@/config/req';
@@ -69,6 +70,7 @@ const CredentialAddForm = () => {
   return (
     <FormProvider {...form}>
       <form onSubmit={form.handleSubmit((d) => putCredential.mutateAsync(d))}>
+        <FormSectionGeneral />
         <FormPartCredential />
         <FormSubmitBtn>{t('form.btn.add')}</FormSubmitBtn>
       </form>

--- a/src/routes/consumers/detail.$username/credentials/add.tsx
+++ b/src/routes/consumers/detail.$username/credentials/add.tsx
@@ -70,7 +70,7 @@ const CredentialAddForm = () => {
   return (
     <FormProvider {...form}>
       <form onSubmit={form.handleSubmit((d) => putCredential.mutateAsync(d))}>
-        <FormSectionGeneral />
+        <FormSectionGeneral showDate={false} />
         <FormPartCredential />
         <FormSubmitBtn>{t('form.btn.add')}</FormSubmitBtn>
       </form>

--- a/src/routes/consumers/detail.$username/credentials/add.tsx
+++ b/src/routes/consumers/detail.$username/credentials/add.tsx
@@ -70,7 +70,7 @@ const CredentialAddForm = () => {
   return (
     <FormProvider {...form}>
       <form onSubmit={form.handleSubmit((d) => putCredential.mutateAsync(d))}>
-        <FormSectionGeneral showDate={false} />
+        <FormSectionGeneral />
         <FormPartCredential />
         <FormSubmitBtn>{t('form.btn.add')}</FormSubmitBtn>
       </form>

--- a/src/routes/consumers/detail.$username/credentials/detail.$id.tsx
+++ b/src/routes/consumers/detail.$username/credentials/detail.$id.tsx
@@ -33,6 +33,7 @@ import { getCredentialQueryOptions } from '@/apis/hooks';
 import { FormSubmitBtn } from '@/components/form/Btn';
 import { FormPartCredential } from '@/components/form-slice/FormPartCredential';
 import { FormTOCBox } from '@/components/form-slice/FormSection';
+import { FormSectionGeneral } from '@/components/form-slice/FormSectionGeneral';
 import { DeleteResourceBtn } from '@/components/page/DeleteResourceBtn';
 import PageHeader from '@/components/page/PageHeader';
 import { DetailCredentialsTabs } from '@/components/page-slice/consumers/DetailCredentialsTabs';
@@ -93,7 +94,8 @@ const CredentialDetailForm = (props: CredentialFormProps) => {
   return (
     <FormProvider {...form}>
       <form onSubmit={form.handleSubmit((d) => putCredential.mutateAsync(d))}>
-        <FormPartCredential showDate />
+        <FormSectionGeneral readOnly />
+        <FormPartCredential />
         {!readOnly && (
           <Group>
             <FormSubmitBtn>{t('form.btn.save')}</FormSubmitBtn>

--- a/src/routes/consumers/detail.$username/index.tsx
+++ b/src/routes/consumers/detail.$username/index.tsx
@@ -92,7 +92,7 @@ const ConsumerDetailForm = (props: Props) => {
           putConsumer.mutateAsync(pipeProduce()(d));
         })}
       >
-        <FormSectionGeneral showID={false} />
+        <FormSectionGeneral showID={false} readOnly />
         <FormPartConsumer />
         {!readOnly && (
           <Group>

--- a/src/routes/global_rules/add.tsx
+++ b/src/routes/global_rules/add.tsx
@@ -29,6 +29,7 @@ import { putGlobalRuleReq } from '@/apis/global_rules';
 import { FormSubmitBtn } from '@/components/form/Btn';
 import { FormPartGlobalRules } from '@/components/form-slice/FormPartGlobalRules';
 import { FormTOCBox } from '@/components/form-slice/FormSection';
+import { FormSectionGeneral } from '@/components/form-slice/FormSectionGeneral';
 import PageHeader from '@/components/page/PageHeader';
 import { req } from '@/config/req';
 import type { APISIXType } from '@/types/schema/apisix';
@@ -67,6 +68,7 @@ const GlobalRuleAddForm = () => {
   return (
     <FormProvider {...form}>
       <form onSubmit={form.handleSubmit((d) => putGlobalRule.mutateAsync(d))}>
+        <FormSectionGeneral />
         <FormPartGlobalRules />
         <FormSubmitBtn>{t('form.btn.add')}</FormSubmitBtn>
       </form>

--- a/src/routes/global_rules/add.tsx
+++ b/src/routes/global_rules/add.tsx
@@ -68,7 +68,7 @@ const GlobalRuleAddForm = () => {
   return (
     <FormProvider {...form}>
       <form onSubmit={form.handleSubmit((d) => putGlobalRule.mutateAsync(d))}>
-        <FormSectionGeneral />
+        <FormSectionGeneral showDate={false} />
         <FormPartGlobalRules />
         <FormSubmitBtn>{t('form.btn.add')}</FormSubmitBtn>
       </form>

--- a/src/routes/global_rules/add.tsx
+++ b/src/routes/global_rules/add.tsx
@@ -68,7 +68,7 @@ const GlobalRuleAddForm = () => {
   return (
     <FormProvider {...form}>
       <form onSubmit={form.handleSubmit((d) => putGlobalRule.mutateAsync(d))}>
-        <FormSectionGeneral showDate={false} />
+        <FormSectionGeneral />
         <FormPartGlobalRules />
         <FormSubmitBtn>{t('form.btn.add')}</FormSubmitBtn>
       </form>

--- a/src/routes/global_rules/detail.$id.tsx
+++ b/src/routes/global_rules/detail.$id.tsx
@@ -33,6 +33,7 @@ import { getGlobalRuleQueryOptions } from '@/apis/hooks';
 import { FormSubmitBtn } from '@/components/form/Btn';
 import { FormPartGlobalRules } from '@/components/form-slice/FormPartGlobalRules';
 import { FormTOCBox } from '@/components/form-slice/FormSection';
+import { FormSectionGeneral } from '@/components/form-slice/FormSectionGeneral';
 import { DeleteResourceBtn } from '@/components/page/DeleteResourceBtn';
 import PageHeader from '@/components/page/PageHeader';
 import { API_GLOBAL_RULES } from '@/config/constant';
@@ -79,6 +80,7 @@ const GlobalRuleDetailForm = (props: Props) => {
   return (
     <FormProvider {...form}>
       <form onSubmit={form.handleSubmit((d) => putGlobalRule.mutateAsync(d))}>
+        <FormSectionGeneral readOnly />
         <FormPartGlobalRules />
         {!readOnly && (
           <Group>

--- a/src/routes/plugin_configs/add.tsx
+++ b/src/routes/plugin_configs/add.tsx
@@ -26,6 +26,7 @@ import { putPluginConfigReq } from '@/apis/plugin_configs';
 import { FormSubmitBtn } from '@/components/form/Btn';
 import { FormPartPluginConfig } from '@/components/form-slice/FormPartPluginConfig';
 import { FormTOCBox } from '@/components/form-slice/FormSection';
+import { FormSectionGeneral } from '@/components/form-slice/FormSectionGeneral';
 import PageHeader from '@/components/page/PageHeader';
 import { req } from '@/config/req';
 import { APISIX, type APISIXType } from '@/types/schema/apisix';
@@ -67,7 +68,8 @@ const PluginConfigAddForm = () => {
           putPluginConfig.mutateAsync(pipeProduce()(d))
         )}
       >
-        <FormPartPluginConfig generalProps={{ showDate: false }} />
+        <FormSectionGeneral />
+        <FormPartPluginConfig />
         <FormSubmitBtn>{t('form.btn.add')}</FormSubmitBtn>
       </form>
     </FormProvider>

--- a/src/routes/plugin_configs/add.tsx
+++ b/src/routes/plugin_configs/add.tsx
@@ -68,7 +68,7 @@ const PluginConfigAddForm = () => {
           putPluginConfig.mutateAsync(pipeProduce()(d))
         )}
       >
-        <FormSectionGeneral showDate={false} />
+        <FormSectionGeneral />
         <FormPartPluginConfig />
         <FormSubmitBtn>{t('form.btn.add')}</FormSubmitBtn>
       </form>

--- a/src/routes/plugin_configs/add.tsx
+++ b/src/routes/plugin_configs/add.tsx
@@ -68,7 +68,7 @@ const PluginConfigAddForm = () => {
           putPluginConfig.mutateAsync(pipeProduce()(d))
         )}
       >
-        <FormSectionGeneral />
+        <FormSectionGeneral showDate={false} />
         <FormPartPluginConfig />
         <FormSubmitBtn>{t('form.btn.add')}</FormSubmitBtn>
       </form>

--- a/src/routes/plugin_configs/detail.$id.tsx
+++ b/src/routes/plugin_configs/detail.$id.tsx
@@ -33,6 +33,7 @@ import { putPluginConfigReq } from '@/apis/plugin_configs';
 import { FormSubmitBtn } from '@/components/form/Btn';
 import { FormPartPluginConfig } from '@/components/form-slice/FormPartPluginConfig';
 import { FormTOCBox } from '@/components/form-slice/FormSection';
+import { FormSectionGeneral } from '@/components/form-slice/FormSectionGeneral';
 import { DeleteResourceBtn } from '@/components/page/DeleteResourceBtn';
 import PageHeader from '@/components/page/PageHeader';
 import { API_PLUGIN_CONFIGS } from '@/config/constant';
@@ -85,6 +86,7 @@ const PluginConfigDetailForm = (props: Props) => {
   return (
     <FormProvider {...form}>
       <form onSubmit={form.handleSubmit((d) => putPluginConfig.mutateAsync(d))}>
+        <FormSectionGeneral readOnly />
         <FormPartPluginConfig />
         {!readOnly && (
           <Group>

--- a/src/routes/protos/detail.$id.tsx
+++ b/src/routes/protos/detail.$id.tsx
@@ -88,7 +88,7 @@ const ProtoDetailForm = ({ id, readOnly, setReadOnly }: ProtoFormProps) => {
   return (
     <FormProvider {...form}>
       <form onSubmit={form.handleSubmit((d) => putProto.mutateAsync(d))}>
-        <FormSectionGeneral />
+        <FormSectionGeneral readOnly />
         <FormPartProto allowUpload={!readOnly} />
         {!readOnly && (
           <Group>

--- a/src/routes/routes/detail.$id.tsx
+++ b/src/routes/routes/detail.$id.tsx
@@ -92,7 +92,7 @@ const RouteDetailForm = (props: Props) => {
   return (
     <FormProvider {...form}>
       <form onSubmit={form.handleSubmit((d) => putRoute.mutateAsync(d))}>
-        <FormSectionGeneral />
+        <FormSectionGeneral readOnly />
         <FormPartRoute />
         {!readOnly && (
           <Group>

--- a/src/routes/secrets/add.tsx
+++ b/src/routes/secrets/add.tsx
@@ -64,7 +64,7 @@ const SecretAddForm = () => {
   return (
     <FormProvider {...form}>
       <form onSubmit={form.handleSubmit((d) => putSecret.mutateAsync(d))}>
-        <FormSectionGeneral showDate={false} />
+        <FormSectionGeneral />
         <FormPartSecret />
         <FormSubmitBtn>{t('form.btn.add')}</FormSubmitBtn>
       </form>

--- a/src/routes/services/detail.$id.tsx
+++ b/src/routes/services/detail.$id.tsx
@@ -92,7 +92,7 @@ const ServiceDetailForm = (props: Props) => {
   return (
     <FormProvider {...form}>
       <form onSubmit={form.handleSubmit((d) => putService.mutateAsync(d))}>
-        <FormSectionGeneral />
+        <FormSectionGeneral readOnly />
         <FormPartService />
         {!readOnly && (
           <Group>

--- a/src/routes/ssls/detail.$id.tsx
+++ b/src/routes/ssls/detail.$id.tsx
@@ -96,7 +96,7 @@ const SSLDetailForm = (props: Props & { id: string }) => {
             putSSL.mutateAsync(pipeProduce()(d))
           )}
         >
-          <FormSectionGeneral />
+          <FormSectionGeneral readOnly />
           <FormPartSSL />
           {!readOnly && (
             <Group>

--- a/src/routes/stream_routes/detail.$id.tsx
+++ b/src/routes/stream_routes/detail.$id.tsx
@@ -88,7 +88,7 @@ const StreamRouteDetailForm = (props: Props) => {
   return (
     <FormProvider {...form}>
       <form onSubmit={form.handleSubmit((d) => putStreamRoute.mutateAsync(d))}>
-        <FormSectionGeneral />
+        <FormSectionGeneral readOnly />
         <FormPartStreamRoute />
         {!readOnly && (
           <Group>

--- a/src/routes/upstreams/detail.$id.tsx
+++ b/src/routes/upstreams/detail.$id.tsx
@@ -105,7 +105,7 @@ const UpstreamDetailForm = (
             putUpstream.mutateAsync(pipeProduce()(d));
           })}
         >
-          <FormSectionGeneral />
+          <FormSectionGeneral readOnly />
           <FormPartUpstream />
           {!readOnly && (
             <Group>


### PR DESCRIPTION
Please answer these questions before submitting a pull request, **or your PR will get closed**.

**Why submit this pull request?**

- [ ] Bugfix
- [x] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

All detail pages will not be able to edit the ID.

After this modification, `FormSectionGeneral` will have the following behavior:

**Default, Allow edit**

```tsx
<FormSectionGeneral />
```

![CleanShot 2025-06-04 at 14 27 31@2x](https://github.com/user-attachments/assets/6b6f2dae-7231-46c0-87d2-743ae1de891f)

**Read Only**

```tsx
// When you need to disable editing of id, you only need to set `readOnly`. 
// `created_at`, `updated_at` will be displayed.
<FormSectionGeneral readOnly />
```

![CleanShot 2025-06-04 at 14 27 53@2x](https://github.com/user-attachments/assets/71515a2b-9c2d-43a6-923b-8b32479181b4)
