### PR TITLE
feat(workflow/e2e): allow `workflow_dispatch` trigger tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,6 +13,7 @@ on:
     # This should be later than the update time of `apache/apisix:dev`
     # Ref: https://github.com/apache/apisix-docker/blob/master/.github/workflows/apisix_dev_push_docker_hub.yaml#L7C15-L7C16
     - cron: '0 2 * * *'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -20,8 +21,8 @@ concurrency:
 
 jobs:
   test:
-    # only run when e2e-test label is added or scheduled
-    if: ${{ (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'e2e-test')) || github.event_name == 'schedule' }}
+    # only run when e2e-test label is added, scheduled, workflow_dispatch
+    if: ${{ (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'e2e-test')) || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     timeout-minutes: 40
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Please answer these questions before submitting a pull request, **or your PR will get closed**.

**Why submit this pull request?**

- [ ] Bugfix
- [x] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

This is part of the https://github.com/apache/apisix/issues/12234

According to [Events that trigger workflows](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_dispatch) , this will allow us to trigger the test manually.

**Why**

This is very suitable for manually running a test to ensure that the dashboard can adapt to the latest APISIX, either on the eve of APISIX's release or after the `APISIX:dev` image is updated.
