### PR TITLE
feat(workflow/e2e): allow `repository_dispatch` trigger tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,6 +13,7 @@ on:
     # This should be later than the update time of `apache/apisix:dev`
     # Ref: https://github.com/apache/apisix-docker/blob/master/.github/workflows/apisix_dev_push_docker_hub.yaml#L7C15-L7C16
     - cron: '0 2 * * *'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -20,8 +21,8 @@ concurrency:
 
 jobs:
   test:
-    # only run when e2e-test label is added or scheduled
-    if: ${{ (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'e2e-test')) || github.event_name == 'schedule' }}
+    # only run when e2e-test label is added, scheduled, workflow_dispatch
+    if: ${{ (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'e2e-test')) || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     timeout-minutes: 40
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,6 +13,8 @@ on:
     # This should be later than the update time of `apache/apisix:dev`
     # Ref: https://github.com/apache/apisix-docker/blob/master/.github/workflows/apisix_dev_push_docker_hub.yaml#L7C15-L7C16
     - cron: '0 2 * * *'
+  repository_dispatch:
+    types: [e2e-test]
   workflow_dispatch:
 
 concurrency:
@@ -21,8 +23,8 @@ concurrency:
 
 jobs:
   test:
-    # only run when e2e-test label is added, scheduled, workflow_dispatch
-    if: ${{ (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'e2e-test')) || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    # only run when e2e-test label is added, scheduled, workflow_dispatch, repository_dispatch
+    if: ${{ (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'e2e-test')) || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch' }}
     timeout-minutes: 40
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Please answer these questions before submitting a pull request, **or your PR will get closed**.

**Why submit this pull request?**

- [ ] Bugfix
- [x] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

This is part of the https://github.com/apache/apisix/issues/12234.

Depend on: #3109

According to [Events that trigger workflows](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#repository_dispatch) , this will allow us to trigger the test in other repositories.

**Why**

I see in https://github.com/apache/echarts/blob/master/.github/workflows/nightly-next.yml that `repository_dispatch` seems to be available in the Apache repositories.

But I haven't found any information about this feature on the ASF-related websites yet.

Because "This event will only trigger a workflow run if the workflow file exists on the default branch.", I need to merge this PR into the master for testing in the APISIX repository.




