### PR TITLE
feat(services): filter routes/stream_routes by `service_id`

### DIFF
--- a/src/apis/hooks.ts
+++ b/src/apis/hooks.ts
@@ -82,14 +82,16 @@ export const genUseList = <
   routeKey: T,
   listQueryOptions: ReturnType<typeof genListQueryOptions<P, R>>
 ) => {
-  return (replaceKey?: U) => {
+  return (replaceKey?: U, defaultParams?: Partial<P>) => {
     const key = replaceKey || routeKey;
     const { params, setParams } = useSearchParams<T | U, P>(key);
-    const listQuery = useSuspenseQuery(listQueryOptions(params));
+    const listQuery = useSuspenseQuery(
+      listQueryOptions({ ...defaultParams, ...params })
+    );
     const { data, isLoading, refetch } = listQuery;
     const opts = { data, setParams, params };
     const pagination = useTablePagination(opts);
-    return { data, isLoading, refetch, pagination };
+    return { data, isLoading, refetch, pagination, setParams };
   };
 };
 

--- a/src/apis/routes.ts
+++ b/src/apis/routes.ts
@@ -21,7 +21,15 @@ import { API_ROUTES, PAGE_SIZE_MAX, PAGE_SIZE_MIN } from '@/config/constant';
 import type { APISIXType } from '@/types/schema/apisix';
 import type { PageSearchType } from '@/types/schema/pageSearch';
 
-export const getRouteListReq = (req: AxiosInstance, params: PageSearchType) =>
+export type GetRouteListReqParams = PageSearchType & {
+  filter?: {
+    service_id?: string;
+  };
+};
+export const getRouteListReq = (
+  req: AxiosInstance,
+  params: GetRouteListReqParams
+) =>
   req
     .get<undefined, APISIXType['RespRouteList']>(API_ROUTES, { params })
     .then((v) => v.data);

--- a/src/apis/routes.ts
+++ b/src/apis/routes.ts
@@ -21,15 +21,13 @@ import { API_ROUTES, PAGE_SIZE_MAX, PAGE_SIZE_MIN } from '@/config/constant';
 import type { APISIXType } from '@/types/schema/apisix';
 import type { PageSearchType } from '@/types/schema/pageSearch';
 
-export type GetRouteListReqParams = PageSearchType & {
+export type WithServiceIdFilter = PageSearchType & {
   filter?: {
     service_id?: string;
   };
 };
-export const getRouteListReq = (
-  req: AxiosInstance,
-  params: GetRouteListReqParams
-) =>
+
+export const getRouteListReq = (req: AxiosInstance, params: WithServiceIdFilter) =>
   req
     .get<undefined, APISIXType['RespRouteList']>(API_ROUTES, { params })
     .then((v) => v.data);

--- a/src/apis/stream_routes.ts
+++ b/src/apis/stream_routes.ts
@@ -20,9 +20,13 @@ import type { AxiosInstance } from 'axios';
 import type { StreamRoutePostType } from '@/components/form-slice/FormPartStreamRoute/schema';
 import { API_STREAM_ROUTES } from '@/config/constant';
 import type { APISIXType } from '@/types/schema/apisix';
-import type { PageSearchType } from '@/types/schema/pageSearch';
 
-export const getStreamRouteListReq = (req: AxiosInstance, params: PageSearchType) =>
+import type { WithServiceIdFilter } from './routes';
+
+export const getStreamRouteListReq = (
+  req: AxiosInstance,
+  params: WithServiceIdFilter
+) =>
   req
     .get<unknown, APISIXType['RespStreamRouteList']>(API_STREAM_ROUTES, {
       params,

--- a/src/config/req.ts
+++ b/src/config/req.ts
@@ -29,10 +29,16 @@ import { globalStore } from '@/stores/global';
 export const req = axios.create();
 
 req.interceptors.request.use((conf) => {
-  conf.paramsSerializer = (p) =>
-    stringify(p, {
+  conf.paramsSerializer = (p) => {
+    // from { filter: { service_id: 1 } }
+    // to `filter=service_id%3D1`
+    if (p.filter) {
+      p.filter = stringify(p.filter);
+    }
+    return stringify(p, {
       arrayFormat: 'repeat',
     });
+  };
   conf.baseURL = API_PREFIX;
   conf.headers.set(API_HEADER_KEY, globalStore.settings.adminKey);
   return conf;

--- a/src/routes/routes/index.tsx
+++ b/src/routes/routes/index.tsx
@@ -21,7 +21,7 @@ import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { getRouteListQueryOptions, useRouteList } from '@/apis/hooks';
-import type { GetRouteListReqParams } from '@/apis/routes';
+import type { WithServiceIdFilter } from '@/apis/routes';
 import { DeleteResourceBtn } from '@/components/page/DeleteResourceBtn';
 import PageHeader from '@/components/page/PageHeader';
 import { ToAddPageBtn, ToDetailPageBtn } from '@/components/page/ToAddPageBtn';
@@ -34,7 +34,7 @@ import type { ListPageKeys } from '@/utils/useTablePagination';
 
 export type RouteListProps = {
   routeKey: Extract<ListPageKeys, '/routes/' | '/services/detail/$id/routes/'>;
-  defaultParams?: Partial<GetRouteListReqParams>;
+  defaultParams?: Partial<WithServiceIdFilter>;
   ToDetailBtn: (props: {
     record: APISIXType['RespRouteItem'];
   }) => React.ReactNode;

--- a/src/routes/routes/index.tsx
+++ b/src/routes/routes/index.tsx
@@ -21,6 +21,7 @@ import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { getRouteListQueryOptions, useRouteList } from '@/apis/hooks';
+import type { GetRouteListReqParams } from '@/apis/routes';
 import { DeleteResourceBtn } from '@/components/page/DeleteResourceBtn';
 import PageHeader from '@/components/page/PageHeader';
 import { ToAddPageBtn, ToDetailPageBtn } from '@/components/page/ToAddPageBtn';
@@ -33,14 +34,18 @@ import type { ListPageKeys } from '@/utils/useTablePagination';
 
 export type RouteListProps = {
   routeKey: Extract<ListPageKeys, '/routes/' | '/services/detail/$id/routes/'>;
+  defaultParams?: Partial<GetRouteListReqParams>;
   ToDetailBtn: (props: {
     record: APISIXType['RespRouteItem'];
   }) => React.ReactNode;
 };
 
 export const RouteList = (props: RouteListProps) => {
-  const { routeKey, ToDetailBtn } = props;
-  const { data, isLoading, refetch, pagination } = useRouteList(routeKey);
+  const { routeKey, ToDetailBtn, defaultParams } = props;
+  const { data, isLoading, refetch, pagination } = useRouteList(
+    routeKey,
+    defaultParams
+  );
   const { t } = useTranslation();
 
   const columns = useMemo<ProColumns<APISIXType['RespRouteItem']>[]>(() => {

--- a/src/routes/services/detail.$id/routes/index.tsx
+++ b/src/routes/services/detail.$id/routes/index.tsx
@@ -32,6 +32,11 @@ function RouteComponent() {
       <PageHeader title={t('sources.routes')} />
       <RouteList
         routeKey="/services/detail/$id/routes/"
+        defaultParams={{
+          filter: {
+            service_id: id,
+          },
+        }}
         ToDetailBtn={({ record }) => (
           <ToDetailPageBtn
             key="detail"

--- a/src/routes/services/detail.$id/stream_routes/index.tsx
+++ b/src/routes/services/detail.$id/stream_routes/index.tsx
@@ -39,6 +39,11 @@ function StreamRouteComponent() {
             params={{ id, routeId: record.value.id }}
           />
         )}
+        defaultParams={{
+          filter: {
+            service_id: id,
+          },
+        }}
       />
     </>
   );

--- a/src/routes/stream_routes/index.tsx
+++ b/src/routes/stream_routes/index.tsx
@@ -21,6 +21,7 @@ import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { getStreamRouteListQueryOptions, useStreamRouteList } from '@/apis/hooks';
+import type { WithServiceIdFilter } from '@/apis/routes';
 import { DeleteResourceBtn } from '@/components/page/DeleteResourceBtn';
 import PageHeader from '@/components/page/PageHeader';
 import { ToAddPageBtn, ToDetailPageBtn } from '@/components/page/ToAddPageBtn';
@@ -39,11 +40,15 @@ export type StreamRouteListProps = {
   ToDetailBtn: (props: {
     record: APISIXType['RespStreamRouteItem'];
   }) => React.ReactNode;
+  defaultParams?: Partial<WithServiceIdFilter>;
 };
 
 export const StreamRouteList = (props: StreamRouteListProps) => {
-  const { routeKey, ToDetailBtn } = props;
-  const { data, isLoading, refetch, pagination } = useStreamRouteList(routeKey);
+  const { routeKey, ToDetailBtn, defaultParams } = props;
+  const { data, isLoading, refetch, pagination } = useStreamRouteList(
+    routeKey,
+    defaultParams
+  );
   const { t } = useTranslation();
 
   const columns = useMemo<


### PR DESCRIPTION
Please answer these questions before submitting a pull request, **or your PR will get closed**.

**Why submit this pull request?**

- [ ] Bugfix
- [x] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

Depend on https://github.com/apache/apisix/pull/12291

According to https://github.com/apache/apisix/pull/12291, we can now filter out all routes/stream_routes that are not for the current service in the service's routes/stream_routes.

This can reduce user confusion.

However, those containing `service_id` in the routes/stream_routes page list cannot be filtered out for now, because the API does not yet support providing multiple `service_id`s or other methods.

**Screenshots**

create one route `test` in services, create one route `test_without_id` with upstream in routes.

<img width="1511" alt="image" src="https://github.com/user-attachments/assets/630becb8-5ff4-442e-a526-916d416bb26a" />

<img width="1511" alt="image" src="https://github.com/user-attachments/assets/08dac5aa-0055-4815-8a98-d2866e4ae61a" />
