### PR TITLE
fix(stream_routes): show `server_addr`, `server_port` instead of `name`

### DIFF
--- a/src/routes/stream_routes/index.tsx
+++ b/src/routes/stream_routes/index.tsx
@@ -62,9 +62,15 @@ export const StreamRouteList = (props: StreamRouteListProps) => {
         valueType: 'text',
       },
       {
-        dataIndex: ['value', 'name'],
-        title: t('form.basic.name'),
-        key: 'name',
+        dataIndex: ['value', 'server_addr'],
+        title: t('form.streamRoutes.serverAddr'),
+        key: 'server_addr',
+        valueType: 'text',
+      },
+      {
+        dataIndex: ['value', 'server_port'],
+        title: t('form.streamRoutes.serverPort'),
+        key: 'server_port',
         valueType: 'text',
       },
       {


### PR DESCRIPTION
Please answer these questions before submitting a pull request, **or your PR will get closed**.

**Why submit this pull request?**

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

Fixed data processing logic for stream_routes-related components to ensure that data can be correctly echoed or submitted.

These problems are found in PR #3113 

Stream routes only support server_addr, server_port.