### PR TITLE
feat(i18n): fallback to en when i18n is incomplete

### DIFF
--- a/src/config/i18n.ts
+++ b/src/config/i18n.ts
@@ -37,6 +37,7 @@ i18n.use(initReactI18next).init({
   ns: ['common'],
   defaultNS,
   resources,
+  fallbackLng: 'en',
 });
 
 export default i18n;


### PR DESCRIPTION
Please answer these questions before submitting a pull request, **or your PR will get closed**.

**Why submit this pull request?**

- [ ] Bugfix
- [x] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

As described in #3140, https://www.i18next.com/principles/fallback#language-fallback provides the functionality of fallback to the default language, which can be configured directly to achieve the function.

|OLD|NEW|
|-|-|
|<img width="350" alt="CleanShot 2025-08-12 at 11 58 49@2x" src="https://github.com/user-attachments/assets/babe3acb-4c71-4067-a78f-10b6b60b0cdb" />|<img width="350" alt="image" src="https://github.com/user-attachments/assets/3cb2e5e2-0620-4867-b226-9f85d41f07c3" />|

Now, untranslated text will use the en text, while translated text will use the corresponding language's i18n.

example:

```json5
// zh/common.json
{
  "sources": {
    "consumers": "消费者"
  }
}
```

<img width="800" alt="image" src="https://github.com/user-attachments/assets/2d07de88-714a-47a0-b221-c415ad3e9aa6" />



I found that the menu style after the language is selected was not provided before during development, and I will create a separate PR to implement it later.

**Related issues**

fix/resolve #3140 

**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first
