### PR TITLE
fix: update etcd image to bitnamilegacy/etcd:3.5

### DIFF
--- a/e2e/server/docker-compose.common.yml
+++ b/e2e/server/docker-compose.common.yml
@@ -27,7 +27,8 @@ services:
       - apisix
 
   etcd:
-    image: bitnami/etcd:3.5
+    image: bitnamilegacy/etcd:3.5
+
     restart: always
     volumes:
       - etcd_data:/bitnami/etcd


### PR DESCRIPTION
The Bitnami etcd image (bitnami/etcd:3.5) is deprecated and no longer available in Docker Hub.  Updated the reference in e2e/server/docker-compose.common.yml to use bitnamilegacy/etcd:3.5 instead.  This resolves the dev container build failure mentioned in issue #3220.

**Why submit this pull request?**

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

The dev container fails to build because the Bitnami etcd image (bitnami/etcd:3.5) has been deprecated and removed from Docker Hub. 
This PR updates the image reference in e2e/server/docker-compose.common.yml to bitnamilegacy/etcd:3.5 so the dev container can build successfully again.

**Related issues**

fix #3220

**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first
