### PR TITLE
fix: use 9180 for admin proxy; guard secrets list parsing; fix lint

### DIFF
--- a/e2e/server/docker-compose.common.yml
+++ b/e2e/server/docker-compose.common.yml
@@ -27,7 +27,7 @@ services:
       - apisix
 
   etcd:
-    image: bitnami/etcd:3.5
+    image: bitnamilegacy/etcd:3.5.11
     restart: always
     volumes:
       - etcd_data:/bitnami/etcd

--- a/src/apis/secrets.ts
+++ b/src/apis/secrets.ts
@@ -42,10 +42,14 @@ export const getSecretListReq = (req: AxiosInstance, params: PageSearchType) =>
       params,
     })
     .then((v) => {
-      const { list, ...rest } = v.data;
+      const data = v.data;
+      const rawList = data?.list;
+      const parsedList = Array.isArray(rawList)
+        ? rawList.map(preParseSecretItem)
+        : [];
       return {
-        ...rest,
-        list: list.map(preParseSecretItem),
+        total: typeof data?.total === 'number' ? data.total : 0,
+        list: parsedList,
       };
     });
 

--- a/src/components/form/Editor.tsx
+++ b/src/components/form/Editor.tsx
@@ -16,7 +16,7 @@
  */
 import { InputWrapper, type InputWrapperProps, Skeleton } from '@mantine/core';
 import { Editor } from '@monaco-editor/react';
-import clsx from 'clsx';
+import cx from 'clsx';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   type FieldValues,
@@ -132,7 +132,7 @@ export const FormItemEditor = <T extends FieldValues>(
       )}
       <Editor
         wrapperProps={{
-          className: clsx(
+          className: cx(
             'editor-wrapper',
             restField.disabled && 'editor-wrapper--disabled'
           ),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -41,7 +41,8 @@ export default defineConfig({
     // as an example, if you want to use the e2e server as the api server,
     proxy: {
       [API_PREFIX]: {
-        target: 'http://localhost:6174',
+        target:
+          process.env.APISIX_ADMIN_URL || 'http://localhost:9180',
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
### Why submit this pull request?
- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

### What changes will this PR take into?
- Fix a runtime crash on the Secrets list page when the APISIX Admin API returns a non-array `list` (e.g., empty object on 401/empty). The code now defensively treats non-array lists as empty arrays.
- Improve developer experience: in dev, proxy `'/apisix/admin'` to `http://localhost:9180` by default, with optional override via `APISIX_ADMIN_URL`. This removes the need for a separate nginx proxy on port 6174 during host development.
- Resolve a strict ESLint warning (`import/no-named-as-default`) in `Editor.tsx` by renaming the default import identifier.

Files touched:
- `vite.config.ts`: use `localhost:9180` for dev admin proxy; allow `APISIX_ADMIN_URL` override.
- `src/apis/secrets.ts`: guard `.map` usage by handling non-array `list` safely.
- `src/components/form/Editor.tsx`: rename default import `clsx` → `cx` and update usage.

Behavioral impact:
- Secrets list no longer crashes when unauthenticated or when the API responds with an empty object.
- Local development works out of the box with APISIX on `:9180`.

### Related issues
- Refs: [#3220](https://github.com/apache/apisix-dashboard/issues/3220)

### Checklist
- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
  - No new tests added; the change is a small guard and dev proxy tweak. Happy to add tests if maintainers prefer.
- [ ] Have you modified the corresponding document?
  - No docs changes; behavior aligns with existing dev setup. Can add a note about `APISIX_ADMIN_URL` if requested.
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first