### PR TITLE
refactor(common): supplement missing chinese i18n translations

### DIFF
--- a/src/locales/zh/common.json
+++ b/src/locales/zh/common.json
@@ -83,8 +83,8 @@
       "remoteAddr": "远程地址",
       "remoteAddrs": "远程地址列表",
       "service": "服务",
-      "uri": "统一资源标识符（URI）",
-      "uris": "统一资源标识符列表（URI）",
+      "uri": "URI",
+      "uris": "URI 列表",
       "vars": "变量条件"
     },
     "search": "搜索",


### PR DESCRIPTION
### Why submit this pull request?
- [ ] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [x] Backport patches


### What changes will this PR take into?
This PR supplements and improves the Simplified Chinese i18n translations for APISIX Dashboard’s frontend language files. It unifies the translation of core technical terms (e.g., "Upstream" → "上游", "Route" → "路由") to ensure consistency, adds clear explanations for professional abbreviations (e.g., "SNI" → "服务器名称指示（SNI）") for better usability, and optimizes interface text expressions to fit Chinese user habits. All changes comply with frontend text length limits to avoid layout issues.


### Checklist:
- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first