### PR TITLE
ci: remove label trigger e2e test

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,8 +22,8 @@ concurrency:
 
 jobs:
   test:
-    # only run when e2e-test label is added, scheduled, workflow_dispatch, repository_dispatch
-    if: ${{ (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'e2e-test')) || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch' }}
+    # only run when e2e-test scheduled, workflow_dispatch, repository_dispatch
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch' }}
     timeout-minutes: 40
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Please answer these questions before submitting a pull request, **or your PR will get closed**.

**Why submit this pull request?**

- [ ] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

Previously, a new pull request (PR) required a corresponding label to be added before end-to-end (E2E) testing would be executed. This did not conform to the CI workflow. This PR removes this rule.

**Related issues**


**Checklist:**

- [ ] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first
