### PR TITLE
feat: add copy-to-clipboard for service ID

### DIFF
--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -3,6 +3,9 @@
     "dashboard": "APISIX Dashboard",
     "logo": "APISIX Logo"
   },
+  "copy_success": "Copied to clipboard!",
+  "copy": "Copy",
+
   "consumerGroups": {
     "singular": "Consumer Group"
   },

--- a/src/routes/services/index.tsx
+++ b/src/routes/services/index.tsx
@@ -17,7 +17,7 @@
 import type { ProColumns } from '@ant-design/pro-components';
 import { ProTable } from '@ant-design/pro-components';
 import { createFileRoute } from '@tanstack/react-router';
-import { Empty } from 'antd';
+import { Button, Empty,message  } from 'antd';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -37,12 +37,28 @@ const ServiceList = () => {
 
   const columns = useMemo<ProColumns<APISIXType['RespServiceItem']>[]>(() => {
     return [
-      {
-        dataIndex: ['value', 'id'],
-        title: 'ID',
-        key: 'id',
-        valueType: 'text',
-      },
+    {
+  dataIndex: ['value', 'id'],
+  title: 'ID',
+  key: 'id',
+  render: (_, record) => (
+    <span style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+      {record.value.id}
+      <Button
+  size="small"
+  type="link"
+  onClick={() => {
+    navigator.clipboard.writeText(record.value.id);
+    message.success(t('copy_success'));
+  }}
+>
+  {t('copy')}
+</Button>
+
+    </span>
+  ),
+},
+
       {
         dataIndex: ['value', 'name'],
         title: t('form.basic.name'),


### PR DESCRIPTION
### What this PR does

This PR adds a one-click copy-to-clipboard button for Service IDs on the Service List page.

Previously, users had to manually select and copy the Service ID, which was inconvenient and could lead to copy mistakes.
With this change, users can copy the ID instantly with a single click and receive visual feedback through a success message.

### Why this change is needed

Service IDs are frequently used when creating routes, plugins, and performing API operations.
Providing a quick copy action significantly improves usability and reduces friction for daily workflows.

### Implementation details

- Adds a lightweight copy action next to each Service ID
- Uses the browser Clipboard API (no extra dependencies)
- Displays a success message after copying
- Follows Apache i18n and linting standards

### Checklist

- [x] UI-only change
- [x] No breaking changes
- [x] Lint passed
- [x] Tested locally
