### PR TITLE
fix: sync upstream nodes to form immediately on change

### DIFF
--- a/src/components/form-slice/FormPartUpstream/FormItemNodes.tsx
+++ b/src/components/form-slice/FormPartUpstream/FormItemNodes.tsx
@@ -16,7 +16,7 @@
  */
 import { EditableProTable, type ProColumns } from '@ant-design/pro-components';
 import { Button, InputWrapper, type InputWrapperProps } from '@mantine/core';
-import { useClickOutside } from '@mantine/hooks';
+import { useDebouncedCallback } from '@mantine/hooks';
 import { toJS } from 'mobx';
 import { useLocalObservable } from 'mobx-react-lite';
 import { nanoid } from 'nanoid';
@@ -203,11 +203,12 @@ export const FormItemNodes = <T extends FieldValues>(
     ob.setDisabled(disabled);
   }, [disabled, ob]);
 
-  const ref = useClickOutside(() => {
-    const vals = parseToUpstreamNodes(toJS(ob.values));
+  // Sync form data with debounce to avoid excessive updates
+  const syncToForm = useDebouncedCallback((dataSource: DataSource[]) => {
+    const vals = parseToUpstreamNodes(dataSource);
     fOnChange?.(vals);
     restProps.onChange?.(vals);
-  }, ['mouseup', 'touchend', 'mousedown', 'touchstart']);
+  }, 100);
 
   return (
     <InputWrapper
@@ -215,7 +216,6 @@ export const FormItemNodes = <T extends FieldValues>(
       label={label}
       required={required}
       withAsterisk={withAsterisk}
-      ref={ref}
     >
       <input name={fName} type="hidden" />
       <AntdConfigProvider>
@@ -232,6 +232,7 @@ export const FormItemNodes = <T extends FieldValues>(
             editableKeys: ob.editableKeys,
             onValuesChange(_, dataSource) {
               ob.setValues(dataSource);
+              syncToForm(dataSource);
             },
             actionRender: (row) => {
               return [
@@ -240,7 +241,10 @@ export const FormItemNodes = <T extends FieldValues>(
                   variant="transparent"
                   size="compact-xs"
                   px={0}
-                  onClick={() => ob.remove(row.id)}
+                  onClick={() => {
+                    ob.remove(row.id);
+                    syncToForm(toJS(ob.values));
+                  }}
                 >
                   {t('form.btn.delete')}
                 </Button>,
@@ -256,7 +260,10 @@ export const FormItemNodes = <T extends FieldValues>(
         size="xs"
         color="cyan"
         style={{ borderColor: 'whitesmoke' }}
-        onClick={() => ob.append(genRecord())}
+        onClick={() => {
+          ob.append(genRecord());
+          syncToForm(toJS(ob.values));
+        }}
         {...(disabled && { display: 'none' })}
       >
         {t('form.upstreams.nodes.add')}


### PR DESCRIPTION
Previously, upstream nodes were only synced to react-hook-form when clicking outside the table (useClickOutside). This caused data loss when users edited nodes and clicked Save without clicking elsewhere first.

Now using useDebouncedCallback to sync form data immediately when:
- Table values change (onValuesChange)
- Node is deleted (delete button)
- Node is added (add button)

This fixes the issue where upstream nodes were not saved correctly in Routes, Services, and Upstreams forms.

**Why submit this pull request?**

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches