### PR TITLE
docs: fix typo 'Basic Infomation' → 'Basic Information' in en locale

### DIFF
--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -28,7 +28,7 @@
         "0": "Disabled",
         "1": "Enabled"
       },
-      "title": "Basic Infomation"
+      "title": "Basic Information"
     },
     "btn": {
       "add": "Add",


### PR DESCRIPTION
**Why submit this pull request?**

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

Fixed a typo in the English locale file (`src/locales/en/common.json`). The word "Infomation" was missing the letter `r` and has been corrected to "Information". This affects the section header displayed on form pages such as Add Route and Add Service.

**Related issues**

fix/resolve #0001

**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [x] Have you modified the corresponding document?
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first

