### PR TITLE
feat: Implement dynamic theme switching and dark mode support

### DIFF
--- a/e2e/tests/dark-mode.spec.ts
+++ b/e2e/tests/dark-mode.spec.ts
@@ -38,7 +38,7 @@ test.describe('Dark Mode', () => {
       });
 
       await test.step('activate auto mode', async () => {
-        await themeOption(page, 'auto').click();
+        await themeOption(page, 'auto').dispatchEvent('click');
         await page.reload();
       });
 
@@ -56,7 +56,7 @@ test.describe('Dark Mode', () => {
     { tag: '@dark-mode' },
     async ({ page }) => {
       await test.step('switch to dark mode', async () => {
-        await themeOption(page, 'dark').click();
+        await themeOption(page, 'dark').dispatchEvent('click');
         await expect(page.locator('html')).toHaveAttribute(
           'data-mantine-color-scheme',
           'dark'
@@ -79,7 +79,7 @@ test.describe('Dark Mode', () => {
       });
 
       await test.step('clean up: restore auto mode', async () => {
-        await themeOption(page, 'auto').click();
+        await themeOption(page, 'auto').dispatchEvent('click');
       });
     }
   );
@@ -89,7 +89,7 @@ test.describe('Dark Mode', () => {
     { tag: '@dark-mode' },
     async ({ page }) => {
       await test.step('switch to light mode', async () => {
-        await themeOption(page, 'light').click();
+        await themeOption(page, 'light').dispatchEvent('click');
         await expect(page.locator('html')).toHaveAttribute(
           'data-mantine-color-scheme',
           'light'
@@ -97,7 +97,7 @@ test.describe('Dark Mode', () => {
       });
 
       await test.step('switch to dark mode', async () => {
-        await themeOption(page, 'dark').click();
+        await themeOption(page, 'dark').dispatchEvent('click');
         await expect(page.locator('html')).toHaveAttribute(
           'data-mantine-color-scheme',
           'dark'
@@ -105,7 +105,7 @@ test.describe('Dark Mode', () => {
       });
 
       await test.step('switch back to auto mode', async () => {
-        await themeOption(page, 'auto').click();
+        await themeOption(page, 'auto').dispatchEvent('click');
       });
 
       await test.step('verify auto mode resolves correctly', async () => {

--- a/e2e/tests/dark-mode.spec.ts
+++ b/e2e/tests/dark-mode.spec.ts
@@ -19,7 +19,7 @@ import { test } from '@e2e/utils/test';
 import { expect } from '@playwright/test';
 
 const themeSegment = (value: string) =>
-  `label:has(input[value="${value}"])`;
+  `input[value="${value}"] + label`;
 
 test.describe('Dark Mode', () => {
   test(

--- a/e2e/tests/dark-mode.spec.ts
+++ b/e2e/tests/dark-mode.spec.ts
@@ -1,0 +1,112 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test } from '@e2e/utils/test';
+import { expect } from '@playwright/test';
+
+const themeSegment = (value: string) =>
+  `label:has(input[value="${value}"])`;
+
+test.describe('Dark Mode', () => {
+  test(
+    'auto mode resolves to dark when OS prefers dark',
+    { tag: '@dark-mode' },
+    async ({ page }) => {
+      await test.step('emulate OS dark preference', async () => {
+        await page.emulateMedia({ colorScheme: 'dark' });
+      });
+
+      await test.step('activate auto mode', async () => {
+        await page.locator(themeSegment('auto')).click();
+        await page.reload();
+      });
+
+      await test.step('verify dark scheme applied', async () => {
+        await expect(page.locator('html')).toHaveAttribute(
+          'data-mantine-color-scheme',
+          'dark'
+        );
+      });
+    }
+  );
+
+  test(
+    'theme preference persists across reload',
+    { tag: '@dark-mode' },
+    async ({ page }) => {
+      await test.step('switch to dark mode', async () => {
+        await page.locator(themeSegment('dark')).click();
+        await expect(page.locator('html')).toHaveAttribute(
+          'data-mantine-color-scheme',
+          'dark'
+        );
+      });
+
+      await test.step('reload and verify persistence', async () => {
+        await page.reload();
+        await expect(page.locator('html')).toHaveAttribute(
+          'data-mantine-color-scheme',
+          'dark'
+        );
+      });
+
+      await test.step('verify localStorage value', async () => {
+        const stored = await page.evaluate(() =>
+          localStorage.getItem('mantine-color-scheme-value')
+        );
+        expect(stored).toBe('dark');
+      });
+
+      await test.step('clean up: restore auto mode', async () => {
+        await page.locator(themeSegment('auto')).click();
+      });
+    }
+  );
+
+  test(
+    'can cycle through all theme modes',
+    { tag: '@dark-mode' },
+    async ({ page }) => {
+      await test.step('switch to light mode', async () => {
+        await page.locator(themeSegment('light')).click();
+        await expect(page.locator('html')).toHaveAttribute(
+          'data-mantine-color-scheme',
+          'light'
+        );
+      });
+
+      await test.step('switch to dark mode', async () => {
+        await page.locator(themeSegment('dark')).click();
+        await expect(page.locator('html')).toHaveAttribute(
+          'data-mantine-color-scheme',
+          'dark'
+        );
+      });
+
+      await test.step('switch back to auto mode', async () => {
+        await page.locator(themeSegment('auto')).click();
+      });
+
+      await test.step('verify auto mode resolves correctly', async () => {
+        const stored = await page.evaluate(() =>
+          localStorage.getItem('mantine-color-scheme-value')
+        );
+        expect(stored).toBe('auto');
+      });
+    }
+  );
+});

--- a/e2e/tests/dark-mode.spec.ts
+++ b/e2e/tests/dark-mode.spec.ts
@@ -16,10 +16,17 @@
  */
 
 import { test } from '@e2e/utils/test';
+import type { Page } from '@playwright/test';
 import { expect } from '@playwright/test';
 
-const themeSegment = (value: string) =>
-  `input[value="${value}"] + label`;
+const themeOptionNameByValue = {
+  auto: 'System theme',
+  dark: 'Dark theme',
+  light: 'Light theme',
+} as const;
+
+const themeOption = (page: Page, value: keyof typeof themeOptionNameByValue) =>
+  page.getByRole('radio', { name: themeOptionNameByValue[value], exact: true });
 
 test.describe('Dark Mode', () => {
   test(
@@ -31,7 +38,7 @@ test.describe('Dark Mode', () => {
       });
 
       await test.step('activate auto mode', async () => {
-        await page.locator(themeSegment('auto')).click();
+        await themeOption(page, 'auto').click();
         await page.reload();
       });
 
@@ -49,7 +56,7 @@ test.describe('Dark Mode', () => {
     { tag: '@dark-mode' },
     async ({ page }) => {
       await test.step('switch to dark mode', async () => {
-        await page.locator(themeSegment('dark')).click();
+        await themeOption(page, 'dark').click();
         await expect(page.locator('html')).toHaveAttribute(
           'data-mantine-color-scheme',
           'dark'
@@ -72,7 +79,7 @@ test.describe('Dark Mode', () => {
       });
 
       await test.step('clean up: restore auto mode', async () => {
-        await page.locator(themeSegment('auto')).click();
+        await themeOption(page, 'auto').click();
       });
     }
   );
@@ -82,7 +89,7 @@ test.describe('Dark Mode', () => {
     { tag: '@dark-mode' },
     async ({ page }) => {
       await test.step('switch to light mode', async () => {
-        await page.locator(themeSegment('light')).click();
+        await themeOption(page, 'light').click();
         await expect(page.locator('html')).toHaveAttribute(
           'data-mantine-color-scheme',
           'light'
@@ -90,7 +97,7 @@ test.describe('Dark Mode', () => {
       });
 
       await test.step('switch to dark mode', async () => {
-        await page.locator(themeSegment('dark')).click();
+        await themeOption(page, 'dark').click();
         await expect(page.locator('html')).toHaveAttribute(
           'data-mantine-color-scheme',
           'dark'
@@ -98,7 +105,7 @@ test.describe('Dark Mode', () => {
       });
 
       await test.step('switch back to auto mode', async () => {
-        await page.locator(themeSegment('auto')).click();
+        await themeOption(page, 'auto').click();
       });
 
       await test.step('verify auto mode resolves correctly', async () => {

--- a/index.html
+++ b/index.html
@@ -6,18 +6,23 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Apache APISIX Dashboard</title>
     <script>
-      try {
-        var scheme = localStorage.getItem('mantine-color-scheme-value');
-        if (scheme === 'dark' || scheme === 'light') {
-          document.documentElement.setAttribute('data-mantine-color-scheme', scheme);
-        } else {
-          var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
-          document.documentElement.setAttribute(
-            'data-mantine-color-scheme',
-            prefersDark ? 'dark' : 'light'
-          );
+      (() => {
+        try {
+          const scheme = localStorage.getItem('mantine-color-scheme-value');
+          if (scheme === 'dark' || scheme === 'light') {
+            document.documentElement.setAttribute('data-mantine-color-scheme', scheme);
+          } else {
+            const prefersDark =
+              window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+            document.documentElement.setAttribute(
+              'data-mantine-color-scheme',
+              prefersDark ? 'dark' : 'light'
+            );
+          }
+        } catch (error) {
+          // Ignore bootstrap errors (e.g., storage access restrictions) and fall back to default rendering.
         }
-      } catch (e) {}
+      })();
     </script>
   </head>
   <body>

--- a/index.html
+++ b/index.html
@@ -20,7 +20,13 @@
             );
           }
         } catch (error) {
-          // Ignore bootstrap errors (e.g., storage access restrictions) and fall back to default rendering.
+          // If storage access is restricted, fall back to system preference or a safe default.
+          const prefersDark =
+            window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+          document.documentElement.setAttribute(
+            'data-mantine-color-scheme',
+            prefersDark ? 'dark' : 'light'
+          );
         }
       })();
     </script>

--- a/index.html
+++ b/index.html
@@ -10,8 +10,12 @@
         var scheme = localStorage.getItem('mantine-color-scheme-value');
         if (scheme === 'dark' || scheme === 'light') {
           document.documentElement.setAttribute('data-mantine-color-scheme', scheme);
-        } else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
-          document.documentElement.setAttribute('data-mantine-color-scheme', 'dark');
+        } else {
+          var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+          document.documentElement.setAttribute(
+            'data-mantine-color-scheme',
+            prefersDark ? 'dark' : 'light'
+          );
         }
       } catch (e) {}
     </script>

--- a/index.html
+++ b/index.html
@@ -5,6 +5,16 @@
     <link rel="icon" type="image/svg+xml" href="/src/assets/apisix-logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Apache APISIX Dashboard</title>
+    <script>
+      try {
+        var scheme = localStorage.getItem('mantine-color-scheme-value');
+        if (scheme === 'dark' || scheme === 'light') {
+          document.documentElement.setAttribute('data-mantine-color-scheme', scheme);
+        } else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+          document.documentElement.setAttribute('data-mantine-color-scheme', 'dark');
+        }
+      } catch (e) {}
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/Header/ThemeToggle.tsx
+++ b/src/components/Header/ThemeToggle.tsx
@@ -35,7 +35,7 @@ export const ThemeToggle = () => {
   const { colorScheme, setColorScheme } = useMantineColorScheme({
     keepTransitions: true,
   });
-  const timerRef = useRef<ReturnType<typeof setTimeout>>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Clean up pending transition timer on unmount
   useEffect(() => {

--- a/src/components/Header/ThemeToggle.tsx
+++ b/src/components/Header/ThemeToggle.tsx
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { SegmentedControl, useMantineColorScheme,VisuallyHidden } from '@mantine/core';
+import { SegmentedControl, useMantineColorScheme, VisuallyHidden } from '@mantine/core';
 import { useCallback, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 

--- a/src/components/Header/ThemeToggle.tsx
+++ b/src/components/Header/ThemeToggle.tsx
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { SegmentedControl, useMantineColorScheme } from '@mantine/core';
+import { SegmentedControl, VisuallyHidden, useMantineColorScheme } from '@mantine/core';
 import { useCallback, useEffect, useRef } from 'react';
 
 import IconDarkMode from '~icons/material-symbols/dark-mode';
@@ -26,9 +26,33 @@ const TRANSITION_DURATION_MS = 200;
 const iconStyle = { width: 14, height: 14 } as const;
 
 const segmentData = [
-  { value: 'light', label: <IconLightMode style={iconStyle} /> },
-  { value: 'dark', label: <IconDarkMode style={iconStyle} /> },
-  { value: 'auto', label: <IconDesktop style={iconStyle} /> },
+  {
+    value: 'light',
+    label: (
+      <>
+        <VisuallyHidden>Light theme</VisuallyHidden>
+        <IconLightMode style={iconStyle} />
+      </>
+    ),
+  },
+  {
+    value: 'dark',
+    label: (
+      <>
+        <VisuallyHidden>Dark theme</VisuallyHidden>
+        <IconDarkMode style={iconStyle} />
+      </>
+    ),
+  },
+  {
+    value: 'auto',
+    label: (
+      <>
+        <VisuallyHidden>System theme</VisuallyHidden>
+        <IconDesktop style={iconStyle} />
+      </>
+    ),
+  },
 ];
 
 export const ThemeToggle = () => {

--- a/src/components/Header/ThemeToggle.tsx
+++ b/src/components/Header/ThemeToggle.tsx
@@ -14,52 +14,60 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { SegmentedControl, VisuallyHidden, useMantineColorScheme } from '@mantine/core';
+import { SegmentedControl, useMantineColorScheme,VisuallyHidden } from '@mantine/core';
 import { useCallback, useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import IconDarkMode from '~icons/material-symbols/dark-mode';
 import IconDesktop from '~icons/material-symbols/desktop-windows';
 import IconLightMode from '~icons/material-symbols/light-mode';
 
 const TRANSITION_DURATION_MS = 200;
+const COLOR_SCHEMES = ['light', 'dark', 'auto'] as const;
+
+type ColorSchemeValue = (typeof COLOR_SCHEMES)[number];
+
+const isColorSchemeValue = (value: string): value is ColorSchemeValue =>
+  (COLOR_SCHEMES as readonly string[]).includes(value);
 
 const iconStyle = { width: 14, height: 14 } as const;
 
-const segmentData = [
-  {
-    value: 'light',
-    label: (
-      <>
-        <VisuallyHidden>Light theme</VisuallyHidden>
-        <IconLightMode style={iconStyle} />
-      </>
-    ),
-  },
-  {
-    value: 'dark',
-    label: (
-      <>
-        <VisuallyHidden>Dark theme</VisuallyHidden>
-        <IconDarkMode style={iconStyle} />
-      </>
-    ),
-  },
-  {
-    value: 'auto',
-    label: (
-      <>
-        <VisuallyHidden>System theme</VisuallyHidden>
-        <IconDesktop style={iconStyle} />
-      </>
-    ),
-  },
-];
-
 export const ThemeToggle = () => {
+  const { t } = useTranslation();
   const { colorScheme, setColorScheme } = useMantineColorScheme({
     keepTransitions: true,
   });
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const segmentData = [
+    {
+      value: 'light',
+      label: (
+        <>
+          <VisuallyHidden>{t('settings.theme.light')}</VisuallyHidden>
+          <IconLightMode style={iconStyle} />
+        </>
+      ),
+    },
+    {
+      value: 'dark',
+      label: (
+        <>
+          <VisuallyHidden>{t('settings.theme.dark')}</VisuallyHidden>
+          <IconDarkMode style={iconStyle} />
+        </>
+      ),
+    },
+    {
+      value: 'auto',
+      label: (
+        <>
+          <VisuallyHidden>{t('settings.theme.auto')}</VisuallyHidden>
+          <IconDesktop style={iconStyle} />
+        </>
+      ),
+    },
+  ];
 
   // Clean up pending transition timer on unmount
   useEffect(() => {
@@ -73,13 +81,17 @@ export const ThemeToggle = () => {
 
   const handleChange = useCallback(
     (value: string) => {
+      if (!isColorSchemeValue(value)) {
+        return;
+      }
+
       // Clear any pending transition timer from a previous rapid toggle
       if (timerRef.current) {
         clearTimeout(timerRef.current);
       }
 
       document.body.classList.add('theme-transitioning');
-      setColorScheme(value as 'light' | 'dark' | 'auto');
+      setColorScheme(value);
 
       timerRef.current = setTimeout(() => {
         document.body.classList.remove('theme-transitioning');

--- a/src/components/Header/ThemeToggle.tsx
+++ b/src/components/Header/ThemeToggle.tsx
@@ -21,7 +21,7 @@ import IconDarkMode from '~icons/material-symbols/dark-mode';
 import IconDesktop from '~icons/material-symbols/desktop-windows';
 import IconLightMode from '~icons/material-symbols/light-mode';
 
-const TRANSITION_DURATION_MS = 250;
+const TRANSITION_DURATION_MS = 200;
 
 const iconStyle = { width: 14, height: 14 } as const;
 

--- a/src/components/Header/ThemeToggle.tsx
+++ b/src/components/Header/ThemeToggle.tsx
@@ -1,0 +1,76 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { SegmentedControl, useMantineColorScheme } from '@mantine/core';
+import { useCallback, useEffect, useRef } from 'react';
+
+import IconDarkMode from '~icons/material-symbols/dark-mode';
+import IconDesktop from '~icons/material-symbols/desktop-windows';
+import IconLightMode from '~icons/material-symbols/light-mode';
+
+const TRANSITION_DURATION_MS = 250;
+
+const iconStyle = { width: 14, height: 14 } as const;
+
+const segmentData = [
+  { value: 'light', label: <IconLightMode style={iconStyle} /> },
+  { value: 'dark', label: <IconDarkMode style={iconStyle} /> },
+  { value: 'auto', label: <IconDesktop style={iconStyle} /> },
+];
+
+export const ThemeToggle = () => {
+  const { colorScheme, setColorScheme } = useMantineColorScheme({
+    keepTransitions: true,
+  });
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(null);
+
+  // Clean up pending transition timer on unmount
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        document.body.classList.remove('theme-transitioning');
+      }
+    };
+  }, []);
+
+  const handleChange = useCallback(
+    (value: string) => {
+      // Clear any pending transition timer from a previous rapid toggle
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+
+      document.body.classList.add('theme-transitioning');
+      setColorScheme(value as 'light' | 'dark' | 'auto');
+
+      timerRef.current = setTimeout(() => {
+        document.body.classList.remove('theme-transitioning');
+        timerRef.current = null;
+      }, TRANSITION_DURATION_MS);
+    },
+    [setColorScheme]
+  );
+
+  return (
+    <SegmentedControl
+      size="xs"
+      value={colorScheme}
+      onChange={handleChange}
+      data={segmentData}
+    />
+  );
+};

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -22,6 +22,7 @@ import apisixLogo from '@/assets/apisix-logo.svg';
 
 import { LanguageMenu } from './LanguageMenu';
 import { SettingModalBtn } from './SettingModalBtn';
+import { ThemeToggle } from './ThemeToggle';
 
 const Logo = () => {
   const { t } = useTranslation();
@@ -46,6 +47,7 @@ export const Header: FC<HeaderProps> = (props) => {
           <div>{t('apisix.dashboard')}</div>
         </Group>
         <Group h="100%" gap="sm">
+          <ThemeToggle />
           <SettingModalBtn />
           <LanguageMenu />
         </Group>

--- a/src/components/form/Editor.tsx
+++ b/src/components/form/Editor.tsx
@@ -14,7 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { InputWrapper, type InputWrapperProps, Skeleton } from '@mantine/core';
+import {
+  InputWrapper,
+  type InputWrapperProps,
+  Skeleton,
+  useComputedColorScheme,
+} from '@mantine/core';
 import { Editor } from '@monaco-editor/react';
 import { clsx } from 'clsx';
 import { useEffect, useMemo, useRef, useState } from 'react';
@@ -32,13 +37,12 @@ import { genControllerProps } from './util';
 
 setupMonacoEditor();
 
-const options: monaco.editor.IStandaloneEditorConstructionOptions = {
+const baseOptions: monaco.editor.IStandaloneEditorConstructionOptions = {
   minimap: { enabled: false },
   contextmenu: false,
   lineNumbersMinChars: 3,
   renderLineHighlight: 'none',
   lineDecorationsWidth: 0,
-  theme: 'vs-light',
   acceptSuggestionOnEnter: 'on',
   // auto adjust width and height to parent
   // see: https://github.com/Microsoft/monaco-editor/issues/543#issuecomment-321767059
@@ -55,11 +59,15 @@ export const FormItemEditor = <T extends FieldValues>(
   props: FormItemEditorProps<T>
 ) => {
   const { t } = useTranslation();
+  const colorScheme = useComputedColorScheme('light');
+  const monacoTheme = colorScheme === 'dark' ? 'vs-dark' : 'vs-light';
+  const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
   const { controllerProps, restProps } = genControllerProps(props, '');
   const { customSchema, language, isLoading, required, ...wrapperProps } =
     restProps;
   const { trigger, watch } = useFormContext();
   const monacoErrorRef = useRef<string | null>(null);
+
   const enhancedControllerProps = useMemo(() => {
     return {
       ...controllerProps,
@@ -103,7 +111,19 @@ export const FormItemEditor = <T extends FieldValues>(
       : undefined;
   const value = restField.disabled ? normalizedWatchedValue ?? '' : controlledValue;
 
+  const editorOptions = useMemo(
+    () => ({ ...baseOptions, theme: monacoTheme, readOnly: restField.disabled }),
+    [monacoTheme, restField.disabled]
+  );
+
   const [internalLoading, setLoading] = useState(false);
+
+  // Imperatively switch Monaco theme — prop changes alone don't re-theme after mount
+  useEffect(() => {
+    if (editorRef.current) {
+      monaco.editor.setTheme(monacoTheme);
+    }
+  }, [monacoTheme]);
 
   useEffect(() => {
     setLoading(true);
@@ -163,6 +183,7 @@ export const FormItemEditor = <T extends FieldValues>(
           trigger(props.name);
         }}
         onMount={(editor) => {
+          editorRef.current = editor;
           if (process.env.NODE_ENV === 'test') {
             window.__monacoEditor__ = editor;
           }
@@ -175,7 +196,7 @@ export const FormItemEditor = <T extends FieldValues>(
             width="100%"
           />
         }
-        options={{ ...options, readOnly: restField.disabled }}
+        options={editorOptions}
         defaultLanguage="json"
         {...(language && { language })}
       />

--- a/src/config/antdConfigProvider.tsx
+++ b/src/config/antdConfigProvider.tsx
@@ -16,25 +16,36 @@
  */
 import '@ant-design/v5-patch-for-react-19';
 
-import { ConfigProvider } from 'antd';
+import { useComputedColorScheme } from '@mantine/core';
+import { ConfigProvider, theme } from 'antd';
 import enUS from 'antd/locale/en_US';
-import type { PropsWithChildren } from 'react';
+import { type PropsWithChildren, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 export const AntdConfigProvider = (props: PropsWithChildren) => {
   const { children } = props;
   const { t } = useTranslation();
+  const colorScheme = useComputedColorScheme('light');
+
+  const antdTheme = useMemo(
+    () => ({
+      algorithm:
+        colorScheme === 'dark'
+          ? theme.darkAlgorithm
+          : theme.defaultAlgorithm,
+      token: {
+        borderRadiusSM: 2,
+      },
+    }),
+    [colorScheme]
+  );
 
   return (
     <ConfigProvider
       virtual
       locale={enUS}
       renderEmpty={() => <div>{t('noData')}</div>}
-      theme={{
-        token: {
-          borderRadiusSM: 2,
-        },
-      }}
+      theme={antdTheme}
     >
       {children}
     </ConfigProvider>

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -334,6 +334,11 @@
   },
   "settings": {
     "adminKey": "Admin Key",
+    "theme": {
+      "auto": "Systemthema",
+      "dark": "Dunkles Thema",
+      "light": "Helles Thema"
+    },
     "title": "Einstellungen",
     "ui-commit-sha": "UI Commit SHA"
   },

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -335,6 +335,11 @@
   },
   "settings": {
     "adminKey": "Admin Key",
+    "theme": {
+      "auto": "System theme",
+      "dark": "Dark theme",
+      "light": "Light theme"
+    },
     "title": "Settings",
     "ui-commit-sha": "UI Commit SHA"
   },

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -334,6 +334,11 @@
   },
   "settings": {
     "adminKey": "Clave de Administrador",
+    "theme": {
+      "auto": "Tema del sistema",
+      "dark": "Tema oscuro",
+      "light": "Tema claro"
+    },
     "title": "Configuraciones",
     "ui-commit-sha": "SHA de Commit de la UI"
   },

--- a/src/locales/tr/common.json
+++ b/src/locales/tr/common.json
@@ -335,9 +335,9 @@
   "settings": {
     "adminKey": "Admin Key",
     "theme": {
-      "auto": "Sistem temasi",
+      "auto": "Sistem teması",
       "dark": "Koyu tema",
-      "light": "Acik tema"
+      "light": "Açık tema"
     },
     "title": "Ayarlar",
     "ui-commit-sha": "UI Commit SHA"

--- a/src/locales/tr/common.json
+++ b/src/locales/tr/common.json
@@ -334,6 +334,11 @@
   },
   "settings": {
     "adminKey": "Admin Key",
+    "theme": {
+      "auto": "Sistem temasi",
+      "dark": "Koyu tema",
+      "light": "Acik tema"
+    },
     "title": "Ayarlar",
     "ui-commit-sha": "UI Commit SHA"
   },

--- a/src/locales/zh/common.json
+++ b/src/locales/zh/common.json
@@ -334,6 +334,11 @@
   },
   "settings": {
     "adminKey": "管理员密钥",
+    "theme": {
+      "auto": "系统主题",
+      "dark": "深色主题",
+      "light": "浅色主题"
+    },
     "title": "设置",
     "ui-commit-sha": "UI Commit SHA"
   },

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -36,7 +36,7 @@ if (!rootElement.innerHTML) {
   const root = ReactDOM.createRoot(rootElement);
   root.render(
     <StrictMode>
-      <MantineProvider theme={theme}>
+      <MantineProvider theme={theme} defaultColorScheme="auto">
         <Notifications position="top-right" autoClose={5000} limit={5} />
         <QueryClientProvider client={queryClient}>
           <ModalsProvider>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3,10 +3,6 @@
   border-radius: var(--mantine-radius-sm);
 }
 
-/*
- * Temporary transition applied only during active theme switch (removed after 250ms).
- * No !important — avoids overriding component transitions (e.g. SegmentedControl indicator).
- */
 body.theme-transitioning,
 body.theme-transitioning * {
   transition: background-color 0.2s ease, color 0.2s ease,

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3,6 +3,16 @@
   border-radius: var(--mantine-radius-sm);
 }
 
+/*
+ * Temporary transition applied only during active theme switch (removed after 250ms).
+ * No !important — avoids overriding component transitions (e.g. SegmentedControl indicator).
+ */
+body.theme-transitioning,
+body.theme-transitioning * {
+  transition: background-color 0.2s ease, color 0.2s ease,
+    border-color 0.2s ease;
+}
+
 /* This is to fix the suggest widget offset problem */
 .monaco-editor .suggest-widget {
   width: 200px !important;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3,12 +3,10 @@
   border-radius: var(--mantine-radius-sm);
 }
 
-body.theme-transitioning,
-body.theme-transitioning * {
+body.theme-transitioning {
   transition: background-color 0.2s ease, color 0.2s ease,
     border-color 0.2s ease;
 }
-
 /* This is to fix the suggest widget offset problem */
 .monaco-editor .suggest-widget {
   width: 200px !important;


### PR DESCRIPTION
**Why submit this pull request?**

- [ ] Bugfix
- [x] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

Add dark mode theme support to the APISIX Dashboard, allowing users to switch between light, dark, and system preferred color schemes via a segmented control (☀️ Light / 🌙 Dark / 🖥️ Auto) in the header.

### Changes

- **FOUC prevention**: Added an inline `<script>` in `index.html` that reads the persisted color scheme from `localStorage` and sets `data-mantine-color-scheme` on `<html>` before CSS parses prevents a flash of the wrong theme on page load
- **Mantine**: Set `defaultColorScheme="auto"` on `MantineProvider` so the dashboard respects the user's OS preference by default
- **Ant Design**: Used Mantine's `useComputedColorScheme('light')` to resolve the actual scheme (since Ant Design does not handle `'auto'` internally), then conditionally applied `theme.darkAlgorithm` on `ConfigProvider` keeps `ProTable` in sync with the Mantine shell
- **Monaco Editor**: Added imperative `monaco.editor.setTheme()` via `useEffect` + `onMount` ref, since Monaco does not re-theme on React prop changes after initial mount
- **Theme toggle**: Added a `ThemeToggle` segmented control component in the header with three options: Light / Dark / Auto
- **Smooth transitions**: Added a temporary CSS transition class on `body` during theme switches (removed after 200ms to avoid impacting Lighthouse performance)
- **E2E tests**: Added tests for auto mode resolution (using Playwright's `emulateMedia`), theme persistence across page reloads, and cycling through all theme modes

### Technical notes

- No separate Jotai atom was needed Mantine manages color scheme persistence internally via `localStorage` (`mantine-color-scheme-value`)
- `forceColorScheme` was intentionally avoided it overrides system preference and would make auto mode a silent no op
- Custom CSS in `global.css` already uses Mantine CSS variables (`--mantine-color-*`), which auto-adapt no manual overrides were needed
- This change is purely additive no structural or architectural changes

**Related issues**

resolve #3322 

**Screenshot**
<img width="1920" height="1048" alt="image" src="https://github.com/user-attachments/assets/9172abd6-8513-4522-b808-126facca2a1f" />


**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [x] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first