### PR TITLE
fix(plugin): prevent overflow in PluginEditorDrawer and keep Add/Save visible

### DIFF
--- a/src/components/form-slice/FormItemPlugins/PluginEditorDrawer.tsx
+++ b/src/components/form-slice/FormItemPlugins/PluginEditorDrawer.tsx
@@ -64,41 +64,43 @@ export const PluginEditorDrawer = (props: PluginEditorDrawerProps) => {
       closeOnEscape={false}
       opened={opened}
       onClose={handleClose}
-      styles={{ body: { paddingTop: '18px' } }}
+      classNames={{
+        body: 'plugin-editor-drawer__body',
+      }}
       {...(mode === 'add' && { title: t('form.plugins.addPlugin') })}
       {...(mode === 'edit' && { title: t('form.plugins.editPlugin') })}
       {...(mode === 'view' && { title: t('form.plugins.viewPlugin') })}
     >
-      <Title order={3} mb={10}>
-        {name}
-      </Title>
-      <FormProvider {...methods}>
-        <form>
-          <FormItemEditor
-            name="config"
-            h={500}
-            customSchema={schema}
-            isLoading={!schema}
-            required
-          />
-        </form>
+      <div className="plugin-editor-drawer__content">
+        <Title order={3}>{name}</Title>
+        <FormProvider {...methods}>
+          <form className="plugin-editor-drawer__form">
+            <FormItemEditor
+              name="config"
+              h="clamp(280px, calc(100vh - 320px), 620px)"
+              customSchema={schema}
+              isLoading={!schema}
+              required
+            />
+          </form>
 
-        {mode !== 'view' && (
-          <Group justify="flex-end" mt={8}>
-            <FormSubmitBtn
-              size="xs"
-              variant="light"
-              onClick={methods.handleSubmit(({ config }) => {
-                onSave({ name, config: JSON.parse(config) });
-                handleClose();
-              })}
-            >
-              {mode === 'add' && t('form.btn.add')}
-              {mode === 'edit' && t('form.btn.save')}
-            </FormSubmitBtn>
-          </Group>
-        )}
-      </FormProvider>
+          {mode !== 'view' && (
+            <Group className="plugin-editor-drawer__actions" justify="flex-end">
+              <FormSubmitBtn
+                size="xs"
+                variant="light"
+                onClick={methods.handleSubmit(({ config }) => {
+                  onSave({ name, config: JSON.parse(config) });
+                  handleClose();
+                })}
+              >
+                {mode === 'add' && t('form.btn.add')}
+                {mode === 'edit' && t('form.btn.save')}
+              </FormSubmitBtn>
+            </Group>
+          )}
+        </FormProvider>
+      </div>
     </Drawer>
   );
 };

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -50,3 +50,30 @@
     color: var(--mantine-color-gray-5) !important;
   }
 }
+
+.plugin-editor-drawer__body {
+  padding-top: 18px;
+  max-height: calc(100vh - 80px);
+  overflow-y: auto;
+}
+
+.plugin-editor-drawer__content {
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--mantine-spacing-xs);
+}
+
+.plugin-editor-drawer__form {
+  min-height: 0;
+}
+
+.plugin-editor-drawer__actions {
+  position: sticky;
+  bottom: 0;
+  margin-top: var(--mantine-spacing-xs);
+  padding-top: var(--mantine-spacing-xs);
+  background: var(--mantine-color-body);
+  border-top: 1px solid var(--mantine-color-gray-2);
+  z-index: 2;
+}


### PR DESCRIPTION
**Problem**

Closes #3335

The PluginEditorDrawer used a fixed editor height which caused overflow issues.
On smaller or medium-height screens, the Monaco editor pushed the Add/Save
actions outside the visible area, making them difficult to access.

**Solution**

Removed fixed height from the editor
Introduced a flex-based column layout
Made the content area scrollable
Added a sticky footer to keep Add/Save actions always visible

**Result**

Add/Save buttons are always accessible
Layout adapts correctly to different screen sizes
Improved usability when editing large plugin configurations

**Scope**

Changes are limited to PluginEditorDrawer layout
No changes to API or business logic