### PR TITLE
fix(i18n): prevent crash when switching languages due to missing progress data

### DIFF
--- a/src/components/Header/LanguageMenu.tsx
+++ b/src/components/Header/LanguageMenu.tsx
@@ -30,7 +30,8 @@ const LangMap: Record<keyof Resources, string> = {
 };
 
 const TranslationProgress = ({ lang }: { lang: string }) => {
-  const percent = i18nProgress[lang].percent;
+  const progressData = i18nProgress[lang as keyof typeof i18nProgress];
+  const percent = progressData?.percent ?? 0;
   if (typeof percent === 'number' && percent < 100) {
     return (
       <span

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -91,7 +91,7 @@ export default defineConfig({
       semicolons: false,
     }),
     i18nProgress({
-      langs: ['en', 'es', 'de', 'zh'],
+      langs: ['en', 'es', 'de', 'zh', 'tr'],
       baseLang: 'en',
       getTranslationDir: (lang) => `./src/locales/${lang}`,
     }),


### PR DESCRIPTION
### Problem
Switching languages caused a runtime error:
"Cannot read properties of undefined (reading 'percent')".

This occurred because some languages were not included in i18nProgress
configuration and the code accessed progress data without null checks.

### Solution
- Added missing language ('tr') to i18nProgress configuration
- Added optional chaining to safely access progress data

### Result
Language switching works correctly without runtime errors for all supported languages.