### PR TITLE
fix(ux): show unsaved changes warning on cancel in route and upstream…

### DIFF
--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -304,6 +304,11 @@
     "edit": {
       "success": "{{name}} erfolgreich bearbeitet",
       "title": "{{name}} bearbeiten"
+    },
+    "unsaved": {
+      "title": "Nicht gespeicherte Änderungen",
+      "content": "Sie haben nicht gespeicherte Änderungen. Möchten Sie wirklich schließen?",
+      "confirm": "Änderungen verwerfen"
     }
   },
   "mark": {

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -304,6 +304,11 @@
     "edit": {
       "success": "Edit {{name}} Successfully",
       "title": "Edit {{name}}"
+    },
+    "unsaved": {
+      "title": "Unsaved Changes",
+      "content": "You have unsaved changes. Are you sure you want to close?",
+      "confirm": "Discard Changes"
     }
   },
   "mark": {

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -304,6 +304,11 @@
     "edit": {
       "success": "Editado {{name}} con éxito",
       "title": "Editar {{name}}"
+    },
+    "unsaved": {
+      "title": "Cambios sin guardar",
+      "content": "Tiene cambios sin guardar. ¿Está seguro de que desea cerrar?",
+      "confirm": "Descartar cambios"
     }
   },
   "mark": {

--- a/src/locales/tr/common.json
+++ b/src/locales/tr/common.json
@@ -304,6 +304,11 @@
     "edit": {
       "success": "{{name}} başarıyla güncellendi",
       "title": "{{name}} Düzenle"
+    },
+    "unsaved": {
+      "title": "Kaydedilmemiş Değişiklikler",
+      "content": "Kaydedilmemiş değişiklikleriniz var. Kapatmak istediğinizden emin misiniz?",
+      "confirm": "Değişiklikleri at"
     }
   },
   "mark": {

--- a/src/locales/zh/common.json
+++ b/src/locales/zh/common.json
@@ -304,6 +304,11 @@
     "edit": {
       "success": "编辑 {{name}} 成功",
       "title": "编辑 {{name}}"
+    },
+    "unsaved": {
+      "title": "未保存的更改",
+      "content": "您有未保存的更改，确定要关闭吗？",
+      "confirm": "放弃更改"
     }
   },
   "mark": {

--- a/src/routes/routes/detail.$id.tsx
+++ b/src/routes/routes/detail.$id.tsx
@@ -15,7 +15,8 @@
  * limitations under the License.
  */
 import { zodResolver } from '@hookform/resolvers/zod';
-import { Button, Group, Skeleton } from '@mantine/core';
+import { Button, Group, Skeleton, Text } from '@mantine/core';
+import { modals } from '@mantine/modals';
 import { notifications } from '@mantine/notifications';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import {
@@ -93,6 +94,23 @@ const RouteDetailForm = (props: Props) => {
     },
   });
 
+  const handleCancel = () => {
+    if (form.formState.isDirty) {
+      modals.openConfirmModal({
+        centered: true,
+        title: t('info.unsaved.title'),
+        children: <Text size="sm">{t('info.unsaved.content')}</Text>,
+        labels: { confirm: t('info.unsaved.confirm'), cancel: t('form.btn.cancel') },
+        onConfirm: () => {
+          form.reset();
+          setReadOnly(true);
+        },
+      });
+    } else {
+      setReadOnly(true);
+    }
+  };
+
   if (isLoading) {
     return <Skeleton height={400} />;
   }
@@ -105,7 +123,7 @@ const RouteDetailForm = (props: Props) => {
         {!readOnly && (
           <Group>
             <FormSubmitBtn>{t('form.btn.save')}</FormSubmitBtn>
-            <Button variant="outline" onClick={() => setReadOnly(true)}>
+            <Button variant="outline" onClick={handleCancel}>
               {t('form.btn.cancel')}
             </Button>
           </Group>

--- a/src/routes/upstreams/detail.$id.tsx
+++ b/src/routes/upstreams/detail.$id.tsx
@@ -15,7 +15,8 @@
  * limitations under the License.
  */
 import { zodResolver } from '@hookform/resolvers/zod';
-import { Button, Group,Skeleton } from '@mantine/core';
+import { Button, Group, Skeleton, Text } from '@mantine/core';
+import { modals } from '@mantine/modals';
 import { notifications } from '@mantine/notifications';
 import {
   queryOptions,
@@ -93,6 +94,23 @@ const UpstreamDetailForm = (
     }
   }, [upstreamData, form, isLoading]);
 
+  const handleCancel = () => {
+    if (form.formState.isDirty) {
+      modals.openConfirmModal({
+        centered: true,
+        title: t('info.unsaved.title'),
+        children: <Text size="sm">{t('info.unsaved.content')}</Text>,
+        labels: { confirm: t('info.unsaved.confirm'), cancel: t('form.btn.cancel') },
+        onConfirm: () => {
+          form.reset();
+          setReadOnly(true);
+        },
+      });
+    } else {
+      setReadOnly(true);
+    }
+  };
+
   if (isLoading) {
     return <Skeleton height={400} />;
   }
@@ -110,7 +128,7 @@ const UpstreamDetailForm = (
           {!readOnly && (
             <Group>
               <FormSubmitBtn>{t('form.btn.save')}</FormSubmitBtn>
-              <Button variant="outline" onClick={() => setReadOnly(true)}>
+              <Button variant="outline" onClick={handleCancel}>
                 {t('form.btn.cancel')}
               </Button>
             </Group>


### PR DESCRIPTION
**Why submit this pull request?**

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

When editing a Route or Upstream and clicking Cancel, all unsaved form changes were silently discarded with no warning. This PR adds a confirmation dialog (same pattern as #3333) that appears only when the form has unsaved changes.

- Added `handleCancel` in `routes/detail.$id.tsx` and `upstreams/detail.$id.tsx` that checks `form.formState.isDirty` before closing
- If dirty → shows "Unsaved Changes" confirmation modal with Discard/Cancel options
- If clean → closes silently without modal
- Added `info.unsaved.*` i18n keys across all 5 locales (en, zh, de, es, tr)

Note: `form.formState.isDirty` is reliable here because `form.reset(fetchedData)` is called after data loads, correctly setting `defaultValues`. This is different from #3333 where direct value comparison was needed.

**Related issues**

fix #3344

**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first
