### PR TITLE
fix(route): allow empty optional vars editor (#3362)

### DIFF
--- a/e2e/tests/routes.crud-required-fields.spec.ts
+++ b/e2e/tests/routes.crud-required-fields.spec.ts
@@ -18,7 +18,12 @@ import { routesPom } from '@e2e/pom/routes';
 import { randomId } from '@e2e/utils/common';
 import { e2eReq } from '@e2e/utils/req';
 import { test } from '@e2e/utils/test';
-import { uiHasToastMsg } from '@e2e/utils/ui';
+import {
+  uiClearMonacoEditor,
+  uiFillMonacoEditor,
+  uiGetMonacoEditor,
+  uiHasToastMsg,
+} from '@e2e/utils/ui';
 import { uiFillUpstreamRequiredFields } from '@e2e/utils/ui/upstreams';
 import { expect } from '@playwright/test';
 
@@ -99,6 +104,8 @@ test('should CRUD route with required fields', async ({ page }) => {
   });
 
   await test.step('edit and update route in detail page', async () => {
+    const varsSection = page.getByText('Vars').locator('..');
+
     // Click the Edit button in the detail page
     await page.getByRole('button', { name: 'Edit' }).click();
 
@@ -113,6 +120,11 @@ test('should CRUD route with required fields', async ({ page }) => {
     // Update URI
     const uriField = page.getByLabel('URI', { exact: true });
     await uriField.fill(`${routeUri}-updated`);
+
+    // Vars is optional and should remain valid when user clears it
+    const varsEditor = await uiGetMonacoEditor(page, varsSection);
+    await uiFillMonacoEditor(page, varsEditor, '[["arg_name", "==", "tmp"]]');
+    await uiClearMonacoEditor(page);
 
     // Click the Save button to save changes
     const saveBtn = page.getByRole('button', { name: 'Save' });

--- a/src/components/form/Editor.tsx
+++ b/src/components/form/Editor.tsx
@@ -56,7 +56,8 @@ export const FormItemEditor = <T extends FieldValues>(
 ) => {
   const { t } = useTranslation();
   const { controllerProps, restProps } = genControllerProps(props, '');
-  const { customSchema, language, isLoading, ...wrapperProps } = restProps;
+  const { customSchema, language, isLoading, required, ...wrapperProps } =
+    restProps;
   const { trigger } = useFormContext();
   const monacoErrorRef = useRef<string | null>(null);
   const enhancedControllerProps = useMemo(() => {
@@ -65,6 +66,9 @@ export const FormItemEditor = <T extends FieldValues>(
       rules: {
         ...controllerProps.rules,
         validate: (value: string) => {
+          if (value.trim().length === 0 && !required) {
+            return true;
+          }
           // Check JSON syntax
           try {
             JSON.parse(value);
@@ -79,7 +83,7 @@ export const FormItemEditor = <T extends FieldValues>(
         },
       },
     };
-  }, [controllerProps, t, monacoErrorRef]);
+  }, [controllerProps, required, t, monacoErrorRef]);
 
   const {
     field: { value, onChange: fOnChange, ...restField },
@@ -113,6 +117,7 @@ export const FormItemEditor = <T extends FieldValues>(
     <InputWrapper
       error={fieldState.error?.message}
       id="#editor-wrapper"
+      required={required}
       {...wrapperProps}
     >
       <input name={restField.name} type="hidden" />


### PR DESCRIPTION
**Why submit this pull request?**

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**
Replaced strict validation logic inside FormItemEditor to allow an empty string when the field is optional (!required). Previously, clearing the vars value inside Route forms triggered false-positive JSON.parse failures, blocking form submission even when empty strings are fully valid per the schema. Also added E2E test cases covering the behavior of clearing optional Monaco editor fields.

**Related issues**

fix #3362

**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first
