### PR TITLE
Fix e2e secrets cleanup delete path (#3367)

### DIFF
--- a/e2e/tests/routes.crud-required-fields.spec.ts
+++ b/e2e/tests/routes.crud-required-fields.spec.ts
@@ -18,7 +18,12 @@ import { routesPom } from '@e2e/pom/routes';
 import { randomId } from '@e2e/utils/common';
 import { e2eReq } from '@e2e/utils/req';
 import { test } from '@e2e/utils/test';
-import { uiHasToastMsg } from '@e2e/utils/ui';
+import {
+  uiClearMonacoEditor,
+  uiFillMonacoEditor,
+  uiGetMonacoEditor,
+  uiHasToastMsg,
+} from '@e2e/utils/ui';
 import { uiFillUpstreamRequiredFields } from '@e2e/utils/ui/upstreams';
 import { expect } from '@playwright/test';
 
@@ -99,6 +104,8 @@ test('should CRUD route with required fields', async ({ page }) => {
   });
 
   await test.step('edit and update route in detail page', async () => {
+    const varsSection = page.getByText('Vars').locator('..');
+
     // Click the Edit button in the detail page
     await page.getByRole('button', { name: 'Edit' }).click();
 
@@ -113,6 +120,11 @@ test('should CRUD route with required fields', async ({ page }) => {
     // Update URI
     const uriField = page.getByLabel('URI', { exact: true });
     await uriField.fill(`${routeUri}-updated`);
+
+    // Vars is optional and should remain valid when user clears it
+    const varsEditor = await uiGetMonacoEditor(page, varsSection);
+    await uiFillMonacoEditor(page, varsEditor, '[["arg_name", "==", "tmp"]]');
+    await uiClearMonacoEditor(page);
 
     // Click the Save button to save changes
     const saveBtn = page.getByRole('button', { name: 'Save' });

--- a/e2e/tests/secrets.list.spec.ts
+++ b/e2e/tests/secrets.list.spec.ts
@@ -65,8 +65,9 @@ test.describe('page and page_size should work correctly', () => {
       .then((v) => v.data);
     await Promise.all(
       (existingSecrets.list || []).map((d) => {
-        const [manager, id] = d.value.id.split('/');
-        return e2eReq.delete(`${API_SECRETS}/${manager}/${id}`);
+        return e2eReq.delete(
+          `${API_SECRETS}/${d.value.manager}/${d.value.id}`
+        );
       })
     );
 

--- a/src/components/form/Editor.tsx
+++ b/src/components/form/Editor.tsx
@@ -56,7 +56,8 @@ export const FormItemEditor = <T extends FieldValues>(
 ) => {
   const { t } = useTranslation();
   const { controllerProps, restProps } = genControllerProps(props, '');
-  const { customSchema, language, isLoading, ...wrapperProps } = restProps;
+  const { customSchema, language, isLoading, required, ...wrapperProps } =
+    restProps;
   const { trigger } = useFormContext();
   const monacoErrorRef = useRef<string | null>(null);
   const enhancedControllerProps = useMemo(() => {
@@ -65,6 +66,9 @@ export const FormItemEditor = <T extends FieldValues>(
       rules: {
         ...controllerProps.rules,
         validate: (value: string) => {
+          if (value.trim().length === 0 && !required) {
+            return true;
+          }
           // Check JSON syntax
           try {
             JSON.parse(value);
@@ -79,7 +83,7 @@ export const FormItemEditor = <T extends FieldValues>(
         },
       },
     };
-  }, [controllerProps, t, monacoErrorRef]);
+  }, [controllerProps, required, t, monacoErrorRef]);
 
   const {
     field: { value, onChange: fOnChange, ...restField },
@@ -113,6 +117,7 @@ export const FormItemEditor = <T extends FieldValues>(
     <InputWrapper
       error={fieldState.error?.message}
       id="#editor-wrapper"
+      required={required}
       {...wrapperProps}
     >
       <input name={restField.name} type="hidden" />


### PR DESCRIPTION
Why submit this pull request?

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

What changes will this PR take into?
Fixes e2e secrets list cleanup by deleting secrets using the separate [manager] and [id] fields instead of splitting [id]. This prevents invalid delete URLs and reduces flaky cleanup.


Related issues

fix/resolve #3367 

Checklist:

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first
