### PR TITLE
fix(e2e): use manager/id for secrets cleanup(#3367)

### DIFF
--- a/e2e/tests/secrets.list.spec.ts
+++ b/e2e/tests/secrets.list.spec.ts
@@ -65,8 +65,9 @@ test.describe('page and page_size should work correctly', () => {
       .then((v) => v.data);
     await Promise.all(
       (existingSecrets.list || []).map((d) => {
-        const [manager, id] = d.value.id.split('/');
-        return e2eReq.delete(`${API_SECRETS}/${manager}/${id}`);
+        return e2eReq.delete(
+          `${API_SECRETS}/${d.value.manager}/${d.value.id}`
+        );
       })
     );
 


### PR DESCRIPTION
Why submit this pull request?

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**
Fixes e2e secrets list cleanup by deleting secrets using the separate [manager] and [id] fields instead of splitting [id]. This prevents invalid delete URLs and reduces flaky cleanup.


Related issues

fix/resolve #3367 

Checklist:

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first
