### PR TITLE
fix(credentials): guard axios error response access(#3370)

### DIFF
--- a/src/apis/credentials.ts
+++ b/src/apis/credentials.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import type { AxiosInstance } from 'axios';
+import axios, { type AxiosInstance } from 'axios';
 
 import { API_CREDENTIALS, SKIP_INTERCEPTOR_HEADER } from '@/config/constant';
 import type { APISIXType } from '@/types/schema/apisix';
@@ -37,7 +37,7 @@ export const getCredentialListReq = (req: AxiosInstance, params: WithUsername) =
     .then((v) => v.data)
     .catch((e) => {
       // 404 means credentials is empty
-      if (e.response.status === 404) {
+      if (axios.isAxiosError(e) && e.response?.status === 404) {
         const res: APISIXListResponse<APISIXType['Credential']> = {
           total: 0,
           list: [],


### PR DESCRIPTION
Why submit this pull request?

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

What changes will this PR take into?

Summary of change:

1. Updated the catch logic in [credentials.ts] to safely handle Axios errors where response is missing.
2. Replaced direct access of e.response.status with a guarded check using axios.isAxiosError(e) and optional chaining.
3. Preserved existing behavior:
4. Return empty list when HTTP status is 404.
5. Re-throw all other errors.

Problem solved:

1. Prevents secondary runtime errors like Cannot read properties of undefined (reading status) during network/CORS/timeout failures.
2. Ensures original error propagation remains intact for non-404 failures.


Related issues

fix/resolve #3370 

Checklist:

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first
