### PR TITLE
fix(header): fix crash on language switch by adding missing 'tr' lang and guard

### DIFF
--- a/src/components/Header/LanguageMenu.tsx
+++ b/src/components/Header/LanguageMenu.tsx
@@ -30,7 +30,7 @@ const LangMap: Record<keyof Resources, string> = {
 };
 
 const TranslationProgress = ({ lang }: { lang: string }) => {
-  const percent = i18nProgress[lang].percent;
+  const percent = i18nProgress[lang as keyof typeof i18nProgress]?.percent;
   if (typeof percent === 'number' && percent < 100) {
     return (
       <span

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -91,7 +91,7 @@ export default defineConfig({
       semicolons: false,
     }),
     i18nProgress({
-      langs: ['en', 'es', 'de', 'zh'],
+      langs: ['en', 'es', 'de', 'zh', 'tr'],
       baseLang: 'en',
       getTranslationDir: (lang) => `./src/locales/${lang}`,
     }),


### PR DESCRIPTION
## Problem

When switching languages in the dashboard, selecting Turkish (tr) causes a runtime error: `TypeError: Cannot read properties of undefined (reading 'percent')`.

## Root Cause

`vite.config.ts` configures the i18nProgress plugin with `langs: ['en', 'es', 'de', 'zh']`, but `LangMap` in `LanguageMenu.tsx` defines 5 languages including `'tr'` (Turkish). When the component accesses `i18nProgress['tr']`, it returns `undefined`, causing the crash when reading `.percent`.

## Changes

1. **Root cause fix**: Add `'tr'` to the `langs` array in `vite.config.ts` so the i18nProgress plugin generates progress data for all supported languages.
2. **Defensive guard**: Add optional chaining (`?.`) in `LanguageMenu.tsx` to prevent crashes if a language is missing from the progress data in the future.

## Related Issues

Fixes #3300

Supersedes #3380 (which only addressed the defensive guard without fixing the root cause)

## Checklist

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first