### PR TITLE
fix(i18n): avoid language menu progress crash

### DIFF
--- a/src/components/Header/LanguageMenu.tsx
+++ b/src/components/Header/LanguageMenu.tsx
@@ -30,7 +30,7 @@ const LangMap: Record<keyof Resources, string> = {
 };
 
 const TranslationProgress = ({ lang }: { lang: string }) => {
-  const percent = i18nProgress[lang].percent;
+  const percent = i18nProgress[lang]?.percent;
   if (typeof percent === 'number' && percent < 100) {
     return (
       <span

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -91,7 +91,7 @@ export default defineConfig({
       semicolons: false,
     }),
     i18nProgress({
-      langs: ['en', 'es', 'de', 'zh'],
+      langs: ['en', 'es', 'de', 'zh', 'tr'],
       baseLang: 'en',
       getTranslationDir: (lang) => `./src/locales/${lang}`,
     }),


### PR DESCRIPTION
### Description

This fixes a runtime error in the language menu.

The language menu includes `tr`, but the i18n progress virtual module was only generated for `en`, `es`, `de`, and `zh`. As a result, rendering the translation progress for `tr` attempted to read `i18nProgress.tr.percent`, causing:

```text
Cannot read properties of undefined (reading 'percent')
```

This patch:

- adds `tr` to the i18n progress language list
- guards `i18nProgress[lang]` before reading `percent`

### Verification

```bash
pnpm run build
```
