### PR TITLE
fix: restore scrollbar interaction on disabled Monaco editors in view mode

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -45,6 +45,13 @@
     background-color: var(--mantine-color-gray-0) !important;
   }
 
+  /* Allow scrolling on disabled Monaco editor */
+  .monaco-scrollable-element,
+  .monaco-scrollable-element > .scrollbar,
+  .monaco-scrollable-element > .scrollbar > .slider {
+    pointer-events: auto !important;
+  }
+
   .monaco-editor .view-lines,
   .monaco-editor .view-line * {
     color: var(--mantine-color-gray-5) !important;


### PR DESCRIPTION
**Why submit this pull request?**
When viewing a plugin configuration in the PluginEditorDrawer (view mode), the Monaco editor's scrollbars become unresponsive. Content with long lines cannot be scrolled horizontally, making it impossible to view the full configuration.

- [x] Bugfix


**What changes will this PR take into?**

This PR restore scrollbar interaction on disabled Monaco editors in view mode.


**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first
