### PR TITLE
fix(consumer): makes the username field read-only on the consumer edit page

### DIFF
--- a/e2e/tests/consumers.crud-all-fields.spec.ts
+++ b/e2e/tests/consumers.crud-all-fields.spec.ts
@@ -76,8 +76,8 @@ test('should CRUD consumer with all fields', async ({ page }) => {
     // Enter edit mode
     await page.getByRole('button', { name: 'Edit' }).click();
 
-    // Verify username remains disabled in edit mode
-    await expect(page.getByRole('textbox', { name: 'Username' })).toBeDisabled();
+    // Verify username remains readonly in edit mode
+    await expect(page.getByRole('textbox', { name: 'Username' })).toHaveAttribute('readonly');
 
     // Update description
     await page.getByRole('textbox', { name: 'Description' }).fill('Updated: ' + description);

--- a/e2e/tests/consumers.crud-all-fields.spec.ts
+++ b/e2e/tests/consumers.crud-all-fields.spec.ts
@@ -76,6 +76,9 @@ test('should CRUD consumer with all fields', async ({ page }) => {
     // Enter edit mode
     await page.getByRole('button', { name: 'Edit' }).click();
 
+    // Verify username remains disabled in edit mode
+    await expect(page.getByRole('textbox', { name: 'Username' })).toBeDisabled();
+
     // Update description
     await page.getByRole('textbox', { name: 'Description' }).fill('Updated: ' + description);
 

--- a/e2e/tests/consumers.crud-required-fields.spec.ts
+++ b/e2e/tests/consumers.crud-required-fields.spec.ts
@@ -68,6 +68,10 @@ test('should CRUD consumer with required fields', async ({ page }) => {
     // Click the Edit button in the detail page
     await page.getByRole('button', { name: 'Edit' }).click();
 
+    // Verify username remains disabled in edit mode
+    const username = page.getByRole('textbox', { name: 'Username' });
+    await expect(username).toBeDisabled();
+
     // Update the description field
     const descriptionField = page.getByRole('textbox', { name: 'Description' });
     await descriptionField.fill('Updated description for testing');

--- a/e2e/tests/consumers.crud-required-fields.spec.ts
+++ b/e2e/tests/consumers.crud-required-fields.spec.ts
@@ -68,9 +68,9 @@ test('should CRUD consumer with required fields', async ({ page }) => {
     // Click the Edit button in the detail page
     await page.getByRole('button', { name: 'Edit' }).click();
 
-    // Verify username remains disabled in edit mode
+    // Verify username remains readonly in edit mode
     const username = page.getByRole('textbox', { name: 'Username' });
-    await expect(username).toBeDisabled();
+    await expect(username).toHaveAttribute('readonly');
 
     // Update the description field
     const descriptionField = page.getByRole('textbox', { name: 'Description' });

--- a/src/components/form-slice/FormPartConsumer.tsx
+++ b/src/components/form-slice/FormPartConsumer.tsx
@@ -33,7 +33,12 @@ export const FormSectionPluginsOnly = () => {
   );
 };
 
-export const FormPartConsumer = () => {
+export type FormPartConsumerProps = {
+  readOnlyUsername?: boolean;
+};
+
+export const FormPartConsumer = (props: FormPartConsumerProps) => {
+  const { readOnlyUsername = false } = props;
   const { t } = useTranslation();
   const { control } = useFormContext<APISIXType['ConsumerPut']>();
 
@@ -47,6 +52,7 @@ export const FormPartConsumer = () => {
             name="username"
             label={t('form.consumers.username')}
             required
+            readOnly={readOnlyUsername}
           />
         }
       />

--- a/src/routes/consumers/add.tsx
+++ b/src/routes/consumers/add.tsx
@@ -62,7 +62,7 @@ const ConsumerAddForm = () => {
           putConsumer.mutateAsync(pipeProduce()(d))
         )}
       >
-        <FormPartConsumer />
+        <FormPartConsumer readOnlyUsername={false} />
         <FormSubmitBtn>{t('form.btn.add')}</FormSubmitBtn>
       </form>
     </FormProvider>

--- a/src/routes/consumers/detail.$username/index.tsx
+++ b/src/routes/consumers/detail.$username/index.tsx
@@ -92,7 +92,7 @@ const ConsumerDetailForm = (props: Props) => {
         })}
       >
         <FormSectionGeneral showID={false} readOnly />
-        <FormPartConsumer />
+        <FormPartConsumer readOnlyUsername />
         {!readOnly && (
           <Group>
             <FormSubmitBtn>{t('form.btn.save')}</FormSubmitBtn>


### PR DESCRIPTION
**Why submit this pull request?**
username is the unique identifier of the Consumer. When editing the Consumer, username should not be editable. Currently, it can be edited and saved to create a new Consumer.

**What changes will this PR take into?**
This PR makes the username field read-only on the consumer edit page.

**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [x] I have added tests corresponding to this change
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first
