### PR TITLE
Stop persisting admin key to localStorage

### DIFF
--- a/e2e/tests/auth.spec.ts
+++ b/e2e/tests/auth.spec.ts
@@ -19,8 +19,9 @@ import { getAPISIXConf } from '@e2e/utils/common';
 import { test } from '@e2e/utils/test';
 import { expect } from '@playwright/test';
 
-// use empty storage state to avoid auth
-test.use({ storageState: { cookies: [], origins: [] } });
+// This suite exercises the manual auth flow itself, so opt out of the
+// automatic Admin API key injection and drive the Settings modal directly.
+test.use({ injectAdminKey: false });
 
 test('can auth with admin key', { tag: '@auth' }, async ({ page }) => {
   const settingsModal = page.getByRole('dialog', { name: 'Settings' });
@@ -60,8 +61,18 @@ test('can auth with admin key', { tag: '@auth' }, async ({ page }) => {
       .getByRole('button')
       .click();
 
-    await page.reload();
+    // The key authenticates the current session immediately (it is held in
+    // memory), so the token check now succeeds without a reload.
     await expect(failedMsg).toBeHidden();
+  });
+
+  await test.step('admin key is not persisted across a full reload', async () => {
+    // The admin key is kept in memory only and never written to browser
+    // storage, so a hard reload drops it and re-authentication is required.
+    await page.reload();
+    await expect(failedMsg).toBeVisible();
+    await expect(settingsModal).toBeVisible();
+    await expect(adminKeyInput).toBeEmpty();
   });
 });
 

--- a/e2e/utils/test.ts
+++ b/e2e/utils/test.ts
@@ -14,59 +14,49 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { readFile } from 'node:fs/promises';
-import path from 'node:path';
+import { test as baseTest } from '@playwright/test';
 
-import { expect, test as baseTest } from '@playwright/test';
+import { API_HEADER_KEY, API_PREFIX } from '@/config/constant';
 
-import { fileExists, getAPISIXConf } from './common';
-import { env } from './env';
+import { getAPISIXConf } from './common';
 
 export type Test = typeof test;
-export const test = baseTest.extend<object, { workerStorageState: string }>({
-  storageState: ({ workerStorageState }, use) => use(workerStorageState),
-  workerStorageState: [
-    async ({ browser }, use) => {
-      // Use parallelIndex as a unique identifier for each worker.
-      const id = test.info().parallelIndex;
-      const fileName = path.resolve(
-        test.info().project.outputDir,
-        `.auth/${id}.json`
-      );
+
+type TestOptions = {
+  /**
+   * Whether to authenticate Admin API requests by injecting the
+   * `X-API-KEY` header at the network layer. On by default.
+   *
+   * The dashboard holds the admin key in memory only (it is no longer
+   * persisted to `localStorage`), so auth cannot be replayed through
+   * Playwright's `storageState` the way it used to be. Instead we add the
+   * header to every Admin API request for the whole browser context, which
+   * keeps the app authenticated across full-page navigations and reloads
+   * (the e2e suite navigates with `page.goto`, i.e. fresh document loads)
+   * without re-driving the Settings modal on every page.
+   *
+   * Tests that exercise the manual auth flow itself (`auth.spec.ts`) opt
+   * out via `test.use({ injectAdminKey: false })`.
+   */
+  injectAdminKey: boolean;
+};
+
+export const test = baseTest.extend<TestOptions>({
+  injectAdminKey: [true, { option: true }],
+  page: async ({ baseURL, page, injectAdminKey }, use) => {
+    if (injectAdminKey) {
       const { adminKey } = await getAPISIXConf();
-
-      // file exists and contains admin key, use it
-      if (
-        (await fileExists(fileName)) &&
-        (await readFile(fileName)).toString().includes(adminKey)
-      ) {
-        return use(fileName);
-      }
-
-      const page = await browser.newPage({ storageState: undefined });
-
-      // have to use env here, because the baseURL is not available in worker
-      await page.goto(env.E2E_TARGET_URL);
-
-      // we need to authenticate
-      const settingsModal = page.getByRole('dialog', { name: 'Settings' });
-      await expect(settingsModal).toBeVisible();
-      // PasswordInput renders with a label, use getByLabel instead
-      const adminKeyInput = page.getByLabel('Admin Key');
-      await adminKeyInput.clear();
-      await adminKeyInput.fill(adminKey);
-      await page
-        .getByRole('dialog', { name: 'Settings' })
-        .getByRole('button')
-        .click();
-
-      await page.context().storageState({ path: fileName });
-      await page.close();
-      await use(fileName);
-    },
-    { scope: 'worker' },
-  ],
-  page: async ({ baseURL, page }, use) => {
+      await page.route(
+        (url) => url.pathname.startsWith(API_PREFIX),
+        (route) =>
+          route.continue({
+            headers: {
+              ...route.request().headers(),
+              [API_HEADER_KEY.toLowerCase()]: adminKey,
+            },
+          })
+      );
+    }
     await page.goto(baseURL);
     await use(page);
   },

--- a/src/stores/global.ts
+++ b/src/stores/global.ts
@@ -15,17 +15,12 @@
  * limitations under the License.
  */
 import { atom } from 'jotai';
-import { atomWithStorage } from 'jotai/utils';
 
-// Admin key with persistent storage
-export const adminKeyAtom = atomWithStorage<string>(
-  'settings:adminKey',
-  '',
-  undefined,
-  {
-    getOnInit: true,
-  }
-);
+// Admin key — in-memory only. Operators re-enter the key each browser
+// session by design: persisting it to localStorage broadens the
+// credential's audience to anything that can read the dashboard origin's
+// storage (XSS, browser extensions, shared workstations).
+export const adminKeyAtom = atom<string>('');
 
 // Settings modal visibility state
 export const isSettingsOpenAtom = atom<boolean>(false);


### PR DESCRIPTION
Note - this is really just a proposal for the APISIX PMC. this has been found as a small inconsistency during preparation of the securiyt model, and while not a CVE worthy security issue, but more of a "hardening/defense-in-depth" and "consistency" change.

Kind request to consider applying this (or change it in the way that the PMC would like to handle)  - or ignore if you do not feel it's worth it - because it does change user experience, so likely also some changelog documentation might be needed if this change is accepted.

Happy to update it if more documentation/migration guides/changelog is needed.

## Summary

Stops persisting the Apache APISIX admin key to `localStorage`
on the dashboard origin. The key is now held in-memory only;
operators re-enter it each browser session.

## The current behaviour

`src/stores/global.ts` defines:

```ts
import { atom } from 'jotai';
import { atomWithStorage } from 'jotai/utils';

// Admin key with persistent storage
export const adminKeyAtom = atomWithStorage<string>(
  'settings:adminKey',
  '',
  undefined,
  {
    getOnInit: true,
  }
);
```

With the 3rd argument left as `undefined`, jotai's
`atomWithStorage` defaults to `createJSONStorage(() => localStorage)`
([jotai docs](https://jotai.org/docs/utilities/storage#createjsonstorage)).
So the admin key is persisted to `localStorage` under the key
`settings:adminKey` and re-loaded on init (`getOnInit: true`).

## Why this is too broad

The admin key authorises **full Apache APISIX control-plane
mutation** — routes, plugins, consumers, SSL certs, every
write operation on the Admin API. The default behaviour widens
the credential's audience to anything that can read the
dashboard origin's `localStorage`:

- **XSS on the dashboard origin** — any reflected or stored XSS
  on the dashboard reaches the admin key. The dashboard
  renders user-supplied route names, plugin configs, consumer
  identifiers, etc. — substantial untrusted-text surface.
- **Browser extensions** — extensions with `storage` permission
  read `localStorage` cross-origin under certain configurations.
- **Shared workstations** — anyone with subsequent session
  access to the same browser profile reads the key.
- **Filesystem access** — `localStorage` is stored in plaintext
  in the browser profile directory.

The admin key is a single credential authorising every
mutation against the gateway control plane. Persisting it
broadly is inconsistent with how operators handle other
control-plane credentials (e.g. etcd auth, SSL cert private
keys, RBAC tokens — none of which are stored in browser
storage).

## The change

Replace `atomWithStorage` with `atom<string>('')`. The
exported `adminKeyAtom` is still an `Atom<string>` so
consumers (the existing `useAtom(adminKeyAtom)` callsites)
are unaffected at the type level. The behavioural difference
is that:

- The key is no longer persisted across page reloads.
- Operators re-enter the key each browser session.
- The `settings:adminKey` `localStorage` entry is no longer
  written. (Existing entries are not cleared by this change —
  see "Migration" below.)

## Migration

Existing dashboard users will lose the persisted key on first
page load after this lands. They re-enter the key once in the
Settings dialog. The previous behaviour can be restored on a
per-deployment basis via:

- Operator-supplied browser autofill / password manager —
  reduces the persistence to a user-controlled credential
  store rather than the dashboard origin's `localStorage`.
- Session-replay tooling for operations that genuinely need
  session continuity across reloads.

Neither of those should be the default for an admin-key-class
credential.

The orphaned `localStorage` entry under `settings:adminKey`
is harmless after this lands (it's no longer read). A
follow-up could optionally clear it on first load for
hygiene, but that is not required for the security fix and
is out of scope here.

## Provenance

The behaviour was identified during a pre-flight security
audit conducted by the ASF Security team at the PMC's request,
documented in the `security@apache.org` thread on 2026-05-17.
The PMC chair (Ming Wen) chose the "fix in dashboard first"
disposition on 2026-05-18 and on 2026-05-26 confirmed dropping
the dashboard from a separate scan-vendor pipeline pending
this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
