### PR TITLE
fix(upstream): apply port min/max constraints to node InputNumber

### DIFF
--- a/e2e/tests/edge/upstreams.port-boundaries.spec.ts
+++ b/e2e/tests/edge/upstreams.port-boundaries.spec.ts
@@ -89,8 +89,10 @@ test('port 0 auto-corrects to 1 (min constraint)', async ({ page }) => {
   await fillSingleNode(page, name, 'zero-port.local', '0');
 
   // InputNumber with min=1 auto-corrects 0 → 1
-  const nodesSection = page.getByRole('group', { name: 'Nodes' });
-  const portInput = nodesSection.locator('input').nth(1);
+  const rows = page
+    .getByRole('group', { name: 'Nodes' })
+    .locator('tr.ant-table-row');
+  const portInput = rows.first().locator('input').nth(1);
   await expect(portInput).toHaveValue('1');
 });
 
@@ -99,7 +101,9 @@ test('port 65536 auto-corrects to 65535 (max constraint)', async ({ page }) => {
   await fillSingleNode(page, name, 'over-port.local', '65536');
 
   // InputNumber with max=65535 auto-corrects 65536 → 65535
-  const nodesSection = page.getByRole('group', { name: 'Nodes' });
-  const portInput = nodesSection.locator('input').nth(1);
+  const rows = page
+    .getByRole('group', { name: 'Nodes' })
+    .locator('tr.ant-table-row');
+  const portInput = rows.first().locator('input').nth(1);
   await expect(portInput).toHaveValue('65535');
 });

--- a/e2e/tests/edge/upstreams.port-boundaries.spec.ts
+++ b/e2e/tests/edge/upstreams.port-boundaries.spec.ts
@@ -84,34 +84,22 @@ test('port 65535 is accepted', async ({ page }) => {
   expect(up.nodes?.[0]?.port).toBe(65535);
 });
 
-test('port 0 is rejected', async ({ page }) => {
+test('port 0 auto-corrects to 1 (min constraint)', async ({ page }) => {
   const name = randomId('edge-port-zero');
   await fillSingleNode(page, name, 'zero-port.local', '0');
-  await upstreamsPom.getAddBtn(page).click();
 
-  const success = page
-    .getByRole('alert')
-    .filter({ hasText: 'Add Upstream Successfully' });
-  const accepted = await success
-    .first()
-    .waitFor({ state: 'visible', timeout: 5000 })
-    .then(() => true)
-    .catch(() => false);
-  expect(accepted, 'port 0 must NOT be silently accepted').toBe(false);
+  // InputNumber with min=1 auto-corrects 0 → 1
+  const nodesSection = page.getByRole('group', { name: 'Nodes' });
+  const portInput = nodesSection.locator('input').nth(1);
+  await expect(portInput).toHaveValue('1');
 });
 
-test('port 65536 (out of range) is rejected', async ({ page }) => {
+test('port 65536 auto-corrects to 65535 (max constraint)', async ({ page }) => {
   const name = randomId('edge-port-overflow');
   await fillSingleNode(page, name, 'over-port.local', '65536');
-  await upstreamsPom.getAddBtn(page).click();
 
-  const success = page
-    .getByRole('alert')
-    .filter({ hasText: 'Add Upstream Successfully' });
-  const accepted = await success
-    .first()
-    .waitFor({ state: 'visible', timeout: 5000 })
-    .then(() => true)
-    .catch(() => false);
-  expect(accepted, 'port 65536 must NOT be silently accepted').toBe(false);
+  // InputNumber with max=65535 auto-corrects 65536 → 65535
+  const nodesSection = page.getByRole('group', { name: 'Nodes' });
+  const portInput = nodesSection.locator('input').nth(1);
+  await expect(portInput).toHaveValue('65535');
 });

--- a/e2e/tests/upstreams.crud-required-fields.spec.ts
+++ b/e2e/tests/upstreams.crud-required-fields.spec.ts
@@ -99,6 +99,27 @@ test('should CRUD upstream with required fields', async ({ page }) => {
     const nameField = page.getByLabel('Name', { exact: true });
     await expect(nameField).toBeEnabled();
 
+    // Verify port decrement arrow is disabled at min=1
+    const nodesSection = page.getByRole('group', { name: 'Nodes' });
+    const rows = nodesSection.locator('tr.ant-table-row');
+    const portCell = rows.nth(0).locator('.ant-input-number').first();
+    // default port is 1, decrement arrow should be disabled
+    await expect(
+      portCell.locator('.ant-input-number-handler-down')
+    ).toHaveClass(/ant-input-number-handler-down-disabled/);
+
+    // Set port to max 65535, increment arrow should be disabled
+    const portInput = rows.nth(0).locator('input').nth(1);
+    await portInput.fill('65535');
+    await expect(portInput).toHaveValue('65535');
+    await expect(
+      portCell.locator('.ant-input-number-handler-up')
+    ).toHaveClass(/ant-input-number-handler-up-disabled/);
+
+    // Reset port to valid value for subsequent edits
+    await portInput.fill('80');
+    await expect(portInput).toHaveValue('80');
+
     // Update the description field
     const descriptionField = page.getByLabel('Description');
     await descriptionField.fill('Updated description for testing');
@@ -117,8 +138,6 @@ test('should CRUD upstream with required fields', async ({ page }) => {
     await expect(labelsField).toHaveValue('');
 
     // Update a node - change the host of the first node
-    const nodesSection = page.getByRole('group', { name: 'Nodes' });
-    const rows = nodesSection.locator('tr.ant-table-row');
     const firstRowHost = rows.nth(0).getByRole('textbox').first();
     await firstRowHost.fill('updated-test.com');
     await expect(firstRowHost).toHaveValue('updated-test.com');

--- a/e2e/tests/upstreams.crud-required-fields.spec.ts
+++ b/e2e/tests/upstreams.crud-required-fields.spec.ts
@@ -99,17 +99,20 @@ test('should CRUD upstream with required fields', async ({ page }) => {
     const nameField = page.getByLabel('Name', { exact: true });
     await expect(nameField).toBeEnabled();
 
-    // Verify port decrement arrow is disabled at min=1
+    // Verify port decrement arrow is disabled at min=1 and increment at max=65535
     const nodesSection = page.getByRole('group', { name: 'Nodes' });
     const rows = nodesSection.locator('tr.ant-table-row');
     const portCell = rows.nth(0).locator('.ant-input-number').first();
-    // default port is 1, decrement arrow should be disabled
+    const portInput = rows.nth(0).locator('input').nth(1);
+
+    // Set port to min=1, decrement arrow should be disabled
+    await portInput.fill('1');
+    await expect(portInput).toHaveValue('1');
     await expect(
       portCell.locator('.ant-input-number-handler-down')
     ).toHaveClass(/ant-input-number-handler-down-disabled/);
 
-    // Set port to max 65535, increment arrow should be disabled
-    const portInput = rows.nth(0).locator('input').nth(1);
+    // Set port to max=65535, increment arrow should be disabled
     await portInput.fill('65535');
     await expect(portInput).toHaveValue('65535');
     await expect(

--- a/src/components/form-slice/FormPartUpstream/FormItemNodes.tsx
+++ b/src/components/form-slice/FormPartUpstream/FormItemNodes.tsx
@@ -25,7 +25,7 @@ import {
   type UseControllerProps,
 } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
-import type { ZodObject, ZodRawShape } from 'zod';
+import { z, type ZodObject, type ZodRawShape } from 'zod';
 
 import { AntdConfigProvider } from '@/config/antdConfigProvider';
 import { APISIX, type APISIXType } from '@/types/schema/apisix';
@@ -90,6 +90,18 @@ const genProps = (field: keyof APISIXType['UpstreamNode']) => {
       },
     ],
   };
+};
+
+const genFieldProps = (field: keyof APISIXType['UpstreamNode']) => {
+  const fieldSchema = APISIX.UpstreamNode.shape[field];
+  if (fieldSchema instanceof z.ZodNumber) {
+    const { minValue, maxValue } = fieldSchema;
+    const props: Record<string, unknown> = {};
+    if (minValue !== null) props.min = minValue;
+    if (maxValue !== null) props.max = maxValue;
+    return props;
+  }
+  return {};
 };
 
 export type FormItemNodesProps<T extends FieldValues> =
@@ -233,6 +245,7 @@ export const FormItemNodes = <T extends FieldValues>(
         dataIndex: 'port',
         valueType: 'digit',
         formItemProps: genProps('port'),
+        fieldProps: genFieldProps('port'),
         render: (_, entity) => {
           return entity.port.toString();
         },


### PR DESCRIPTION
**Why submit this pull request?**
When adding a node in the upstream form, the port InputNumber did not respect the schema's min: 1 constraint — the decrement arrow remained active at port value 1, allowing users to step down to 0. The increment arrow also had no max bound from lte(65535).

- [x] Bugfix

**What changes will this PR take into?**
apply port min/max constraints to node InputNumber, decrement arrow disabled at port = 1, increment arrow disabled at port = 65535

**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [x] Have you added corresponding test cases?
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first
