### PR TITLE
chore: bump pnpm to 10.34.4 to fix supply-chain advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
       "pnpm lint:fix"
     ]
   },
-  "packageManager": "pnpm@10.10.0+sha512.d615db246fe70f25dcfea6d8d73dee782ce23e2245e3c4f6f888249fb568149318637dca73c2c5c8ef2a4ca0d5657fb9567188bfab47f566d1ee6ce987815c39",
+  "packageManager": "pnpm@10.34.4+sha512.8768be55200ae3f2226b6527fcca2687e14bc4e5f12d7721a0f25da3df47915177058648db4177baf348120fa0ba2752d8d8d93f6beaf1fe64ae18da8de961af",
   "pnpm": {
     "overrides": {
       "lodash": ">=4.18.0",


### PR DESCRIPTION
### Summary

Bumps the pinned package manager from `pnpm@10.10.0` to `pnpm@10.34.4`.

`10.10.0` falls within the affected ranges of several pnpm supply-chain advisories disclosed in June 2026. Bumping to `10.34.4` moves us out of all of them:

| Advisory | Severity | Patched |
|---|---|---|
| [GHSA-w466-c33r-3gjp](https://github.com/advisories/GHSA-w466-c33r-3gjp) — env lockfile can short-circuit package-manager resolution and execute lockfile-selected pnpm bytes | High | 10.34.2 |
| [GHSA-gj8w-mvpf-x27x](https://github.com/advisories/GHSA-gj8w-mvpf-x27x) — repository-controlled `configDependencies` can select a pacquet native install engine | High | 10.34.2 |
| [GHSA-3qhv-2rgh-x77r](https://github.com/advisories/GHSA-3qhv-2rgh-x77r) — repository config can expand environment secrets into registry requests before scripts run | Medium | 10.34.2 |
| [GHSA-5wx6-mg75-v57r](https://github.com/advisories/GHSA-5wx6-mg75-v57r) — manifest identity spoof satisfies `allowBuilds` and runs attacker lifecycle scripts | High | 10.34.2 |
| [GHSA-qrv3-253h-g69c](https://github.com/advisories/GHSA-qrv3-253h-g69c) — path traversal in `configDependencies` env lockfile allows symlink creation outside `node_modules/.pnpm-config` | High | 10.34.4 |

`10.34.4` is the lowest release that covers all five (the path-traversal fix landed in 10.34.4; the others in 10.34.2).

### Changes

- `package.json`: `packageManager` → `pnpm@10.34.4` with the SHA-512 integrity of the 10.34.4 npm tarball.

No dependency or `pnpm-lock.yaml` changes are required — all pnpm 10.x releases share lockfile v9, and no dependencies change.

### Notes

There is no evidence this repository was compromised; these are design-level advisories with no malicious-package IOCs. This is a precautionary version bump out of the affected range.

### Checklist

- [x] Did you explain what problem does this PR solve? Or what new features / functionality will this PR add?
- [x] Did you add corresponding test cases? — N/A, package-manager version bump only.
- [x] Did you update the corresponding documentation? — N/A.
