### PR TITLE
fix(plugin-metadata): stop toasting 404 probes as errors

### DIFF
--- a/e2e/tests/regression/plugin-metadata.no-false-404-toasts.spec.ts
+++ b/e2e/tests/regression/plugin-metadata.no-false-404-toasts.spec.ts
@@ -69,7 +69,7 @@ test('page load with unconfigured plugins shows no error toasts', async ({
         lastSeen = probes;
         return settled;
       },
-      { timeout: 15000, intervals: [500] }
+      { timeout: 15000, intervals: [1000] }
     )
     .toBe(true);
 
@@ -82,4 +82,37 @@ test('page load with unconfigured plugins shows no error toasts', async ({
   const drawer = page.getByRole('dialog');
   await expect(drawer.getByRole('button', { name: 'Add' }).first())
     .toBeVisible();
+});
+
+test('a plugin whose metadata probe fails is not offered as an empty config', async ({
+  page,
+}) => {
+  // Fault injection: a real Admin API cannot be made to 500 a single
+  // plugin's metadata GET deterministically. A failed (non-404) probe
+  // must NOT be presented as "unconfigured" — saving the offered empty
+  // config would overwrite the plugin's existing metadata.
+  await page.route('**/apisix/admin/plugin_metadata/http-logger', (route) =>
+    route.fulfill({
+      status: 500,
+      contentType: 'application/json',
+      body: JSON.stringify({ error_msg: 'injected metadata failure' }),
+    })
+  );
+
+  await pluginMetadataPom.toIndex(page);
+  await pluginMetadataPom.isIndexPage(page);
+
+  // The real failure must surface to the user ...
+  await expect(
+    page.getByRole('alert').filter({ hasText: 'injected metadata failure' })
+  ).toBeVisible({ timeout: 15000 });
+
+  // ... and the failed plugin must not be offered in the select drawer.
+  await page.getByRole('button', { name: 'Select Plugins' }).click();
+  const drawer = page.getByRole('dialog');
+  await expect(drawer.getByRole('button', { name: 'Add' }).first())
+    .toBeVisible();
+  await expect(
+    drawer.getByText('http-logger', { exact: true })
+  ).toHaveCount(0);
 });

--- a/e2e/tests/regression/plugin-metadata.no-false-404-toasts.spec.ts
+++ b/e2e/tests/regression/plugin-metadata.no-false-404-toasts.spec.ts
@@ -1,0 +1,85 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Regression for apache/apisix-dashboard#3412: the Plugin Metadata page
+// probes GET /plugin_metadata/{name} once per metadata-capable plugin.
+// The Admin API answers 404 for every plugin whose metadata was never
+// configured — the normal state for most plugins on any deployment — and
+// each 404 used to fall through to the global axios interceptor as a red
+// "Key not found" toast. A fresh page load must show zero error toasts.
+
+import { pluginMetadataPom } from '@e2e/pom/plugin_metadata';
+import { e2eReq } from '@e2e/utils/req';
+import { test } from '@e2e/utils/test';
+import { expect } from '@playwright/test';
+
+import { API_PLUGIN_METADATA } from '@/config/constant';
+
+// Plugin metadata has no deleteAll helper; clear plugins commonly used in
+// other specs so the page probes an unconfigured state.
+const deleteKnownPluginMetadata = async () => {
+  const pluginsToClean = ['http-logger', 'syslog', 'skywalking', 'datadog'];
+  await Promise.all(
+    pluginsToClean.map((name) =>
+      e2eReq.delete(`${API_PLUGIN_METADATA}/${name}`).catch(() => {
+        // ignore: metadata may not exist
+      })
+    )
+  );
+};
+
+test.beforeAll(async () => {
+  await deleteKnownPluginMetadata();
+});
+
+test('page load with unconfigured plugins shows no error toasts', async ({
+  page,
+}) => {
+  // Track the per-plugin probes so the assertion runs after the storm of
+  // 404s has actually happened, not before.
+  let probes = 0;
+  page.on('response', (res) => {
+    if (res.url().includes('/apisix/admin/plugin_metadata/')) probes += 1;
+  });
+
+  await pluginMetadataPom.toIndex(page);
+  await pluginMetadataPom.isIndexPage(page);
+
+  // The page enumerates every metadata-capable plugin; wait until the
+  // probe count is non-trivial AND has stopped growing (storm settled).
+  let lastSeen = -1;
+  await expect
+    .poll(
+      () => {
+        const settled = probes > 5 && probes === lastSeen;
+        lastSeen = probes;
+        return settled;
+      },
+      { timeout: 15000, intervals: [500] }
+    )
+    .toBe(true);
+
+  // A 404 probe result means "not configured" — it must not toast.
+  await expect(page.getByRole('alert')).toHaveCount(0);
+
+  // The page must remain functional: the select drawer offers plugins to
+  // configure even though every probe 404'd.
+  await page.getByRole('button', { name: 'Select Plugins' }).click();
+  const drawer = page.getByRole('dialog');
+  await expect(drawer.getByRole('button', { name: 'Add' }).first())
+    .toBeVisible();
+});

--- a/src/components/page-slice/plugin_metadata/PluginMetadata.tsx
+++ b/src/components/page-slice/plugin_metadata/PluginMetadata.tsx
@@ -51,7 +51,8 @@ export const PluginMetadata = () => {
   const { t } = useTranslation();
 
   const metadataList = usePluginMetadataList();
-  const { pluginInfoMap, hasConfigNames, allPluginNames } = metadataList;
+  const { pluginInfoMap, hasConfigNames, failedPluginNames, allPluginNames } =
+    metadataList;
 
   const putMetadata = useMutation({
     mutationFn: putPluginMetadataReq,
@@ -86,17 +87,28 @@ export const PluginMetadata = () => {
   const [search, setSearch] = useState('');
 
   const unSelected = useMemo(
-    () => difference(allPluginNames ?? [], hasConfigNames),
-    [allPluginNames, hasConfigNames]
+    // a plugin whose metadata fetch failed (non-404) must not be offered
+    // as an empty config: saving it would overwrite existing metadata
+    () =>
+      difference(allPluginNames ?? [], [
+        ...hasConfigNames,
+        ...failedPluginNames,
+      ]),
+    [allPluginNames, hasConfigNames, failedPluginNames]
   );
 
   const curPlugin = useMemo<PluginConfig>(() => {
     if (!curPluginName) return {} as PluginConfig;
     const info = pluginInfoMap.get(curPluginName);
-    return info
-      ? ({ name: info.name, config: info.config } as PluginConfig)
-      : ({ name: curPluginName, config: {} } as PluginConfig);
-  }, [curPluginName, pluginInfoMap]);
+    if (info) {
+      return { name: info.name, config: info.config } as PluginConfig;
+    }
+    // fall back to an empty config only for plugins legitimately offered
+    // as unconfigured — never for ones whose fetch failed
+    return unSelected.includes(curPluginName)
+      ? ({ name: curPluginName, config: {} } as PluginConfig)
+      : ({} as PluginConfig);
+  }, [curPluginName, pluginInfoMap, unSelected]);
 
   const curPluginSchema = useMemo(() => {
     if (!curPluginName) return {};

--- a/src/components/page-slice/plugin_metadata/hooks.ts
+++ b/src/components/page-slice/plugin_metadata/hooks.ts
@@ -16,6 +16,7 @@
  */
 import { useListState, useMap } from '@mantine/hooks';
 import { useQueries, useSuspenseQuery } from '@tanstack/react-query';
+import { HttpStatusCode, isAxiosError } from 'axios';
 import { useDeepCompareEffect } from 'react-use';
 
 import {
@@ -39,8 +40,11 @@ export const usePluginMetadataList = () => {
     queries: names
       ? names.map((pluginName) => ({
           ...getPluginMetadataQueryOptions(pluginName, {
-            // skip show 500 error toast
-            [SKIP_INTERCEPTOR_HEADER]: ['500'],
+            // the Admin API answers 404 for a plugin whose metadata was
+            // never configured — that is the normal state for most
+            // plugins, not an error, so keep the interceptor quiet.
+            // Real failures (5xx, network) still toast.
+            [SKIP_INTERCEPTOR_HEADER]: ['404'],
           }),
           retry: false,
         }))
@@ -58,6 +62,14 @@ export const usePluginMetadataList = () => {
     hasConfigNamesOp.setState([]);
     for (const [index, pluginName] of names.entries()) {
       const req = metadataQueries[index];
+      // 404 means "not configured yet" — offer an empty config.
+      // Any other failure (5xx, network) must NOT be presented as an
+      // empty config: saving that would overwrite existing metadata.
+      const isUnconfigured =
+        req.isError &&
+        isAxiosError(req.error) &&
+        req.error.response?.status === HttpStatusCode.NotFound;
+      if (!req.isSuccess && !isUnconfigured) continue;
       const info = {
         name: pluginName,
         config: req.isSuccess ? req.data?.value : {},

--- a/src/components/page-slice/plugin_metadata/hooks.ts
+++ b/src/components/page-slice/plugin_metadata/hooks.ts
@@ -46,7 +46,14 @@ export const usePluginMetadataList = () => {
             // Real failures (5xx, network) still toast.
             [SKIP_INTERCEPTOR_HEADER]: ['404'],
           }),
-          retry: false,
+          // 404 = "not configured", retrying is pointless (and would
+          // multiply the probe storm); give real failures two more tries
+          retry: (failureCount: number, error: unknown) =>
+            failureCount < 2 &&
+            !(
+              isAxiosError(error) &&
+              error.response?.status === HttpStatusCode.NotFound
+            ),
         }))
       : [],
   });
@@ -82,11 +89,25 @@ export const usePluginMetadataList = () => {
     }
   }, [metadataQueries, names]);
 
+  // plugins whose metadata fetch failed with something other than 404;
+  // they must not be offered as an empty editable config anywhere
+  const failedPluginNames = (names ?? []).filter((_, index) => {
+    const query = metadataQueries[index];
+    return (
+      query.isError &&
+      !(
+        isAxiosError(query.error) &&
+        query.error.response?.status === HttpStatusCode.NotFound
+      )
+    );
+  });
+
   return {
     isLoading,
     isError: pluginsListQuery.isError,
     error: pluginsListQuery.error,
     hasConfigNames,
+    failedPluginNames,
     pluginInfoMap,
     allPluginNames: names,
     originalMetadataQueries: metadataQueries,


### PR DESCRIPTION
## What

Fixes #3412.

Opening the Plugin Metadata page on any deployment that hasn't configured metadata for all ~24 metadata-capable plugins produced a red `Key not found` toast per unconfigured plugin. The page probes `GET /plugin_metadata/{name}` per plugin; the Admin API's documented answer for never-configured metadata is **404**, but the per-request interceptor skip list said `'500'` — the wrong status code.

## How

- `src/components/page-slice/plugin_metadata/hooks.ts`: skip list `['500']` → `['404']`. Unconfigured plugins stay quiet; real failures (5xx, network) now surface via the interceptor toast instead of being silently swallowed.
- Same hook, second defect: any failed metadata GET used to be classified as "not configured" and offered as an empty editable `{}` — for a plugin whose fetch failed with a 500/network error, saving that would overwrite existing metadata. Non-404 failures are now excluded from the plugin map until the fetch succeeds.

## Verification

- new regression e2e `e2e/tests/regression/plugin-metadata.no-false-404-toasts.spec.ts`: waits for the probe storm to settle, asserts **zero** `role=alert` toasts, and confirms the select-plugins drawer still offers plugins (404 = unconfigured still works)
- existing `plugin_metadata.list.spec.ts` + `plugin_metadata.crud-required-fields.spec.ts` pass locally against a real APISIX
- `pnpm lint` clean, `tsc -b` clean