### PR TITLE
fix: secrets detail must not render a blank editable form on fetch failure

### DIFF
--- a/e2e/tests/regression/secrets.detail-fetch-error.spec.ts
+++ b/e2e/tests/regression/secrets.detail-fetch-error.spec.ts
@@ -1,0 +1,99 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Regression: the secrets detail page was the only detail page on plain
+// useQuery, gated by `isLoading` alone. After a failed fetch, isLoading is
+// false and isError was never checked, so the page rendered a blank,
+// editable form over an existing secret — inviting the user to "restore"
+// it and overwrite the real values. Converted to useSuspenseQuery, a fetch
+// failure now lands on the root error page (RootError, #3418) instead.
+//
+// Part of apache/apisix-dashboard#3417 (error handling item 6).
+
+import { e2eReq } from '@e2e/utils/req';
+import { test } from '@e2e/utils/test';
+import { uiGoto } from '@e2e/utils/ui';
+import { expect } from '@playwright/test';
+import { customAlphabet } from 'nanoid';
+
+import { getSecretReq, putSecretReq } from '@/apis/secrets';
+import { API_SECRETS } from '@/config/constant';
+import type { APISIXType } from '@/types/schema/apisix';
+
+const nanoid = customAlphabet(
+  'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789',
+  8
+);
+
+const secretId = `regsecerr${nanoid()}`;
+const vaultSecret = {
+  manager: 'vault',
+  id: secretId,
+  uri: 'http://vault.example.com:8200',
+  prefix: '/kv',
+  token: 'real-token',
+} as APISIXType['Secret'];
+
+test.beforeAll(async () => {
+  await putSecretReq(e2eReq, vaultSecret);
+});
+
+test.afterAll(async () => {
+  await e2eReq
+    .delete(`${API_SECRETS}/vault/${secretId}`)
+    .catch(() => undefined);
+});
+
+test('secret detail shows the error page, not a blank editable form, when its fetch fails', async ({
+  page,
+}) => {
+  // Abort only the detail GET; afterAll cleanup uses e2eReq (a Playwright
+  // request context), which page.route does not intercept.
+  await page.route(
+    (url) => url.pathname.endsWith(`/apisix/admin/secrets/vault/${secretId}`),
+    async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.abort('failed');
+      } else {
+        await route.fallback();
+      }
+    }
+  );
+
+  await uiGoto(page, '/secrets/detail/$manager/$id', {
+    manager: 'vault',
+    id: secretId,
+  });
+
+  // react-query retries up to 3 times (~7s backoff) before the error
+  // surfaces, hence the generous timeout on the first assertion.
+  await expect(page.getByText('Something went wrong')).toBeVisible({
+    timeout: 15_000,
+  });
+  await expect(page.getByRole('button', { name: 'Retry' })).toBeVisible();
+
+  // The lying blank form must be unreachable: no Edit path, no fields.
+  await expect(page.getByRole('button', { name: 'Edit' })).toBeHidden();
+  await expect(page.getByLabel('URI')).toBeHidden();
+
+  // The real secret is untouched on the backend.
+  const secret = await getSecretReq(e2eReq, {
+    manager: 'vault',
+    id: secretId,
+  });
+  expect(secret.value.uri).toBe('http://vault.example.com:8200');
+});

--- a/src/routes/secrets/detail.$manager.$id.tsx
+++ b/src/routes/secrets/detail.$manager.$id.tsx
@@ -17,7 +17,7 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Button, Group,Skeleton } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import {
   createFileRoute,
   useNavigate,
@@ -52,7 +52,7 @@ const SecretDetailForm = (props: Props) => {
   const { t } = useTranslation();
   const { manager, id } = useParams({ from: '/secrets/detail/$manager/$id' });
 
-  const secretQuery = useQuery(
+  const secretQuery = useSuspenseQuery(
     getSecretQueryOptions({
       id,
       manager: manager as APISIXType['Secret']['manager'],


### PR DESCRIPTION
**Why submit this pull request?**

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

### Problem

This addresses one item from the tracking issue #3417 (Error handling / resilience):

> `secrets/detail.$manager.$id.tsx` is the only non-suspense detail page; on fetch failure it renders a blank editable form where Save would PUT an empty object over the real secret, rather than displaying an error state.

Root cause: the page is the only detail page (1 of 12) on plain `useQuery`, gated by `if (isLoading)` alone. In react-query v5, `isLoading` becomes `false` after a failed fetch while `isError` is never checked, so the failure path falls through to the form renderer with `secretData === undefined`: the `useEffect` skips `form.reset` and the user gets a fully blank form that becomes editable via the Edit button.

### Verified severity (tested against a live Admin API)

- A fully blank submit is actually blocked twice — the zod discriminated union rejects an empty `manager`, and APISIX-side schema validation rejects empty strings (e.g. the vault `uri` pattern) — so the tracking issue's literal claim is slightly overstated for the all-blank case.
- The real data-loss path is indirect: a transient fetch failure shows a blank form that reads as "this secret is empty/lost"; a user who re-enters plausible values (e.g. a stale token) passes all validation and silently overwrites the production secret.
- A guaranteed harm needs no user action at all: any transient network error makes the page misrepresent existing data as empty, and a later focus-triggered refetch that succeeds will `form.reset` over anything typed meanwhile.

### Change

Two-line conversion in `src/routes/secrets/detail.$manager.$id.tsx`, mirroring `ssls/detail.$id.tsx` (the closest sibling): `useQuery` → `useSuspenseQuery`. Data is now guaranteed present at render time, so the blank-form class is eliminated structurally; a fetch failure throws to the root error page added by #3418 (`RootError`: "Something went wrong" + error message + Retry with query-error-reset — its comment explicitly anticipates detail pages throwing from `useSuspenseQuery`).

Everything else stays sibling-identical: the `isLoading` skeleton (covers refetch states under suspense), the `form.reset` effect, and the mutation. No explicit `<Suspense>` wrapper, matching ssls.

### Tests

New e2e spec `e2e/tests/regression/secrets.detail-fetch-error.spec.ts` (fault injection via `route.abort('failed')`, written first and verified failing against the old behavior):

- creates a real vault secret via the Admin API, aborts only the detail GET, opens the page;
- asserts the root error page appears (title + Retry button; generous timeout because react-query retries 3 times before surfacing the error);
- asserts the blank editable form is unreachable (no Edit button, no URI field);
- asserts the backend secret is untouched afterwards.

Also ran locally: all secrets suites (crud-all-fields, crud-required-fields, list) and the full `e2e/tests/regression/` folder — all green.

**Related issues**

Part of #3417 (item: "secrets detail is the only non-suspense detail page" under Error handling / resilience). Does **not** close the tracking issue.

**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [x] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first