### PR TITLE
fix: keep plugin editor drawer open when saving fails

### DIFF
--- a/e2e/tests/regression/plugin-metadata.drawer-keeps-edits-on-failed-save.spec.ts
+++ b/e2e/tests/regression/plugin-metadata.drawer-keeps-edits-on-failed-save.spec.ts
@@ -1,0 +1,115 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Regression: PluginEditorDrawer called its void-typed onSave and then
+// synchronously closed the drawer and reset the form. On the Plugin
+// Metadata page onSave is putMetadata.mutateAsync, so a failed PUT closed
+// the drawer as if it had succeeded and destroyed the user's edited JSON.
+// The drawer now awaits onSave and keeps the drawer (and edits) on failure.
+//
+// Part of apache/apisix-dashboard#3417 (error handling item 5).
+
+import { pluginMetadataPom } from '@e2e/pom/plugin_metadata';
+import { e2eReq } from '@e2e/utils/req';
+import { test } from '@e2e/utils/test';
+import {
+  uiFillMonacoEditor,
+  uiGetMonacoEditor,
+  uiHasToastMsg,
+} from '@e2e/utils/ui';
+import { expect } from '@playwright/test';
+
+import { API_PLUGIN_METADATA } from '@/config/constant';
+
+const PLUGIN = 'syslog';
+const EDITED_HOST = '10.0.0.99';
+
+const deletePluginMetadata = async () => {
+  await e2eReq.delete(`${API_PLUGIN_METADATA}/${PLUGIN}`).catch(() => {
+    // ignore when it does not exist
+  });
+};
+
+test.beforeAll(async () => {
+  await deletePluginMetadata();
+  await e2eReq.put(`${API_PLUGIN_METADATA}/${PLUGIN}`, { host: '127.0.0.1' });
+});
+
+test.afterAll(async () => {
+  await deletePluginMetadata();
+});
+
+test('failed metadata save keeps the drawer open with the edits intact', async ({
+  page,
+}) => {
+  await pluginMetadataPom.toIndex(page);
+  await pluginMetadataPom.isIndexPage(page);
+
+  // Force the PUT to fail with a server-style error; reads stay live.
+  // Keep the matcher in a const: page.unroute matches function matchers
+  // by reference, so the same instance must be used to lift the fault.
+  const metadataUrl = (url: URL) =>
+    url.pathname.endsWith(`/apisix/admin/plugin_metadata/${PLUGIN}`);
+  await page.route(metadataUrl, async (route) => {
+    if (route.request().method() === 'PUT') {
+      await route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({ error_msg: 'forced 500 for regression' }),
+      });
+    } else {
+      await route.fallback();
+    }
+  });
+
+  const card = page.getByTestId(`plugin-${PLUGIN}`);
+  await card.getByRole('button', { name: 'Edit' }).click();
+
+  const dialog = page.getByRole('dialog', { name: 'Edit Plugin' });
+  await expect(dialog).toBeVisible();
+
+  const editor = await uiGetMonacoEditor(page, dialog);
+  await uiFillMonacoEditor(
+    page,
+    editor,
+    `{"host": "${EDITED_HOST}", "port": 5140}`
+  );
+
+  await dialog.getByRole('button', { name: 'Save' }).click();
+
+  // The failure toast comes from the axios interceptor.
+  await uiHasToastMsg(page, { hasText: 'forced 500 for regression' });
+
+  // Core contract: the drawer did NOT close and the edits are intact.
+  await expect(dialog).toBeVisible();
+  const editorValue = await page.evaluate(() =>
+    window.__monacoEditor__?.getValue()
+  );
+  expect(editorValue).toContain(EDITED_HOST);
+
+  // Recovery: lift the fault and the same Save must go through.
+  await page.unroute(metadataUrl);
+  await dialog.getByRole('button', { name: 'Save' }).click();
+  await uiHasToastMsg(page, { hasText: 'success' });
+  await expect(dialog).toBeHidden();
+
+  const saved = await e2eReq.get<
+    unknown,
+    { data: { value: { host: string; port: number } } }
+  >(`${API_PLUGIN_METADATA}/${PLUGIN}`);
+  expect(saved.data.value.host).toBe(EDITED_HOST);
+});

--- a/src/components/form-slice/FormItemPlugins/PluginEditorDrawer.tsx
+++ b/src/components/form-slice/FormItemPlugins/PluginEditorDrawer.tsx
@@ -16,6 +16,7 @@
  */
 import { Drawer, Group, Text, Title } from '@mantine/core';
 import { modals } from '@mantine/modals';
+import { isAxiosError } from 'axios';
 import { isEmpty, isNil } from 'rambdax';
 import { useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
@@ -30,7 +31,7 @@ export type PluginConfig = { name: string; config: object };
 export type PluginEditorDrawerProps = Pick<PluginCardListProps, 'mode'> & {
   opened: boolean;
   onClose: () => void;
-  onSave: (props: PluginConfig) => void;
+  onSave: (props: PluginConfig) => void | Promise<unknown>;
   plugin: PluginConfig;
   schema?: object;
 };
@@ -104,8 +105,16 @@ export const PluginEditorDrawer = (props: PluginEditorDrawerProps) => {
             <FormSubmitBtn
               size="xs"
               variant="light"
-              onClick={methods.handleSubmit(({ config }) => {
-                onSave({ name, config: JSON.parse(config) });
+              onClick={methods.handleSubmit(async ({ config }) => {
+                try {
+                  await onSave({ name, config: JSON.parse(config) });
+                } catch (e) {
+                  // the axios interceptor owns the error toast; keep the
+                  // drawer open with the edits intact so the save can be
+                  // retried, and rethrow non-axios errors (real bugs)
+                  if (!isAxiosError(e)) throw e;
+                  return;
+                }
                 onClose();
                 methods.reset();
               })}


### PR DESCRIPTION
**Why submit this pull request?**

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

### Problem

This addresses one item from the tracking issue #3417 (Error handling / resilience):

> `PluginEditorDrawer` invokes `onSave` (async `mutateAsync`), then closes and resets **without awaiting** — failed saves lose user edits.

Root cause: the drawer's `onSave` prop is typed `(props: PluginConfig) => void`, and the submit handler called it fire-and-forget, then synchronously ran `onClose()` and `methods.reset()`. The drawer has two call sites with different semantics:

- the embedded plugins field (`FormItemPlugins/index.tsx`, used by route/service/consumer/global-rule/credential forms) passes a synchronous callback that only writes local form state — closing immediately is correct there;
- the Plugin Metadata page passes `putMetadata.mutateAsync`, so the returned promise was silently discarded: the drawer closed as if the save had succeeded while the PUT was still in flight.

When that PUT failed (network failure, 500, APISIX rejecting the metadata), the user's hand-edited JSON — plugin metadata configs are often long, e.g. log-format definitions — was already destroyed by `reset()`, and reopening the drawer showed the stale config from the query cache. An error toast (from the axios interceptor) appeared next to a drawer that had just closed as if everything went fine.

### Change

Single component, `src/components/form-slice/FormItemPlugins/PluginEditorDrawer.tsx`:

- widen `onSave` to `(props: PluginConfig) => void | Promise<unknown>` (both existing call sites already satisfy it, no caller changes);
- make the submit handler async: `await onSave(...)`, and only on success run `onClose()` + `methods.reset()`;
- on failure, swallow axios errors only — the interceptor owns their toasts (same pattern as `DeleteResourceBtn` in #3418) — and keep the drawer open with the edits intact so the save can be retried; non-axios errors still throw.

The synchronous embedded call site is unaffected (`await undefined` is a no-op, the drawer still closes immediately). Bonus: `FormSubmitBtn` already binds `formState.isSubmitting`, so the Save button now shows a loading state during the request and double-clicks are prevented, with no extra code.

### Tests

New e2e spec `e2e/tests/regression/plugin-metadata.drawer-keeps-edits-on-failed-save.spec.ts` (written first and verified failing against the old behavior):

- seeds syslog plugin metadata via the Admin API, opens the metadata page, edits the JSON in the drawer;
- forces the PUT to fail with a route-fulfilled 500 (`error_msg` payload, so the failure toast works independently of any interceptor changes);
- asserts the failure toast appears **and** the drawer stays open with the edited value still in the Monaco editor;
- lifts the fault and asserts the very same edit can be re-saved successfully (drawer closes, backend value verified via the Admin API).

Also ran locally: both plugin_metadata CRUD suites, `plugin_editor_drawer.unsaved-changes`, `routes.empty-plugin-config` (embedded call-site coverage), and the full `e2e/tests/regression/` folder — all green. Manual testing additionally covered the responseless network-failure shape (request blocked at the browser level): edits are preserved there too.

**Related issues**

Part of #3417 (item: "PluginEditorDrawer invokes onSave then closes and resets without awaiting" under Error handling / resilience). Does **not** close the tracking issue.

**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [x] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first