### PR TITLE
fix: validate route vars JSON syntax before submit

### DIFF
--- a/e2e/tests/regression/routes.vars-invalid-json.spec.ts
+++ b/e2e/tests/regression/routes.vars-invalid-json.spec.ts
@@ -1,0 +1,106 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Regression: the route `vars` Monaco editor's field-level JSON validate
+// rule is ignored by react-hook-form because the route forms attach a zod
+// resolver, and the schema typed vars as a plain optional string. Invalid
+// JSON therefore sailed through validation and JSON.parse threw inside
+// mutationFn — a non-axios error no interceptor sees — so clicking Add did
+// nothing at all. The schema now refines vars for JSON syntax, surfacing a
+// field error under the editor before any request is attempted.
+//
+// Part of apache/apisix-dashboard#3417 (error handling item 7).
+
+import { routesPom } from '@e2e/pom/routes';
+import { randomId } from '@e2e/utils/common';
+import { e2eReq } from '@e2e/utils/req';
+import { test } from '@e2e/utils/test';
+import {
+  uiFillMonacoEditor,
+  uiGetMonacoEditor,
+  uiHasToastMsg,
+} from '@e2e/utils/ui';
+import { uiFillUpstreamRequiredFields } from '@e2e/utils/ui/upstreams';
+import { expect } from '@playwright/test';
+
+import { deleteAllRoutes } from '@/apis/routes';
+import type { APISIXType } from '@/types/schema/apisix';
+
+const nodes: APISIXType['UpstreamNode'][] = [
+  { host: 'reg-vars-json.local', port: 80, weight: 100 },
+  { host: 'reg-vars-json-2.local', port: 80, weight: 100 },
+];
+
+test.beforeAll(async () => {
+  await deleteAllRoutes(e2eReq);
+});
+
+test.afterAll(async () => {
+  await deleteAllRoutes(e2eReq);
+});
+
+test('invalid vars JSON blocks Add with a field error instead of failing silently', async ({
+  page,
+}) => {
+  const routeName = randomId('reg-vars-json');
+
+  // Count POSTs: an invalid submit must never reach the Admin API.
+  let postCount = 0;
+  await page.route('**/apisix/admin/routes', async (route) => {
+    if (route.request().method() === 'POST') {
+      postCount += 1;
+    }
+    await route.fallback();
+  });
+
+  await routesPom.toAdd(page);
+  await routesPom.isAddPage(page);
+
+  await page.getByLabel('Name', { exact: true }).first().fill(routeName);
+  await page.getByLabel('URI', { exact: true }).fill('/regression/vars-json');
+  await page.getByRole('textbox', { name: 'HTTP Methods' }).click();
+  await page.getByRole('option', { name: 'GET' }).click();
+  await page.keyboard.press('Escape');
+
+  const upstreamSection = page.getByRole('group', {
+    name: 'Upstream',
+    exact: true,
+  });
+  await uiFillUpstreamRequiredFields(upstreamSection, {
+    nodes,
+    name: randomId('reg-up'),
+    desc: 'reg',
+  });
+
+  const varsSection = page.getByText('Vars').locator('..');
+  const varsEditor = await uiGetMonacoEditor(page, varsSection);
+  await uiFillMonacoEditor(page, varsEditor, '[["arg_name", "==", "tmp"'); // missing brackets
+
+  await routesPom.getAddBtn(page).click();
+
+  // Field error appears under the editor; nothing was sent; still on Add.
+  await expect(page.getByText('JSON format is not valid')).toBeVisible();
+  expect(postCount).toBe(0);
+  await expect(page).toHaveURL((url) => url.pathname.endsWith('/routes/add'));
+
+  // Fixing the JSON lets the very same form submit successfully.
+  await uiFillMonacoEditor(page, varsEditor, '[["arg_name", "==", "tmp"]]');
+  await routesPom.getAddBtn(page).click();
+  await uiHasToastMsg(page, { hasText: 'Add Route Successfully' });
+  await routesPom.isDetailPage(page);
+  expect(postCount).toBe(1);
+});

--- a/src/components/form-slice/FormPartRoute/schema.ts
+++ b/src/components/form-slice/FormPartRoute/schema.ts
@@ -18,21 +18,40 @@ import { z } from 'zod';
 
 import { APISIX } from '@/types/schema/apisix';
 
+// the FormItemEditor (monaco) is for editing text, and passing the
+// original schema of `vars` for validation is not in line with that
+// usage — but the text must at least be parseable JSON, because the
+// submit pipeline JSON.parses it (produceVarsToAPI) before the request
+// is built. Semantic validation of the expression array stays with the
+// Admin API, whose 400 error_msg the interceptor already toasts.
+const varsJSONString = z
+  .string()
+  .optional()
+  .refine(
+    (v) => {
+      if (!v || v.trim().length === 0) return true;
+      try {
+        JSON.parse(v);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    { message: 'JSON format is not valid' }
+  );
+
 export const RoutePostSchema = APISIX.Route.omit({
   id: true,
   create_time: true,
   update_time: true,
 }).extend({
-  // the FormItemEditor (monaco) is for editing text,
-  // and passing the original schema of `vars` for validation
-  // is not in line with this usage.
-  vars: z.string().optional(),
+  vars: varsJSONString,
 });
 
 export type RoutePostType = z.infer<typeof RoutePostSchema>;
 
 export const RoutePutSchema = APISIX.Route.extend({
-  vars: z.string().optional(),
+  vars: varsJSONString,
 });
 
 export type RoutePutType = z.infer<typeof RoutePutSchema>;


### PR DESCRIPTION
**Why submit this pull request?**

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

### Problem

This addresses one item from the tracking issue #3417 (Error handling / resilience):

> Route `vars` invalid JSON: with zod resolver attached, React Hook Form ignores Monaco field-level `validate` rules, causing `JSON.parse` to throw inside `mutationFn` — on `routes/add`, the Add click silently fails.

Root cause is a three-layer misalignment:

1. The Monaco editor component (`FormItemEditor`) does define a field-level JSON-syntax `validate` rule — but react-hook-form's documented behavior is to ignore all field-level rules once a `resolver` is attached, and the route forms use `zodResolver`. The rule is dead code there. (The plugin editor drawer's form has no resolver, which is why the very same component validates correctly in that context.)
2. The zod schemas typed `vars` as a plain `z.string().optional()` — any text passes.
3. `produceVarsToAPI` then runs `JSON.parse` inside `mutationFn`. On invalid JSON it throws a `SyntaxError` before any request is built — a non-axios error the interceptor never sees — so clicking Add/Save produced no toast, no field error, no navigation: nothing.

### Change

Single schema file, `src/components/form-slice/FormPartRoute/schema.ts`: a shared `varsJSONString` type — `z.string().optional()` refined with a JSON-syntax check (empty/whitespace allowed, message `JSON format is not valid`) — used by both `RoutePostSchema` and `RoutePutSchema`. Inferred types are unchanged (`string | undefined`), so no consumer changes.

Invalid JSON now surfaces as a field error under the Monaco editor before any request is attempted (`FormItemEditor` already renders `fieldState.error?.message`, and the forms already set `shouldFocusError`), and `JSON.parse` in the submit pipeline only ever sees validated strings.

The layering is deliberate: **syntax** errors are caught by the frontend schema; **semantic** errors (vars must be a valid APISIX expression array) stay with the Admin API, whose 400 `error_msg` the axios interceptor already surfaces as a toast. No new catch layers.

### Tests

New e2e spec `e2e/tests/regression/routes.vars-invalid-json.spec.ts` (written first and verified failing against the old behavior):

- fills a complete valid Add Route form but with broken JSON in vars, clicks Add;
- asserts the field error appears, the page stays on `/routes/add`, and — via a request-counting route — that **zero** POSTs reached the Admin API;
- then fixes the JSON in the same form and asserts the submit succeeds (exactly one POST, success toast, detail page).

Also ran locally: routes CRUD suites, `routes.clear-upstream-field`, `services.routes.crud`, and the full `e2e/tests/regression/` folder — 34/34 green.

**Related issues**

Part of #3417 (item: "Route vars invalid JSON silently fails on Add" under Error handling / resilience). Does **not** close the tracking issue.

**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [x] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first