### PR TITLE
fix: harden stream_routes error rendering and pagination search params

### DIFF
--- a/e2e/tests/regression/pagination.invalid-search-params.spec.ts
+++ b/e2e/tests/regression/pagination.invalid-search-params.spec.ts
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Regression: pageSearchSchema accepted any string for page/page_size and
+// transformed it with Number(), so `?page=abc` sent page=NaN to the Admin
+// API, and malformed inputs that failed the union (e.g. duplicated params
+// parsed as arrays) threw a ZodError out of validateSearch. The schema now
+// coerces and falls back to the defaults (page=1, page_size=10) for any
+// invalid input, so hand-edited URLs and stale bookmarks degrade
+// gracefully instead of failing.
+//
+// Part of apache/apisix-dashboard#3417 (error handling item 8).
+
+import { test } from '@e2e/utils/test';
+import { watchForCrashes } from '@e2e/utils/ui/crash';
+import { expect } from '@playwright/test';
+
+test('?page=abc degrades to page=1 instead of sending NaN', async ({
+  page,
+  baseURL,
+}) => {
+  const crashes = watchForCrashes(page);
+
+  const listRequests: string[] = [];
+  await page.route(
+    (url) => url.pathname.endsWith('/apisix/admin/routes'),
+    async (route) => {
+      if (route.request().method() === 'GET') {
+        listRequests.push(route.request().url());
+      }
+      await route.fallback();
+    }
+  );
+
+  await page.goto(`${baseURL}routes?page=abc&page_size=xyz`);
+
+  // The list must render normally on the fallback values.
+  await expect(
+    page.getByRole('heading', { name: 'Routes', exact: true })
+  ).toBeVisible({ timeout: 15_000 });
+  crashes.expectNoCrash('routes list with ?page=abc');
+
+  expect(listRequests.length).toBeGreaterThan(0);
+  for (const url of listRequests) {
+    const params = new URL(url).searchParams;
+    expect(params.get('page')).toBe('1');
+    expect(params.get('page_size')).toBe('10');
+  }
+});
+
+test('duplicated pagination params do not crash the list page', async ({
+  page,
+  baseURL,
+}) => {
+  const crashes = watchForCrashes(page);
+
+  await page.goto(`${baseURL}routes?page=1&page=2`);
+
+  await expect(
+    page.getByRole('heading', { name: 'Routes', exact: true })
+  ).toBeVisible({ timeout: 15_000 });
+  crashes.expectNoCrash('routes list with duplicated page params');
+});

--- a/e2e/tests/regression/stream-routes.error-400-no-body.spec.ts
+++ b/e2e/tests/regression/stream-routes.error-400-no-body.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Regression: StreamRoutesErrorComponent special-cases 400 responses to
+// show APISIX's error_msg, but dereferenced `err.response?.data.error_msg`
+// — guarding response, not data. A 400 with an empty or non-JSON body
+// rendered an empty error area (or crashed the error component itself for
+// nullish data). It now guards data and falls back to the axios error
+// message so the error area is never blank.
+//
+// Part of apache/apisix-dashboard#3417 (error handling item 2, residual).
+
+import { test } from '@e2e/utils/test';
+import { uiGoto } from '@e2e/utils/ui';
+import { watchForCrashes } from '@e2e/utils/ui/crash';
+import { expect } from '@playwright/test';
+
+test('stream routes 400 without a body renders a visible error, not a blank page', async ({
+  page,
+}) => {
+  const crashes = watchForCrashes(page);
+
+  // A 400 with an EMPTY body: axios cannot parse error_msg out of it.
+  await page.route(
+    (url) => url.pathname.endsWith('/apisix/admin/stream_routes'),
+    async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({ status: 400, body: '' });
+      } else {
+        await route.fallback();
+      }
+    }
+  );
+
+  await uiGoto(page, '/stream_routes');
+
+  // Queries retry 3 times (~7s) before the loader error surfaces.
+  await expect(
+    page.getByText('Request failed with status code 400')
+  ).toBeVisible({ timeout: 15_000 });
+
+  crashes.expectNoCrash('stream_routes 400-no-body error render');
+});

--- a/src/components/page-slice/stream_routes/ErrorComponent.tsx
+++ b/src/components/page-slice/stream_routes/ErrorComponent.tsx
@@ -26,7 +26,9 @@ export const StreamRoutesErrorComponent = (props: ErrorComponentProps) => {
   if (props.error instanceof AxiosError) {
     const err = props.error as AxiosError<APISIXRespErr>;
     if (err.response?.status === 400) {
-      return <span>{err.response?.data.error_msg}</span>;
+      // data can be missing or unparsed (empty/non-JSON body); never
+      // dereference it bare and never render an empty error area
+      return <span>{err.response.data?.error_msg ?? err.message}</span>;
     }
   }
   return <ErrorComponent {...props} />;

--- a/src/types/schema/pageSearch.ts
+++ b/src/types/schema/pageSearch.ts
@@ -17,18 +17,14 @@
 import { z } from 'zod';
 
 
+// Search params come from the URL and can be arbitrary garbage
+// (hand-edited, stale bookmarks, duplicated keys parsed as arrays).
+// `catch` degrades every invalid shape to the default instead of sending
+// NaN to the Admin API or throwing a ZodError out of validateSearch.
 export const pageSearchSchema = z
   .object({
-    page: z
-      .union([z.string(), z.number()])
-      .optional()
-      .default(1)
-      .transform((val) => (val ? Number(val) : 1)),
-    page_size: z
-      .union([z.string(), z.number()])
-      .optional()
-      .default(10)
-      .transform((val) => (val ? Number(val) : 10)),
+    page: z.coerce.number().int().min(1).catch(1),
+    page_size: z.coerce.number().int().min(1).catch(10),
     name: z.string().optional(),
     label: z.string().optional(),
   })


### PR DESCRIPTION
**Why submit this pull request?**

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

Two small, independent hardening fixes from the tracking issue #3417 (Error handling / resilience), one commit each. They share a theme but touch disjoint files, so they ship together to keep review overhead low. A third candidate originally planned for this PR (the settings admin-key refetch storm) turned out to be already fixed upstream by #3422 and is not included.

### Commit 1: guard the stream_routes error component against bodyless 400s (#3417 item 2, residual)

`StreamRoutesErrorComponent` special-cases 400 responses to show APISIX's `error_msg` (the "stream mode is disabled, can not add stream routes" hint), but dereferenced `err.response?.data.error_msg` — the optional chain guarded `response`, not `data`. A 400 whose body is empty or non-JSON (proxy/gateway truncation) rendered an empty error area, and for nullish `data` shapes the error component itself threw a TypeError, crashing into the root boundary. Five stream_routes routes share this component.

Fix: guard `data` and fall back to the axios error message, so the error area is never blank. The `error_msg` branch is untouched — verified manually by disabling `proxy_mode` stream on a live APISIX: the disabled-mode hint renders exactly as before.

### Commit 2: degrade invalid pagination search params to defaults (#3417 item 8)

`pageSearchSchema` accepted any string for `page`/`page_size` and transformed it with `Number()`, so `?page=abc` sent `page=NaN` to the Admin API; inputs that failed the union (e.g. duplicated params parsed as arrays, `?page=1&page=2`) threw a ZodError out of `validateSearch` and crashed the list page into the error boundary. Hand-edited URLs, stale bookmarks, and external links can all produce these shapes.

Fix: `z.coerce.number().int().min(1).catch(default)` — every invalid shape (non-numeric, arrays, zero/negative, floats) degrades gracefully to the first page instead of failing. Inferred types are unchanged and valid URL params keep working, which the existing pagination helpers across the list suites pin.

### Tests

- `e2e/tests/regression/stream-routes.error-400-no-body.spec.ts`: fulfills the list GET with a bodyless 400 and asserts a visible error message renders (axios fallback text) with no crash. Written first and verified failing against the old behavior (empty error area).
- `e2e/tests/regression/pagination.invalid-search-params.spec.ts`: `?page=abc&page_size=xyz` renders the list normally and the outgoing request carries `page=1&page_size=10` (asserted via request capture); duplicated `page` params render without crashing. Both written first and verified failing.

Also ran locally: stream_routes CRUD suites, five list-page suites (whose pagination helpers assert valid URL params still switch pages), and the full `e2e/tests/regression/` folder — all green. Manual verification on the production-like build covered the URL matrix (`abc`, duplicates, `0`, negatives, valid `page=2`) and the stream-disabled hint path.

**Related issues**

Part of #3417 (items: "stream_routes custom error handler unguarded dereference" under item 2, and "invalid pagination search params" item 8, both under Error handling / resilience). Does **not** close the tracking issue.

**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [x] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first