### PR TITLE
fix: stop deleting inline upstream name/desc/labels on submit

### DIFF
--- a/e2e/tests/regression/form.inline-upstream-basic-fields.spec.ts
+++ b/e2e/tests/regression/form.inline-upstream-basic-fields.spec.ts
@@ -1,0 +1,138 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Regression for a data-integrity item of apache/apisix-dashboard#3417:
+// the inline-upstream form section renders editable Name / Description /
+// Labels inputs (FormPartBasic under NamePrefixProvider "upstream"), but
+// `produceRmEmptyUpstreamFields` unconditionally `delete`s
+// `upstream.name` / `upstream.desc` / `upstream.labels` from every submit
+// body. Consequences, both directions:
+//   - values stored via the Admin API are silently erased by any
+//     dashboard edit-save of the parent resource;
+//   - values the user types into those inputs on the add page are
+//     silently discarded ("successful" save, nothing stored).
+// The Admin API accepts all three fields on an inline upstream, so the
+// deletion is not an API-compatibility workaround.
+
+import { routesPom } from '@e2e/pom/routes';
+import { randomId } from '@e2e/utils/common';
+import { e2eReq } from '@e2e/utils/req';
+import { test } from '@e2e/utils/test';
+import { uiGoto, uiHasToastMsg } from '@e2e/utils/ui';
+import { uiFillUpstreamRequiredFields } from '@e2e/utils/ui/upstreams';
+import { expect } from '@playwright/test';
+
+import { deleteAllRoutes } from '@/apis/routes';
+import type { APISIXType } from '@/types/schema/apisix';
+
+const seededUpstream = {
+  name: 'inline-upstream-name',
+  desc: 'inline upstream stored via admin api',
+  labels: { env: 'prod', team: 'gateway' },
+  type: 'roundrobin',
+  nodes: { 'inline-basic.local:80': 1 },
+};
+
+test.beforeAll(async () => {
+  await deleteAllRoutes(e2eReq);
+});
+
+test.afterAll(async () => {
+  await deleteAllRoutes(e2eReq);
+});
+
+test('no-op edit-save preserves inline upstream name/desc/labels', async ({
+  page,
+}) => {
+  const name = randomId('reg-inline-basic');
+  const res = await e2eReq.put<{ value: APISIXType['Route'] }>(
+    `/routes/${name}`,
+    { name, uri: `/reg-inline-basic/${name}`, upstream: seededUpstream }
+  );
+  const id = res.data.value.id;
+
+  await uiGoto(page, '/routes/detail/$id', { id });
+  await routesPom.isDetailPage(page);
+
+  // the editable surface whose content the submit pipeline discards:
+  // the upstream section's own Name input must display the stored value
+  const upstreamSection = page.getByRole('group', {
+    name: 'Upstream',
+    exact: true,
+  });
+  await expect(
+    upstreamSection.getByLabel('Name', { exact: true })
+  ).toHaveValue(seededUpstream.name);
+
+  await page.getByRole('button', { name: 'Edit' }).click();
+  await page.getByRole('button', { name: 'Save' }).click();
+  await expect(
+    page.getByRole('alert').filter({ hasText: /success/i })
+  ).toBeVisible();
+
+  const after = await e2eReq.get<{ value: APISIXType['Route'] }>(
+    `/routes/${id}`
+  );
+  expect(after.data.value.upstream?.name).toBe(seededUpstream.name);
+  expect(after.data.value.upstream?.desc).toBe(seededUpstream.desc);
+  expect(after.data.value.upstream?.labels).toEqual(seededUpstream.labels);
+});
+
+test('add page keeps user-typed inline upstream name and desc', async ({
+  page,
+}) => {
+  const routeName = randomId('reg-inline-basic-add');
+  const typedName = 'typed-inline-upstream';
+  const typedDesc = 'typed into the add form';
+
+  await routesPom.toIndex(page);
+  await routesPom.isIndexPage(page);
+  await routesPom.getAddRouteBtn(page).click();
+  await routesPom.isAddPage(page);
+
+  await page.getByLabel('Name', { exact: true }).first().fill(routeName);
+  await page
+    .getByLabel('URI', { exact: true })
+    .fill(`/reg-inline-basic-add/${routeName}`);
+
+  const upstreamSection = page.getByRole('group', {
+    name: 'Upstream',
+    exact: true,
+  });
+  // the helper fills the upstream section's Name input and the nodes (it
+  // always adds a second node row, hence two); it does NOT fill desc
+  await uiFillUpstreamRequiredFields(upstreamSection, {
+    nodes: [
+      { host: 'inline-a.local', port: 80, weight: 100 },
+      { host: 'inline-b.local', port: 80, weight: 100 },
+    ],
+    name: typedName,
+  });
+  await upstreamSection.getByLabel('Description').fill(typedDesc);
+
+  await routesPom.getAddBtn(page).click();
+  await uiHasToastMsg(page, { hasText: 'Add Route Successfully' });
+  await routesPom.isDetailPage(page);
+
+  const list = await e2eReq.get<{
+    list: { value: APISIXType['Route'] }[];
+  }>('/routes');
+  const created = list.data.list.find((r) => r.value.name === routeName);
+  expect(created).toBeTruthy();
+  expect(created?.value.upstream?.name).toBe(typedName);
+  expect(created?.value.upstream?.desc).toBe(typedDesc);
+});

--- a/src/components/form-slice/FormPartUpstream/util.ts
+++ b/src/components/form-slice/FormPartUpstream/util.ts
@@ -88,9 +88,15 @@ export const produceRmEmptyUpstreamFields = produce(
 
     if (draft.upstream) {
       const u = draft.upstream as Record<string, unknown>;
-      delete u.name;
-      delete u.desc;
-      delete u.labels;
+      // only strip these when EMPTY: the Admin API rejects e.g. name: ''
+      // (minLength 1) but accepts and stores non-empty name/desc/labels
+      // on an inline upstream — unconditional deletes silently erased
+      // stored values on every edit-save and discarded form input (#3417)
+      if (!u.name) delete u.name;
+      if (!u.desc) delete u.desc;
+      if (!u.labels || Object.keys(u.labels as object).length === 0) {
+        delete u.labels;
+      }
 
       if (draft.upstream.timeout && isAllUndefined(draft.upstream.timeout)) {
         delete draft.upstream.timeout;


### PR DESCRIPTION
**Why submit this pull request?**

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

Part of #3417 (Data-integrity section): "Inline upstream `name`/`desc`/`labels` are unconditionally `delete`d on submit while the form renders inputs for them — user input silently discarded; API-created values lost on any edit-save."

The inline upstream section of the route / service / stream-route forms renders editable Name, Description and Labels inputs (`FormPartBasic` under the `upstream` name prefix), but `produceRmEmptyUpstreamFields` unconditionally deleted `upstream.name`, `upstream.desc` and `upstream.labels` from every submit body (introduced in #3277, no rationale recorded). Both directions lose data silently:

- values stored through the Admin API are erased by any dashboard edit-save of the parent resource — including a no-op Edit -> Save;
- values typed into those inputs on the add page are discarded while the save reports success.

Verified against a live gateway before changing anything: the Admin API accepts and stores non-empty `name`/`desc`/`labels` on an inline upstream (HTTP 201), so the deletion is not an API-compatibility workaround.

**Fix.** The deletes now only strip *empty* values (`''` name/desc, empty `labels` object) instead of all values. Keeping the empty-guard rather than removing the deletes outright is deliberate: the Admin API rejects `name: ""` with 400 ("string too short, expected at least 1"), and the stream_routes create path does not run the deep empty-cleaner (`pipeProduce`), so a typed-then-cleared name would otherwise reach the API and fail the save. Clearing a previously stored value in edit mode still removes it (PUT is full-replace), with no error.

**Tests.** New regression spec `form.inline-upstream-basic-fields.spec.ts` (red on the unfixed build at the exact data-loss assertions, green after):

1. a route seeded via the Admin API with inline upstream name/desc/labels survives a no-op Edit → Save with all three fields intact;
2. name/desc typed into the add page's upstream section are actually stored.

Note for reviewers: the spec fills the upstream Description input directly instead of passing `desc` to `uiFillUpstreamRequiredFields` — that helper accepts a `desc` parameter but never fills it (7 existing call sites pass it, silently ignored). Fixing the helper would change the fixtures of those 7 specs, so it is left for a separate test-gap PR.

Blast radius: routes / services / stream_routes / upstreams / hot-path suites plus the regression folder — 76 passed; the 3 local failures are pre-existing environment items unrelated to this change (`stream_routes.show-disabled-error` cannot run outside the repo's own compose project; one Monaco render race and one late-serial-run load flake, both green on isolated reruns, stream_routes additionally green on 3× repeat). Unit tests 10/10, lint and build clean.

**Related issues**

Part of #3417 

**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [x] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document? (no user-facing document covers this form behavior)
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first