### PR TITLE
fix: allow colons in label values

### DIFF
--- a/e2e/tests/regression/form.labels-colon-value.spec.ts
+++ b/e2e/tests/regression/form.labels-colon-value.spec.ts
@@ -1,0 +1,123 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Regression for a data-integrity item of apache/apisix-dashboard#3417:
+// the Labels widget split every tag on EVERY colon and required exactly
+// two parts. A label value containing a colon (e.g. a registry address —
+// accepted and stored by the Admin API) could not be typed in, and once
+// stored via the API its mere presence made every subsequent edit of the
+// tag set (adding or removing ANY tag) error out and be discarded — the
+// resource's labels were permanently uneditable from the dashboard.
+
+import { routesPom } from '@e2e/pom/routes';
+import { randomId } from '@e2e/utils/common';
+import { e2eReq } from '@e2e/utils/req';
+import { test } from '@e2e/utils/test';
+import { uiGoto } from '@e2e/utils/ui';
+import { expect } from '@playwright/test';
+
+import { deleteAllRoutes } from '@/apis/routes';
+import type { APISIXType } from '@/types/schema/apisix';
+
+test.beforeAll(async () => {
+  await deleteAllRoutes(e2eReq);
+});
+
+test.afterAll(async () => {
+  await deleteAllRoutes(e2eReq);
+});
+
+test('tag set stays editable when a stored label value contains a colon', async ({
+  page,
+}) => {
+  const name = randomId('reg-colon-label');
+  const res = await e2eReq.put<{ value: APISIXType['Route'] }>(
+    `/routes/${name}`,
+    {
+      name,
+      uri: `/reg-colon-label/${name}`,
+      labels: { registry: 'docker.io:5000', env: 'prod' },
+      upstream: { type: 'roundrobin', nodes: { 'colon-label.local:80': 1 } },
+    }
+  );
+  const id = res.data.value.id;
+
+  await uiGoto(page, '/routes/detail/$id', { id });
+  await routesPom.isDetailPage(page);
+  // the stored labels display as joined tags
+  await expect(page.getByText('registry:docker.io:5000')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Edit' }).click();
+
+  // adding a tag re-parses the whole set: unfixed, the colon-value
+  // survivor fails the exactly-one-colon check, an error shows, and the
+  // addition is discarded
+  const labelsInput = page.getByLabel('Labels', { exact: true }).first();
+  await labelsInput.fill('team:gateway');
+  await labelsInput.press('Enter');
+  await expect(page.getByText('team:gateway')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Save' }).click();
+  await expect(
+    page.getByRole('alert').filter({ hasText: /success/i })
+  ).toBeVisible();
+
+  const after = await e2eReq.get<{ value: APISIXType['Route'] }>(
+    `/routes/${id}`
+  );
+  expect(after.data.value.labels).toEqual({
+    registry: 'docker.io:5000',
+    env: 'prod',
+    team: 'gateway',
+  });
+});
+
+test('a new label whose value contains a colon can be typed in', async ({
+  page,
+}) => {
+  const name = randomId('reg-colon-label-input');
+  const res = await e2eReq.put<{ value: APISIXType['Route'] }>(
+    `/routes/${name}`,
+    {
+      name,
+      uri: `/reg-colon-label-input/${name}`,
+      upstream: { type: 'roundrobin', nodes: { 'colon-label.local:80': 1 } },
+    }
+  );
+  const id = res.data.value.id;
+
+  await uiGoto(page, '/routes/detail/$id', { id });
+  await routesPom.isDetailPage(page);
+  await page.getByRole('button', { name: 'Edit' }).click();
+
+  const labelsInput = page.getByLabel('Labels', { exact: true }).first();
+  await labelsInput.fill('mirror:registry.local:5443');
+  await labelsInput.press('Enter');
+  await expect(page.getByText('mirror:registry.local:5443')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Save' }).click();
+  await expect(
+    page.getByRole('alert').filter({ hasText: /success/i })
+  ).toBeVisible();
+
+  const after = await e2eReq.get<{ value: APISIXType['Route'] }>(
+    `/routes/${id}`
+  );
+  expect(after.data.value.labels).toEqual({
+    mirror: 'registry.local:5443',
+  });
+});

--- a/src/components/form/Labels.tsx
+++ b/src/components/form/Labels.tsx
@@ -25,6 +25,11 @@ import { useTranslation } from 'react-i18next';
 
 import type { APISIXType } from '@/types/schema/apisix';
 
+import {
+  labelsToTags,
+  parseLabelTag,
+  tagsToLabels,
+} from './labels-conversion';
 import { genControllerProps } from './util';
 
 export type FormItemLabels<T extends FieldValues> = UseControllerProps<T> &
@@ -44,17 +49,12 @@ export const FormItemLabels = <T extends FieldValues>(
   const { t } = useTranslation();
   const [internalError, setInternalError] = useState<string | null>();
 
-  const values = useMemo(() => {
-    // Defensive: ensure value is a plain object (not array or null)
-    if (!value || typeof value !== 'object' || Array.isArray(value)) return [];
-    return Object.entries(value).map(([key, val]) => `${key}:${val}`);
-  }, [value]);
+  const values = useMemo(() => labelsToTags(value), [value]);
 
   const handleSearchChange = useCallback(
     (val: string) => {
-      const tuple = val.split(':');
       // when clear input, val can be ''
-      if (val && tuple.length !== 2) {
+      if (val && !parseLabelTag(val)) {
         setInternalError(t('form.basic.labels.errorFormat'));
         return;
       }
@@ -65,20 +65,16 @@ export const FormItemLabels = <T extends FieldValues>(
 
   const handleChange = useCallback(
     (vals: string[]) => {
-      const obj: APISIXType['Labels'] = {};
-      for (const val of vals) {
-        const tuple = val.split(':');
-        if (tuple.length !== 2) {
-          setInternalError(t('form.basic.labels.errorFormat'));
-          return;
-        }
-        obj[tuple[0]] = tuple[1];
+      const obj = tagsToLabels(vals, value);
+      if (!obj) {
+        setInternalError(t('form.basic.labels.errorFormat'));
+        return;
       }
       setInternalError(null);
       fOnChange(obj);
       restProps.onChange?.(obj);
     },
-    [fOnChange, restProps, t]
+    [fOnChange, restProps, t, value]
   );
 
   return (

--- a/src/components/form/labels-conversion.test.ts
+++ b/src/components/form/labels-conversion.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  labelsToTags,
+  parseLabelTag,
+  tagsToLabels,
+} from './labels-conversion';
+
+// Regression for a data-integrity item of #3417: the Labels widget split
+// every tag on EVERY colon and required exactly two parts, so a label
+// value containing a colon (registry addresses, times, ratios — accepted
+// and stored by the Admin API, verified live) could not be typed in, and
+// its mere presence made every subsequent edit of the tag set error out
+// and be discarded. New-input parsing splits on the FIRST colon; strings
+// that match an existing entry's joined form keep that entry verbatim, so
+// stored labels (including colon-in-KEY ones, which the API also accepts)
+// are never silently rewritten by edits to other tags.
+
+describe('parseLabelTag', () => {
+  it('splits on the first colon only', () => {
+    expect(parseLabelTag('registry:docker.io:5000')).toEqual([
+      'registry',
+      'docker.io:5000',
+    ]);
+  });
+
+  it('accepts a plain key:value pair', () => {
+    expect(parseLabelTag('env:prod')).toEqual(['env', 'prod']);
+  });
+
+  it('rejects a tag without a colon', () => {
+    expect(parseLabelTag('env')).toBeNull();
+  });
+
+  it('rejects empty key or value (the Admin API rejects them with 400)', () => {
+    expect(parseLabelTag(':prod')).toBeNull();
+    expect(parseLabelTag('env:')).toBeNull();
+  });
+});
+
+describe('tagsToLabels', () => {
+  it('parses new colon-value input by first colon', () => {
+    expect(tagsToLabels(['registry:docker.io:5000'], {})).toEqual({
+      registry: 'docker.io:5000',
+    });
+  });
+
+  it('keeps existing entries verbatim when other tags change', () => {
+    const current = { 'a:b': 'c', env: 'prod' };
+    expect(tagsToLabels(['a:b:c', 'env:prod', 'team:gw'], current)).toEqual({
+      'a:b': 'c',
+      env: 'prod',
+      team: 'gw',
+    });
+  });
+
+  it('supports removing a tag without disturbing colon-key survivors', () => {
+    const current = { 'a:b': 'c', env: 'prod' };
+    expect(tagsToLabels(['a:b:c'], current)).toEqual({ 'a:b': 'c' });
+  });
+
+  it('returns null for invalid new input', () => {
+    expect(tagsToLabels(['nocolon'], {})).toBeNull();
+    expect(tagsToLabels(['env:'], {})).toBeNull();
+  });
+
+  it('tolerates a non-object current value', () => {
+    expect(tagsToLabels(['env:prod'], undefined)).toEqual({ env: 'prod' });
+    expect(tagsToLabels(['env:prod'], ['array'])).toEqual({ env: 'prod' });
+  });
+});
+
+describe('labelsToTags', () => {
+  it('joins entries with a colon', () => {
+    expect(labelsToTags({ registry: 'docker.io:5000' })).toEqual([
+      'registry:docker.io:5000',
+    ]);
+  });
+
+  it('returns [] for non-object values', () => {
+    expect(labelsToTags(undefined)).toEqual([]);
+    expect(labelsToTags(['x'])).toEqual([]);
+    expect(labelsToTags(null)).toEqual([]);
+  });
+});

--- a/src/components/form/labels-conversion.ts
+++ b/src/components/form/labels-conversion.ts
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { APISIXType } from '@/types/schema/apisix';
+
+export const labelsToTags = (value: unknown): string[] => {
+  // Defensive: ensure value is a plain object (not array or null)
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return [];
+  return Object.entries(value).map(([key, val]) => `${key}:${val}`);
+};
+
+/**
+ * Parse NEW user input on the FIRST colon: keys cannot contain colons via
+ * the dashboard, values can (registry addresses, times, ratios — the
+ * Admin API accepts and stores them). Key and value must both be
+ * non-empty: the Admin API rejects empty ones with 400.
+ */
+export const parseLabelTag = (tag: string): [string, string] | null => {
+  const i = tag.indexOf(':');
+  if (i <= 0 || i === tag.length - 1) return null;
+  return [tag.slice(0, i), tag.slice(i + 1)];
+};
+
+/**
+ * Convert the TagsInput strings back into a labels object. A string that
+ * matches an existing entry's joined `key:value` form keeps that entry
+ * VERBATIM — editing other tags can never rewrite a stored label (the
+ * Admin API also accepts colon-in-KEY labels, which a re-parse would
+ * silently turn into a different pair). Only genuinely new strings are
+ * parsed. Returns null when a new string is not a valid `key:value`.
+ */
+export const tagsToLabels = (
+  tags: string[],
+  current: unknown
+): APISIXType['Labels'] | null => {
+  const existing = new Map<string, [string, string]>();
+  if (current && typeof current === 'object' && !Array.isArray(current)) {
+    for (const [key, val] of Object.entries(
+      current as Record<string, unknown>
+    )) {
+      const joined = `${key}:${val}`;
+      if (!existing.has(joined)) existing.set(joined, [key, String(val)]);
+    }
+  }
+  const obj: APISIXType['Labels'] = {};
+  for (const tag of tags) {
+    const pair = existing.get(tag) ?? parseLabelTag(tag);
+    if (!pair) return null;
+    obj[pair[0]] = pair[1];
+  }
+  return obj;
+};


### PR DESCRIPTION
**Why submit this pull request?**

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

Part of #3417 (Data-integrity section): "Labels widget splits on every `:` — a label value containing a colon errors on any subsequent edit of the tag set (`Labels.tsx`; split on first colon only)."

The Labels widget represents `{key: value}` labels as `key:value` tags, and both its typing validator and its change handler split every tag on EVERY colon, requiring exactly two parts. Verified against a live gateway: the Admin API accepts and stores colon-containing label values (`{"registry": "docker.io:5000"}` → 201) — registry addresses, times, ratios are all realistic values. Consequences:

- such a value could not be typed into the dashboard at all (instant format error);
- once such a label existed on a resource (created via the Admin API), **any** edit of the tag set — adding or removing an unrelated tag — re-parsed every surviving tag, errored on the colon-value one, and silently discarded the whole change: the resource's labels were permanently uneditable from the dashboard.

**Fix.** New input is parsed on the **first** colon (key and value must both be non-empty — the Admin API rejects empty ones with 400, also verified). This alone would not be safe, though: the Admin API even accepts colons in label **keys** (`{"a:b": "c"}` → 201, verified), and `a:b:c` is genuinely ambiguous — a blind first-colon re-parse would silently rewrite a stored `{"a:b": "c"}` into `{"a": "b:c"}` on any unrelated tag edit, trading today's loud failure for silent corruption. So the change handler first matches each tag string against the current value's entries in joined `key:value` form and keeps matching entries **verbatim**; only genuinely new strings are parsed. Stored labels can only ever be kept or explicitly removed, never mutated as a side effect of editing other tags.

Known limitation, disclosed: colon-in-key labels still cannot be *created* through the dashboard input — unchanged from before (they errored), and the API-created ones now survive editing instead of blocking it.

The conversion helpers live in `labels-conversion.ts`, extracted from the component solely so they are unit-testable.

**Tests** (red on the unfixed build at the intended assertions, green after):

- Unit `labels-conversion.test.ts`: 13 cases — first-colon parsing, empty key/value rejection, verbatim preservation of colon-key survivors across add/remove, non-object tolerance, display join.
- E2E regression `form.labels-colon-value.spec.ts`: a route seeded with `{"registry": "docker.io:5000"}` keeps an editable tag set (add a tag, save, full label set persisted), and a new colon-value label can be typed in and round-trips to the API.

Blast radius (the widget is used by every resource's Basic section and the health-check request-headers field): full local e2e suite — **173 passed**, the only failure being `stream_routes.show-disabled-error`, which cannot run outside the repo's own compose project (documented environment limitation). Unit tests 21/21, lint and build clean.

**Related issues**

Part of #3417 (please do not auto-close the tracking issue)

**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [x] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document? (no user-facing document covers the labels widget)
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first