### PR TITLE
fix: array<string> fields rendered with wrong widgets; SSL edit wiped the mTLS client block

### DIFF
--- a/e2e/tests/regression/ssls.noop-edit-preserves-client.spec.ts
+++ b/e2e/tests/regression/ssls.noop-edit-preserves-client.spec.ts
@@ -15,12 +15,20 @@
  * limitations under the License.
  */
 
-// Regression for a data-integrity item of apache/apisix-dashboard#3417:
-// `ssls.client.skip_mtls_uri_regex` is typed `array<string>` (URI regex
-// list, matching the Admin API) but was rendered as a boolean Switch.
-// Both directions were broken: a stored regex list displayed as a
-// meaningless "on" toggle with the actual values invisible, and toggling
-// wrote a boolean that failed the zod array schema on submit.
+// Regression for a silent data-loss bug found while fixing the
+// skip_mtls_uri_regex widget (#3417 follow-up): the SSL detail page
+// created its form WITHOUT `defaultValues` and populated it only through
+// a later `form.reset(...)`. Under `shouldUnregister: true`, a
+// controlled field that mounts AFTER that reset (the whole client
+// section, gated on `__clientEnabled`) has its entry in `_defaultValues`
+// overwritten from `_options.defaultValues` — i.e. with undefined — by
+// react-hook-form's useController mount effect. The unmount/remount
+// around toggling Edit then drops the value with nothing to re-seed
+// from, wiping the whole `client.*` subtree: an edit-save silently
+// DELETED the mTLS client block (PUT succeeded, verification gone).
+// Passing the producer output as `defaultValues` at creation (the same
+// pattern routes/services/stream_routes detail pages already use) keeps
+// the re-seed source populated.
 
 import { sslsPom } from '@e2e/pom/ssls';
 import { genTLS, randomId } from '@e2e/utils/common';
@@ -32,8 +40,6 @@ import { expect } from '@playwright/test';
 import { deleteAllSSLs } from '@/apis/ssls';
 import type { APISIXType } from '@/types/schema/apisix';
 
-const regexes = ['/health.*', '/metrics'];
-
 test.beforeAll(async () => {
   await deleteAllSSLs(e2eReq);
 });
@@ -42,18 +48,20 @@ test.afterAll(async () => {
   await deleteAllSSLs(e2eReq);
 });
 
-test('client skip_mtls_uri_regex displays and round-trips', async ({
-  page,
-}) => {
+test('no-op edit-save preserves the mTLS client block', async ({ page }) => {
   const { cert, key } = await genTLS();
-  const sni = `${randomId('reg-mtls')}.example.com`;
+  const sni = `${randomId('reg-client-keep')}.example.com`;
   const res = await e2eReq.put<{ value: APISIXType['SSL'] }>(
-    `/ssls/${randomId('reg-mtls')}`,
+    `/ssls/${randomId('reg-client-keep')}`,
     {
       snis: [sni],
       cert,
       key,
-      client: { ca: cert, skip_mtls_uri_regex: regexes },
+      client: {
+        ca: cert,
+        depth: 2,
+        skip_mtls_uri_regex: ['/health.*', '/metrics'],
+      },
     }
   );
   const id = res.data.value.id;
@@ -61,33 +69,19 @@ test('client skip_mtls_uri_regex displays and round-trips', async ({
   await uiGoto(page, '/ssls/detail/$id', { id });
   await sslsPom.isDetailPage(page);
 
-  // stored regexes must be visible (unfixed: a bare "on" Switch, values
-  // nowhere on the page)
-  await expect(page.getByText(regexes[0], { exact: true })).toBeVisible();
-  await expect(page.getByText(regexes[1], { exact: true })).toBeVisible();
-
   await page.getByRole('button', { name: 'Edit' }).click();
-
-  const field = page.getByRole('textbox', {
-    name: 'Skip mTLS URI Regex',
-    exact: true,
-  });
-  await field.fill('/status');
-  await field.press('Enter');
-  await expect(page.getByText('/status', { exact: true })).toBeVisible();
-
-  // the API does not return the private key to the form; re-fill it so
-  // the PUT passes validation (same reason the crud spec cancels edits)
+  // the API never returns the private key, so a save always needs it
+  // re-entered — everything else must survive untouched
   await page.getByRole('textbox', { name: 'Key 1' }).fill(key);
-
   await page.getByRole('button', { name: 'Save' }).click();
   await expect(
     page.getByRole('alert').filter({ hasText: /success/i })
   ).toBeVisible();
 
   const after = await e2eReq.get<{ value: APISIXType['SSL'] }>(`/ssls/${id}`);
-  expect(after.data.value.client?.skip_mtls_uri_regex).toEqual([
-    ...regexes,
-    '/status',
-  ]);
+  const client = after.data.value.client;
+  expect(client).toBeTruthy();
+  expect(client?.ca).toBe(cert);
+  expect(client?.depth).toBe(2);
+  expect(client?.skip_mtls_uri_regex).toEqual(['/health.*', '/metrics']);
 });

--- a/e2e/tests/regression/ssls.skip-mtls-uri-regex-field.spec.ts
+++ b/e2e/tests/regression/ssls.skip-mtls-uri-regex-field.spec.ts
@@ -1,0 +1,106 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Regression for a data-integrity item of apache/apisix-dashboard#3417:
+// `ssls.client.skip_mtls_uri_regex` is typed `array<string>` (URI regex
+// list, matching the Admin API) but was rendered as a boolean Switch.
+// Both directions were broken: a stored regex list displayed as a
+// meaningless "on" toggle with the actual values invisible, and toggling
+// wrote a boolean that failed the zod array schema on submit.
+
+import { sslsPom } from '@e2e/pom/ssls';
+import { genTLS, randomId } from '@e2e/utils/common';
+import { e2eReq } from '@e2e/utils/req';
+import { test } from '@e2e/utils/test';
+import { uiGoto } from '@e2e/utils/ui';
+import { expect } from '@playwright/test';
+
+import { deleteAllSSLs } from '@/apis/ssls';
+import type { APISIXType } from '@/types/schema/apisix';
+
+const regexes = ['/health.*', '/metrics'];
+
+test.beforeAll(async () => {
+  await deleteAllSSLs(e2eReq);
+});
+
+test.afterAll(async () => {
+  await deleteAllSSLs(e2eReq);
+});
+
+test('client skip_mtls_uri_regex displays and round-trips', async ({
+  page,
+}) => {
+  const { cert, key } = await genTLS();
+  const sni = `${randomId('reg-mtls')}.example.com`;
+  const res = await e2eReq.put<{ value: APISIXType['SSL'] }>(
+    `/ssls/${randomId('reg-mtls')}`,
+    {
+      snis: [sni],
+      cert,
+      key,
+      client: { ca: cert, skip_mtls_uri_regex: regexes },
+    }
+  );
+  const id = res.data.value.id;
+
+  await uiGoto(page, '/ssls/detail/$id', { id });
+  await sslsPom.isDetailPage(page);
+
+  // stored regexes must be visible (unfixed: a bare "on" Switch, values
+  // nowhere on the page)
+  await expect(page.getByText(regexes[0], { exact: true })).toBeVisible();
+  await expect(page.getByText(regexes[1], { exact: true })).toBeVisible();
+
+  await page.getByRole('button', { name: 'Edit' }).click();
+
+  const field = page.getByRole('textbox', {
+    name: 'Skip mTLS URI Regex',
+    exact: true,
+  });
+  // type the full set: a pre-existing separate bug (NOT this fix's scope)
+  // wipes the client.* subtree from the form state when toggling Edit, so
+  // the seeded tags may be gone here. TagsInput dedupes, so this stays
+  // correct once that bug is fixed and the seeded tags survive.
+  for (const regex of [...regexes, '/status']) {
+    await field.fill(regex);
+    await field.press('Enter');
+  }
+  await expect(page.getByText('/status', { exact: true })).toBeVisible();
+
+  // the API does not return the private key to the form; re-fill it so
+  // the PUT passes validation (same reason the crud spec cancels edits)
+  await page.getByRole('textbox', { name: 'Key 1' }).fill(key);
+  // pre-existing separate bug (NOT this fix's scope): toggling Edit wipes
+  // client.ca from the form state, and the Admin API requires ca whenever
+  // client is present — re-fill it like the key so the round-trip can be
+  // asserted at the storage level
+  await page
+    .getByRole('textbox', { name: 'Client CA Certificate' })
+    .fill(cert);
+
+  await page.getByRole('button', { name: 'Save' }).click();
+  await expect(
+    page.getByRole('alert').filter({ hasText: /success/i })
+  ).toBeVisible();
+
+  const after = await e2eReq.get<{ value: APISIXType['SSL'] }>(`/ssls/${id}`);
+  expect(after.data.value.client?.skip_mtls_uri_regex).toEqual([
+    ...regexes,
+    '/status',
+  ]);
+});

--- a/e2e/tests/regression/ssls.skip-mtls-uri-regex-field.spec.ts
+++ b/e2e/tests/regression/ssls.skip-mtls-uri-regex-field.spec.ts
@@ -72,9 +72,14 @@ test('client skip_mtls_uri_regex displays and round-trips', async ({
     name: 'Skip mTLS URI Regex',
     exact: true,
   });
-  await field.fill('/status');
+  // a regex legitimately containing a comma (quantifier {1,3}) must stay
+  // ONE tag — the field must not comma-split it (#3435 review)
+  const commaRegex = '^/v[0-9]{1,3}$';
+  // type character by character so the comma keystroke would trigger
+  // Mantine's default comma-split (the actual user path)
+  await field.pressSequentially(commaRegex);
   await field.press('Enter');
-  await expect(page.getByText('/status', { exact: true })).toBeVisible();
+  await expect(page.getByText(commaRegex, { exact: true })).toBeVisible();
 
   // the API does not return the private key to the form; re-fill it so
   // the PUT passes validation (same reason the crud spec cancels edits)
@@ -88,6 +93,6 @@ test('client skip_mtls_uri_regex displays and round-trips', async ({
   const after = await e2eReq.get<{ value: APISIXType['SSL'] }>(`/ssls/${id}`);
   expect(after.data.value.client?.skip_mtls_uri_regex).toEqual([
     ...regexes,
-    '/status',
+    commaRegex,
   ]);
 });

--- a/e2e/tests/regression/upstreams.http-request-headers-field.spec.ts
+++ b/e2e/tests/regression/upstreams.http-request-headers-field.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Regression for a data-integrity item of apache/apisix-dashboard#3417:
+// `checks.active.http_request_headers` is typed `array<string>` (matching
+// the Admin API) but was rendered with the Labels widget, which expects
+// an OBJECT value. Both directions were broken: stored header lines
+// displayed as an empty field (the widget's array guard returns []), and
+// anything typed in produced an object that failed the zod array schema
+// on submit — the field was unusable.
+
+import { upstreamsPom } from '@e2e/pom/upstreams';
+import { randomId } from '@e2e/utils/common';
+import { e2eReq } from '@e2e/utils/req';
+import { test } from '@e2e/utils/test';
+import { uiGoto } from '@e2e/utils/ui';
+import { expect } from '@playwright/test';
+
+import { deleteAllUpstreams } from '@/apis/upstreams';
+import type { APISIXType } from '@/types/schema/apisix';
+
+const headers = ['User-Agent: apisix-probe', 'X-Check: 1'];
+
+test.beforeAll(async () => {
+  await deleteAllUpstreams(e2eReq);
+});
+
+test.afterAll(async () => {
+  await deleteAllUpstreams(e2eReq);
+});
+
+test('active health-check request headers display and round-trip', async ({
+  page,
+}) => {
+  const name = randomId('reg-hdr-field');
+  const res = await e2eReq.put<{ value: APISIXType['Upstream'] }>(
+    `/upstreams/${name}`,
+    {
+      name,
+      type: 'roundrobin',
+      nodes: { 'hdr-field.local:80': 1 },
+      checks: {
+        active: {
+          http_path: '/health',
+          http_request_headers: headers,
+          unhealthy: { interval: 2, http_failures: 3 },
+        },
+      },
+    }
+  );
+  const id = res.data.value.id;
+
+  await uiGoto(page, '/upstreams/detail/$id', { id });
+  await upstreamsPom.isDetailPage(page);
+
+  // stored header lines must be visible (unfixed: the field renders empty)
+  await expect(page.getByText(headers[0], { exact: true })).toBeVisible();
+  await expect(page.getByText(headers[1], { exact: true })).toBeVisible();
+
+  await page.getByRole('button', { name: 'Edit' }).click();
+
+  // typed input must survive submit as an array member
+  const field = page.getByRole('textbox', {
+    name: 'HTTP Request Headers',
+    exact: true,
+  });
+  await field.fill('X-Extra: 2');
+  await field.press('Enter');
+  await expect(page.getByText('X-Extra: 2', { exact: true })).toBeVisible();
+
+  await page.getByRole('button', { name: 'Save' }).click();
+  await expect(
+    page.getByRole('alert').filter({ hasText: /success/i })
+  ).toBeVisible();
+
+  const after = await e2eReq.get<{ value: APISIXType['Upstream'] }>(
+    `/upstreams/${id}`
+  );
+  expect(after.data.value.checks?.active?.http_request_headers).toEqual([
+    ...headers,
+    'X-Extra: 2',
+  ]);
+});

--- a/e2e/tests/regression/upstreams.http-request-headers-field.spec.ts
+++ b/e2e/tests/regression/upstreams.http-request-headers-field.spec.ts
@@ -78,9 +78,12 @@ test('active health-check request headers display and round-trip', async ({
     name: 'HTTP Request Headers',
     exact: true,
   });
-  await field.fill('X-Extra: 2');
+  // a header value legitimately containing a comma must stay ONE entry —
+  // the field must not comma-split it (#3435 review)
+  const commaHeader = 'Accept: text/html,application/json';
+  await field.pressSequentially(commaHeader);
   await field.press('Enter');
-  await expect(page.getByText('X-Extra: 2', { exact: true })).toBeVisible();
+  await expect(page.getByText(commaHeader, { exact: true })).toBeVisible();
 
   await page.getByRole('button', { name: 'Save' }).click();
   await expect(
@@ -92,6 +95,6 @@ test('active health-check request headers display and round-trip', async ({
   );
   expect(after.data.value.checks?.active?.http_request_headers).toEqual([
     ...headers,
-    'X-Extra: 2',
+    commaHeader,
   ]);
 });

--- a/src/components/form-slice/FormPartSSL/index.tsx
+++ b/src/components/form-slice/FormPartSSL/index.tsx
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { InputWrapper, Text } from '@mantine/core';
+import { Text } from '@mantine/core';
 import { useFormContext, useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
@@ -54,12 +54,13 @@ const FormSectionClient = () => {
             defaultValue={1}
             min={0}
           />
-          <InputWrapper label={t('form.ssls.client.skipMtlsUriRegex')}>
-            <FormItemSwitch
-              control={control}
-              name="client.skip_mtls_uri_regex"
-            />
-          </InputWrapper>
+          {/* array<string> of URI regexes — a TagsInput, not a Switch:
+              the boolean broke this field both ways (#3417) */}
+          <FormItemTagsInput
+            control={control}
+            name="client.skip_mtls_uri_regex"
+            label={t('form.ssls.client.skipMtlsUriRegex')}
+          />
         </>
       ) : (
         <Text c="gray.6" size="sm">

--- a/src/components/form-slice/FormPartSSL/index.tsx
+++ b/src/components/form-slice/FormPartSSL/index.tsx
@@ -55,11 +55,14 @@ const FormSectionClient = () => {
             min={0}
           />
           {/* array<string> of URI regexes — a TagsInput, not a Switch:
-              the boolean broke this field both ways (#3417) */}
+              the boolean broke this field both ways (#3417). splitChars={[]}
+              because a regex can contain a comma (e.g. the quantifier
+              `{1,3}`) and must stay one entry (#3435 review). */}
           <FormItemTagsInput
             control={control}
             name="client.skip_mtls_uri_regex"
             label={t('form.ssls.client.skipMtlsUriRegex')}
+            splitChars={[]}
           />
         </>
       ) : (

--- a/src/components/form-slice/FormPartUpstream/FormSectionChecks.tsx
+++ b/src/components/form-slice/FormPartUpstream/FormSectionChecks.tsx
@@ -18,7 +18,6 @@ import { Text } from '@mantine/core';
 import { useFormContext, useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
-import { FormItemLabels } from '@/components/form/Labels';
 import { FormItemNumberInput } from '@/components/form/NumberInput';
 import { FormItemSelect } from '@/components/form/Select';
 import { FormItemSwitch } from '@/components/form/Switch';
@@ -76,7 +75,10 @@ const FormSectionChecksActive = () => {
         name={np('checks.active.http_path')}
         label={t('form.upstreams.checks.active.http_path')}
       />
-      <FormItemLabels
+      {/* array<string> of raw header lines — a TagsInput, not the Labels
+          widget (which produces an object and broke this field both ways,
+          #3417) */}
+      <FormItemTagsInput
         control={control}
         name={np('checks.active.http_request_headers')}
         label={t('form.upstreams.checks.active.http_request_headers')}

--- a/src/components/form-slice/FormPartUpstream/FormSectionChecks.tsx
+++ b/src/components/form-slice/FormPartUpstream/FormSectionChecks.tsx
@@ -77,11 +77,14 @@ const FormSectionChecksActive = () => {
       />
       {/* array<string> of raw header lines — a TagsInput, not the Labels
           widget (which produces an object and broke this field both ways,
-          #3417) */}
+          #3417). splitChars={[]} because a header value can contain a
+          comma (e.g. `Accept: text/html,application/json`) and must stay
+          one entry (#3435 review). */}
       <FormItemTagsInput
         control={control}
         name={np('checks.active.http_request_headers')}
         label={t('form.upstreams.checks.active.http_request_headers')}
+        splitChars={[]}
       />
       <FormSection legend={t('form.upstreams.checks.active.healthy.title')}>
         <FormItemNumberInput

--- a/src/routes/ssls/detail.$id.tsx
+++ b/src/routes/ssls/detail.$id.tsx
@@ -65,6 +65,14 @@ const SSLDetailForm = (props: Props & { id: string }) => {
     shouldUnregister: true,
     mode: 'all',
     disabled: readOnly,
+    // Without creation-time defaultValues, any controlled field that
+    // mounts AFTER the reset below (the whole client section, gated on
+    // __clientEnabled) gets its _defaultValues entry overwritten with
+    // undefined by RHF's useController mount effect under
+    // shouldUnregister — the unmount/remount around toggling Edit then
+    // wipes the client.* subtree and an edit-save silently deletes the
+    // mTLS client block (same pattern as routes/services detail, #3414).
+    defaultValues: produceToSSLForm(sslData),
   });
 
   const putSSL = useMutation({


### PR DESCRIPTION
**Why submit this pull request?**

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

Part of #3417 (Data-integrity section), two widget/type-mismatch items plus a silent data-loss bug discovered while fixing the second one. Three commits, one root cause each:

**1. `checks.active.http_request_headers` rendered with the Labels widget (`d8157e7`)**

The field is `array<string>` (raw header lines, matching the Admin API) but was rendered with the Labels widget, which expects an object. Both directions were broken: stored header lines displayed as an empty field (the widget's array guard returns `[]`), and typed input produced an object that failed the zod array schema on submit — the field was unusable. Now a `FormItemTagsInput`, the same control the sibling `http_statuses` fields already use.

**2. `ssls.client.skip_mtls_uri_regex` rendered as a boolean Switch (`1c0d99c`)**

Same class: the field is `array<string>` (URI regexes) but was rendered as a Switch. A stored regex list displayed as a meaningless "on" toggle with the values invisible, and toggling wrote a boolean that failed the array schema. Also now a `FormItemTagsInput`.

**3. Edit-save silently deleted the SSL's mTLS client block (`997f608`)**

Found while writing the e2e for item 2: on master, opening an SSL that has a `client` block, clicking Edit and saving **silently deletes the whole `client` block** — the PUT succeeds, the success toast shows, and mTLS client verification is gone. (The existing ssls crud spec's "click Cancel instead of Save" workaround hints at this area's fragility.)

Root cause, probe-verified: the SSL detail page created its form **without creation-time `defaultValues`** and populated it only through a later `form.reset()`. Under `shouldUnregister: true`, react-hook-form's `useController` mount effect (v7.56.1) overwrites a field's `_defaultValues` entry from `_options.defaultValues` — i.e. with `undefined` — so every controlled field that mounts **after** that reset loses its re-seed source. The client section is exactly that (it mounts once the reset sets `__clientEnabled`), so the unmount/remount around toggling Edit dropped the values with nothing to restore from: `client.ca` measured 1333 chars in view mode and `undefined` immediately after clicking Edit, while root-level fields that registered before the reset (e.g. `cert`) survived.

Fix: pass `produceToSSLForm(sslData)` as creation-time `defaultValues` (the data is synchronously available via `useSuspenseQuery`) — the exact pattern the routes/services/stream_routes detail pages already use, and the same bug class as #3414. A survey of all detail pages confirmed ssls was the only remaining page combining `shouldUnregister` + reset-only population + a conditionally-mounted controlled section.

**Tests** (each red on the unfixed build at the intended assertion, green after):

- `upstreams.http-request-headers-field.spec.ts` — stored header lines visible, typed line round-trips to storage as an array member.
- `ssls.skip-mtls-uri-regex-field.spec.ts` — stored regexes visible as tags, typed regex round-trips; the private key must be re-entered before saving because the Admin API never returns it (pre-existing, same as the crud spec).
- `ssls.noop-edit-preserves-client.spec.ts` — a no-op Edit → Save preserves `client.ca`, `client.depth` and `client.skip_mtls_uri_regex` verbatim (red reproduced the silent deletion: save "succeeded" with `client` gone from storage).

Blast radius: full local e2e suite — **173 passed**; the only 2 failures are documented environment items unrelated to this change (a Monaco read-back race that reproduces on pristine master, and `stream_routes.show-disabled-error`, which cannot run outside the repo's own compose project). Unit tests, lint and build clean.

**Related issues**

Part of #3417 (please do not auto-close the tracking issue)

**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [x] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document? (no user-facing document covers these form fields)
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first