### PR TITLE
fix: unify stream-route submit pipelines, drop phantom plugin_config_id

### DIFF
--- a/e2e/tests/regression/stream-routes.no-phantom-plugin-config-id.spec.ts
+++ b/e2e/tests/regression/stream-routes.no-phantom-plugin-config-id.spec.ts
@@ -65,6 +65,39 @@ test('stream route forms do not offer the unsupported Plugin Config ID', async (
   await expect(page.getByLabel('Plugin Config ID')).toHaveCount(0);
 });
 
+// #3437 review: the Admin API accepts a stream-route name, so it must
+// survive a dashboard edit-save instead of being deleted by the producer.
+test('a stream route keeps its name across a no-op edit-save', async ({
+  page,
+}) => {
+  const id = randomId('reg-sr-name');
+  const name = `sr name ${id}`;
+  const res = await e2eReq.put<{ value: APISIXType['StreamRoute'] }>(
+    `/stream_routes/${id}`,
+    {
+      name,
+      server_port: 9100,
+      upstream: { type: 'roundrobin', nodes: { 'sr-name.local:80': 1 } },
+    }
+  );
+
+  await uiGoto(page, '/stream_routes/detail/$id', { id: res.data.value.id });
+  await streamRoutesPom.isDetailPage(page);
+  // the name must render (form now shows it) and survive edit-save
+  await expect(page.locator('input[name="name"]')).toHaveValue(name);
+
+  await page.getByRole('button', { name: 'Edit' }).click();
+  await page.getByRole('button', { name: 'Save' }).click();
+  await expect(
+    page.getByRole('alert').filter({ hasText: /success/i })
+  ).toBeVisible();
+
+  const after = await e2eReq.get<{ value: APISIXType['StreamRoute'] }>(
+    `/stream_routes/${res.data.value.id}`
+  );
+  expect((after.data.value as { name?: string }).name).toBe(name);
+});
+
 test('the HTTP route form still offers Plugin Config ID', async ({ page }) => {
   await routesPom.toIndex(page);
   await routesPom.isIndexPage(page);

--- a/e2e/tests/regression/stream-routes.no-phantom-plugin-config-id.spec.ts
+++ b/e2e/tests/regression/stream-routes.no-phantom-plugin-config-id.spec.ts
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Regression for a data-integrity item of apache/apisix-dashboard#3417:
+// the stream-route form reused the HTTP-route plugins section, which
+// renders a "Plugin Config ID" input — a field the stream_routes
+// resource does not have (the Admin API rejects it with 400, and the
+// dashboard's zod resolver strips it before the request): anything the
+// user typed there was silently discarded on a "successful" save.
+
+import { routesPom } from '@e2e/pom/routes';
+import { streamRoutesPom } from '@e2e/pom/stream_routes';
+import { randomId } from '@e2e/utils/common';
+import { e2eReq } from '@e2e/utils/req';
+import { test } from '@e2e/utils/test';
+import { uiGoto } from '@e2e/utils/ui';
+import { expect } from '@playwright/test';
+
+import { deleteAllStreamRoutes } from '@/apis/stream_routes';
+import type { APISIXType } from '@/types/schema/apisix';
+
+test.beforeAll(async () => {
+  await deleteAllStreamRoutes(e2eReq);
+});
+
+test.afterAll(async () => {
+  await deleteAllStreamRoutes(e2eReq);
+});
+
+test('stream route forms do not offer the unsupported Plugin Config ID', async ({
+  page,
+}) => {
+  await streamRoutesPom.toAdd(page);
+  await streamRoutesPom.isAddPage(page);
+  // the plugins section itself must stay
+  await expect(
+    page.getByRole('button', { name: 'Select Plugins' })
+  ).toBeVisible();
+  await expect(page.getByLabel('Plugin Config ID')).toHaveCount(0);
+
+  const name = randomId('reg-no-pcid');
+  const res = await e2eReq.put<{ value: APISIXType['StreamRoute'] }>(
+    `/stream_routes/${name}`,
+    {
+      server_port: 9100,
+      upstream: { type: 'roundrobin', nodes: { 'no-pcid.local:80': 1 } },
+    }
+  );
+  await uiGoto(page, '/stream_routes/detail/$id', { id: res.data.value.id });
+  await streamRoutesPom.isDetailPage(page);
+  await expect(page.getByLabel('Plugin Config ID')).toHaveCount(0);
+});
+
+test('the HTTP route form still offers Plugin Config ID', async ({ page }) => {
+  await routesPom.toIndex(page);
+  await routesPom.isIndexPage(page);
+  await routesPom.getAddRouteBtn(page).click();
+  await routesPom.isAddPage(page);
+  await expect(page.getByLabel('Plugin Config ID')).toBeVisible();
+});

--- a/src/components/form-slice/FormPartRoute/index.tsx
+++ b/src/components/form-slice/FormPartRoute/index.tsx
@@ -125,17 +125,26 @@ export const FormSectionUpstream = () => {
   );
 };
 
-export const FormSectionPlugins = () => {
+export type FormSectionPluginsProps = {
+  /** stream_routes has no plugin_config_id — the Admin API rejects it */
+  showConfigId?: boolean;
+};
+export const FormSectionPlugins = (props: FormSectionPluginsProps) => {
+  const { showConfigId = true } = props;
   const { t } = useTranslation();
   const { control } = useFormContext<RoutePostType>();
   return (
     <FormSection legend={t('form.plugins.label')}>
-      <FormItemTextInput
-        control={control}
-        name="plugin_config_id"
-        label={t('form.plugins.configId')}
-      />
-      <Divider my="xs" label={t('or')} />
+      {showConfigId && (
+        <>
+          <FormItemTextInput
+            control={control}
+            name="plugin_config_id"
+            label={t('form.plugins.configId')}
+          />
+          <Divider my="xs" label={t('or')} />
+        </>
+      )}
       <FormItemPlugins name="plugins" />
     </FormSection>
   );

--- a/src/components/form-slice/FormPartStreamRoute/index.tsx
+++ b/src/components/form-slice/FormPartStreamRoute/index.tsx
@@ -97,7 +97,7 @@ const FormSectionStreamRouteProtocol = () => {
 export const FormPartStreamRoute = () => {
   return (
     <>
-      <FormPartBasic showName={false} />
+      <FormPartBasic />
       <FormSectionStreamRouteBasic />
       <FormSectionService />
       <FormSectionUpstream />

--- a/src/components/form-slice/FormPartStreamRoute/index.tsx
+++ b/src/components/form-slice/FormPartStreamRoute/index.tsx
@@ -101,7 +101,7 @@ export const FormPartStreamRoute = () => {
       <FormSectionStreamRouteBasic />
       <FormSectionService />
       <FormSectionUpstream />
-      <FormSectionPlugins />
+      <FormSectionPlugins showConfigId={false} />
       <FormSectionStreamRouteProtocol />
     </>
   );

--- a/src/components/form-slice/FormPartStreamRoute/util.test.ts
+++ b/src/components/form-slice/FormPartStreamRoute/util.test.ts
@@ -65,7 +65,11 @@ describe('produceStreamRoute', () => {
     expect(out.plugins).toEqual({ 'key-auth': {} });
   });
 
-  it('still deletes name/status and empty protocol', () => {
+  // #3437 review (LiteSun): the Admin API accepts a stream-route `name`
+  // (201) but rejects `status` (400). The producer must preserve name so
+  // an API-created named stream route does not lose its name on an
+  // edit-save, while still stripping the unsupported status.
+  it('keeps name, strips status, and drops empty protocol', () => {
     const val = {
       ...base,
       name: 'n1',
@@ -73,7 +77,7 @@ describe('produceStreamRoute', () => {
       protocol: { conf: {} },
     } as unknown as StreamRoutePostType;
     const out = produceStreamRoute(val) as Record<string, unknown>;
-    expect('name' in out).toBe(false);
+    expect(out.name).toBe('n1');
     expect('status' in out).toBe(false);
     expect('protocol' in out).toBe(false);
   });

--- a/src/components/form-slice/FormPartStreamRoute/util.test.ts
+++ b/src/components/form-slice/FormPartStreamRoute/util.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, expect, it } from 'vitest';
+
+import type { StreamRoutePostType } from './schema';
+import { produceStreamRoute } from './util';
+
+// Regression for a data-integrity item of #3417: stream routes were the
+// only resource whose create and edit paths ran DIFFERENT cleaning
+// pipelines — create used a bare pipe without pipeProduce (no __-key
+// removal, no empty-value cleaning, no empty-plugin restore; only the
+// zod resolver's key-stripping stood between UI flags and the Admin API,
+// which rejects unknown root keys with 400), while edit borrowed the
+// HTTP-route producer. produceStreamRoute now wraps pipeProduce and is
+// used by both paths.
+
+const base = {
+  server_port: 9100,
+  upstream: { type: 'roundrobin', nodes: { 'a.local:80': 1 } },
+} as unknown as StreamRoutePostType;
+
+describe('produceStreamRoute', () => {
+  it('strips __-prefixed UI flags', () => {
+    const val = {
+      ...base,
+      __checksEnabled: true,
+      upstream: {
+        ...base.upstream,
+        __checksPassiveEnabled: false,
+      },
+    } as unknown as StreamRoutePostType;
+    const out = produceStreamRoute(val) as Record<string, unknown>;
+    expect('__checksEnabled' in out).toBe(false);
+    expect(
+      '__checksPassiveEnabled' in (out.upstream as Record<string, unknown>)
+    ).toBe(false);
+  });
+
+  it('cleans empty-string fields', () => {
+    const val = { ...base, desc: '' } as unknown as StreamRoutePostType;
+    const out = produceStreamRoute(val) as Record<string, unknown>;
+    expect('desc' in out).toBe(false);
+  });
+
+  it('preserves plugins with empty config', () => {
+    const val = {
+      ...base,
+      plugins: { 'key-auth': {} },
+    } as unknown as StreamRoutePostType;
+    const out = produceStreamRoute(val) as Record<string, unknown>;
+    expect(out.plugins).toEqual({ 'key-auth': {} });
+  });
+
+  it('still deletes name/status and empty protocol', () => {
+    const val = {
+      ...base,
+      name: 'n1',
+      status: 1,
+      protocol: { conf: {} },
+    } as unknown as StreamRoutePostType;
+    const out = produceStreamRoute(val) as Record<string, unknown>;
+    expect('name' in out).toBe(false);
+    expect('status' in out).toBe(false);
+    expect('protocol' in out).toBe(false);
+  });
+
+  it('still drops the inline upstream when a reference id is present', () => {
+    const val = {
+      ...base,
+      upstream_id: 'u1',
+    } as unknown as StreamRoutePostType;
+    const out = produceStreamRoute(val) as Record<string, unknown>;
+    expect('upstream' in out).toBe(false);
+  });
+});

--- a/src/components/form-slice/FormPartStreamRoute/util.ts
+++ b/src/components/form-slice/FormPartStreamRoute/util.ts
@@ -15,28 +15,33 @@
  * limitations under the License.
  */
 import { produce } from 'immer';
-import { pipe } from 'rambdax';
 
 import { produceRmEmptyUpstreamFields } from '@/components/form-slice/FormPartUpstream/util';
 import { produceRmUpstreamWhenHas } from '@/utils/form-producer';
+import { pipeProduce } from '@/utils/producer';
 
 import type { StreamRoutePostType } from './schema';
 
-export const produceStreamRoute = (val: StreamRoutePostType) =>
-  pipe(
-    produceRmEmptyUpstreamFields,
-    (produceRmUpstreamWhenHas('service_id', 'upstream_id') as unknown as (
-      d: StreamRoutePostType
-    ) => StreamRoutePostType),
-    produce((draft: StreamRoutePostType) => {
-      // Stream Routes do not support name and status
-      const d = draft as StreamRoutePostType & { name?: string; status?: number };
-      delete d.name;
-      delete d.status;
+/**
+ * Shared by BOTH the create and edit paths — stream routes used to be the
+ * only resource whose two paths ran different cleaning pipelines (create
+ * skipped pipeProduce entirely; edit borrowed the HTTP-route producer).
+ * pipeProduce supplies the __-flag removal, empty-value cleaning and
+ * empty-plugin restore every other resource gets (#3417).
+ */
+export const produceStreamRoute = pipeProduce(
+  produceRmUpstreamWhenHas('service_id', 'upstream_id'),
+  produceRmEmptyUpstreamFields,
+  produce((draft: StreamRoutePostType) => {
+    // the form never renders name/status for stream routes; strip them in
+    // case values arrive via reused generic components
+    const d = draft as StreamRoutePostType & { name?: string; status?: number };
+    delete d.name;
+    delete d.status;
 
-      // Cleanup protocol if name is missing
-      if (draft.protocol && !draft.protocol.name) {
-        delete draft.protocol;
-      }
-    })
-  )(val);
+    // Cleanup protocol if name is missing
+    if (draft.protocol && !draft.protocol.name) {
+      delete draft.protocol;
+    }
+  })
+);

--- a/src/components/form-slice/FormPartStreamRoute/util.ts
+++ b/src/components/form-slice/FormPartStreamRoute/util.ts
@@ -33,10 +33,11 @@ export const produceStreamRoute = pipeProduce(
   produceRmUpstreamWhenHas('service_id', 'upstream_id'),
   produceRmEmptyUpstreamFields,
   produce((draft: StreamRoutePostType) => {
-    // the form never renders name/status for stream routes; strip them in
-    // case values arrive via reused generic components
-    const d = draft as StreamRoutePostType & { name?: string; status?: number };
-    delete d.name;
+    // The Admin API accepts a stream-route `name` (kept — the form renders
+    // it, and an API-created name must survive an edit-save, #3437 review)
+    // but rejects `status` (stripped; the form never renders it, but a
+    // reused generic component could introduce it).
+    const d = draft as StreamRoutePostType & { status?: number };
     delete d.status;
 
     // Cleanup protocol if name is missing

--- a/src/routes/stream_routes/detail.$id.tsx
+++ b/src/routes/stream_routes/detail.$id.tsx
@@ -31,8 +31,8 @@ import { useBoolean } from 'react-use';
 import { getStreamRouteQueryOptions } from '@/apis/hooks';
 import { putStreamRouteReq } from '@/apis/stream_routes';
 import { FormSubmitBtn } from '@/components/form/Btn';
-import { produceRoute } from '@/components/form-slice/FormPartRoute/util';
 import { FormPartStreamRoute } from '@/components/form-slice/FormPartStreamRoute';
+import { produceStreamRoute } from '@/components/form-slice/FormPartStreamRoute/util';
 import { produceToNestedUpstreamForm } from '@/components/form-slice/FormPartUpstream/util';
 import { FormTOCBox } from '@/components/form-slice/FormSection';
 import { FormSectionGeneral } from '@/components/form-slice/FormSectionGeneral';
@@ -79,7 +79,7 @@ const StreamRouteDetailForm = (props: Props) => {
 
   const putStreamRoute = useMutation({
     mutationFn: (d: APISIXType['StreamRoute']) =>
-      putStreamRouteReq(req, produceRoute(d)),
+      putStreamRouteReq(req, produceStreamRoute(d)),
     async onSuccess() {
       notifications.show({
         message: t('info.edit.success', { name: t('streamRoutes.singular') }),

--- a/src/types/schema/apisix/stream_routes.ts
+++ b/src/types/schema/apisix/stream_routes.ts
@@ -45,7 +45,10 @@ const StreamRoute = z
     protocol: StreamRouteProtocol.partial().optional(),
   })
   .partial()
-  .merge(APISIXCommon.Basic.omit({ name: true, status: true }))
+  // the Admin API accepts name/desc/labels on a stream route but rejects
+  // status — omit only status so the edit form (which resolves against
+  // this schema) does not strip a stored name (#3437 review)
+  .merge(APISIXCommon.Basic.omit({ status: true }))
   .merge(APISIXCommon.Info);
 
 export const APISIXStreamRoutes = {


### PR DESCRIPTION
**Why submit this pull request?**

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

Part of #3417 (Data-integrity section): "Stream routes: create path bypasses `pipeProduce` (only resource whose create/edit run different cleaning pipelines), and the reused plugins section offers a `plugin_config_id` input the resource schema doesn't have — typed values silently vanish."

**Phantom `plugin_config_id` input (the user-visible bug).** The stream-route form reuses the HTTP-route plugins section, which renders a Plugin Config ID input — but the stream_routes resource has no such field. Verified against a live gateway: the Admin API rejects `plugin_config_id` on stream_routes with 400; in practice the dashboard's zod resolver strips the typed value before the request is built, so whatever the user enters there silently vanishes on a "successful" save and never takes effect. `FormSectionPlugins` gains a `showConfigId` flag (default `true`, HTTP routes unchanged) and the stream-route form turns it off. The regression spec asserts the input is absent on the stream-route add and detail pages and still present on the HTTP-route form.

**Pipeline asymmetry (the hardening).** Stream routes were the only resource whose create and edit paths ran different cleaning pipelines:

- create used a bare `pipe` **without** `pipeProduce` — no `__`-flag removal, no empty-value cleaning, no empty-plugin restore. The only thing keeping form-internal `__` flags out of the request body was the zod resolver's unknown-key stripping — and the Admin API rejects unknown root keys with 400 (verified live), so that protection was load-bearing by accident;
- edit borrowed the **HTTP-route** producer (`produceRoute`), whose `vars` JSON.parse stage is dead code for stream routes.

`produceStreamRoute` now wraps `pipeProduce` (gaining the same explicit defenses every other resource has) and **both** paths use it. Unit tests pin the new behavior (`__` flags stripped at root and nested, empty strings cleaned) and the preserved behavior (name/status deletes, empty-protocol cleanup, inline-upstream removal when a reference id is present, empty-config plugins restored).

One more live-verified correction, disclosed for reviewers: the Admin API nowadays *accepts* `name` on stream routes, so the old "Stream Routes do not support name" comment was outdated — the deletes are kept as defense for values arriving through reused generic components, with the comment corrected.

**Tests** (red on the unfixed build at the intended assertions, green after):

- Unit `FormPartStreamRoute/util.test.ts`: 5 cases (2 red pre-fix: `__`-flag stripping, empty-string cleaning; 3 behavior-preservation guards).
- E2E regression `stream-routes.no-phantom-plugin-config-id.spec.ts`: no Plugin Config ID on stream-route add/detail (plugins section itself still present), input still offered on the HTTP-route form.

Blast radius: full local e2e suite — **175 passed**, all stream_routes suites green; the failures are documented environment items unrelated to this change (two Monaco read-back races that reproduce at the same rate on a pristine master build, one late-serial-run pagination load flake green on isolated rerun, and `stream_routes.show-disabled-error`, which cannot run outside the repo's own compose project). Unit tests 38/38, lint and build clean.

**Related issues**

Part of #3417 (please do not auto-close the tracking issue)

**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [x] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document? (no user-facing document covers the stream-route form)
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first