### PR TITLE
fix: stop deep-cleaning inside plugin configs, keep nested discovery_args

### DIFF
--- a/e2e/tests/regression/form.plugin-config-nested-empties.spec.ts
+++ b/e2e/tests/regression/form.plugin-config-nested-empties.spec.ts
@@ -1,0 +1,113 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Regression for a data-integrity item of apache/apisix-dashboard#3417:
+// the submit pipeline deep-cleans every empty value ({} / [] / "" /
+// null), and the restore stage only brought back WHOLE plugin entries —
+// meaningful empty members inside a surviving plugin config were
+// silently removed on any edit-save, and `discovery_args: {}` on an
+// INLINE upstream was dropped (the #3376 fix only covered the upstreams
+// page's root-level field). The Admin API accepts and stores all these
+// shapes (verified live); plugin configs now pass through verbatim.
+
+import { routesPom } from '@e2e/pom/routes';
+import { randomId } from '@e2e/utils/common';
+import { e2eReq } from '@e2e/utils/req';
+import { test } from '@e2e/utils/test';
+import { uiGoto } from '@e2e/utils/ui';
+import { expect } from '@playwright/test';
+
+import { deleteAllRoutes } from '@/apis/routes';
+import type { APISIXType } from '@/types/schema/apisix';
+
+test.beforeAll(async () => {
+  await deleteAllRoutes(e2eReq);
+});
+
+test.afterAll(async () => {
+  await deleteAllRoutes(e2eReq);
+});
+
+test('no-op edit-save keeps empty members inside a plugin config', async ({
+  page,
+}) => {
+  const pluginConfig = {
+    empty_obj: {},
+    empty_arr: [],
+    empty_str: '',
+    kept: 'x',
+  };
+  const name = randomId('reg-nested-empty');
+  const res = await e2eReq.put<{ value: APISIXType['Route'] }>(
+    `/routes/${name}`,
+    {
+      name,
+      uri: `/reg-nested-empty/${name}`,
+      plugins: { 'key-auth': pluginConfig },
+      upstream: { type: 'roundrobin', nodes: { 'nested-empty.local:80': 1 } },
+    }
+  );
+  const id = res.data.value.id;
+
+  await uiGoto(page, '/routes/detail/$id', { id });
+  await routesPom.isDetailPage(page);
+  await page.getByRole('button', { name: 'Edit' }).click();
+  await page.getByRole('button', { name: 'Save' }).click();
+  await expect(
+    page.getByRole('alert').filter({ hasText: /success/i })
+  ).toBeVisible();
+
+  const after = await e2eReq.get<{ value: APISIXType['Route'] }>(
+    `/routes/${id}`
+  );
+  expect(after.data.value.plugins?.['key-auth']).toEqual(pluginConfig);
+});
+
+test('no-op edit-save keeps discovery_args on an inline upstream', async ({
+  page,
+}) => {
+  const name = randomId('reg-inline-disc');
+  const res = await e2eReq.put<{ value: APISIXType['Route'] }>(
+    `/routes/${name}`,
+    {
+      name,
+      uri: `/reg-inline-disc/${name}`,
+      upstream: {
+        type: 'roundrobin',
+        discovery_type: 'dns',
+        service_name: 'svc.local',
+        discovery_args: {},
+      },
+    }
+  );
+  const id = res.data.value.id;
+
+  await uiGoto(page, '/routes/detail/$id', { id });
+  await routesPom.isDetailPage(page);
+  await page.getByRole('button', { name: 'Edit' }).click();
+  await page.getByRole('button', { name: 'Save' }).click();
+  await expect(
+    page.getByRole('alert').filter({ hasText: /success/i })
+  ).toBeVisible();
+
+  const after = await e2eReq.get<{ value: APISIXType['Route'] }>(
+    `/routes/${id}`
+  );
+  const upstream = after.data.value.upstream as Record<string, unknown>;
+  expect(upstream.discovery_type).toBe('dns');
+  expect(upstream.discovery_args).toEqual({});
+});

--- a/src/routes/upstreams/detail.$id.tsx
+++ b/src/routes/upstreams/detail.$id.tsx
@@ -91,7 +91,7 @@ const UpstreamDetailForm = (
   const putUpstream = useMutation({
     mutationFn: (d: APISIXType['Upstream']) => {
       // Merge original discovery_args into form data before processing,
-      // so pipeProduce's produceRestoreEmptyPlugins can restore discovery_args: {}
+      // so pipeProduce's produceCleanPreservingUserValues can restore discovery_args: {}
       // even if the field was not touched (and thus absent from d).
       const merged = {
         ...d,

--- a/src/utils/producer.test.ts
+++ b/src/utils/producer.test.ts
@@ -76,4 +76,81 @@ describe('pipeProduce', () => {
     // owned by the existing null-cleaner / empty-plugin-restore stages
     expect(produced?.plugins['key-auth']).toBeTruthy();
   });
+
+  // Regression for #3417 D2: plugin configs are user-authored JSON — the
+  // deep-clean silently removed meaningful empty members ({} / [] / "" /
+  // null) from configs that partially survived cleaning (the old restore
+  // only brought back WHOLE plugin entries). The gateway is the only
+  // judge of such members: loose-schema plugins accept and store them
+  // (verified live, 201), strict ones reject with a descriptive 400.
+  it('passes plugin configs through verbatim, empties included', () => {
+    const plugins = {
+      'key-auth': {
+        empty_obj: {},
+        empty_arr: [],
+        empty_str: '',
+        note: null,
+        kept: 'x',
+      },
+    };
+    const val = {
+      uri: '/r2',
+      plugins,
+      // array-form nodes: this shape (the add-page default) once tripped
+      // an immer set-trap crash when the restore stage assigned the
+      // original base reference back into the draft — keep it here
+      upstream: {
+        type: 'roundrobin',
+        nodes: [{ host: 'a.local', port: 80, weight: 1 }],
+      },
+    };
+    const produced = pipeProduce()(val);
+    expect(produced.plugins).toEqual(plugins);
+  });
+
+  it('restores discovery_args on an inline upstream', () => {
+    const val = {
+      uri: '/r3',
+      upstream: {
+        type: 'roundrobin',
+        discovery_type: 'dns',
+        service_name: 'svc.local',
+        discovery_args: {},
+      },
+    };
+    const produced = pipeProduce()(val);
+    expect(produced.upstream.discovery_args).toEqual({});
+  });
+
+  // the routes detail page composes produceRoute — itself a pipeProduce —
+  // as a stage of another pipeProduce, so inner stages receive the outer
+  // DRAFT instead of a plain value; a restore stage that closed over the
+  // pipeline input crashed exactly here (immer set trap / structuredClone
+  // on a live proxy). Keep this composition pinned.
+  it('survives nested pipeProduce composition with plugins verbatim', () => {
+    const plugins = { 'basic-auth': { hide_credentials: true, e: {} } };
+    const val = {
+      uri: '/r4',
+      plugins,
+      upstream: {
+        type: 'roundrobin',
+        nodes: [{ host: 'a.local', port: 80, weight: 1 }],
+      },
+    };
+    const inner = pipeProduce();
+    const produced = pipeProduce((v: object) => inner(v))(val);
+    expect(produced.plugins).toEqual(plugins);
+  });
+
+  it('still restores discovery_args at the root (upstreams page)', () => {
+    const val = {
+      name: 'u1',
+      type: 'roundrobin',
+      discovery_type: 'dns',
+      service_name: 'svc.local',
+      discovery_args: {},
+    };
+    const produced = pipeProduce()(val);
+    expect(produced.discovery_args).toEqual({});
+  });
 });

--- a/src/utils/producer.test.ts
+++ b/src/utils/producer.test.ts
@@ -108,6 +108,24 @@ describe('pipeProduce', () => {
     expect(produced.plugins).toEqual(plugins);
   });
 
+  // #3438 review (LiteSun): the __-key cleaner runs over the whole draft
+  // before the plugins subtree is snapshotted, so a plugin config field
+  // that legitimately starts with __ was deleted — the "verbatim" claim
+  // did not hold. Plugin JSON is gateway-owned; nothing in it is a UI flag.
+  it('passes __-prefixed plugin config fields through verbatim', () => {
+    const plugins = { 'my-plugin': { __mode: 'strict', on: true } };
+    const val = {
+      uri: '/r-uu',
+      plugins,
+      upstream: {
+        type: 'roundrobin',
+        nodes: [{ host: 'a.local', port: 80, weight: 1 }],
+      },
+    };
+    const produced = pipeProduce()(val);
+    expect(produced.plugins).toEqual(plugins);
+  });
+
   it('restores discovery_args on an inline upstream', () => {
     const val = {
       uri: '/r3',

--- a/src/utils/producer.ts
+++ b/src/utils/producer.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 import { clean, type ICleanerOptions } from 'fast-clean';
-import { produce } from 'immer';
+import { current, isDraft, produce } from 'immer';
 import { pipe } from 'rambdax';
 
 import { produceTime } from './form-producer';
@@ -35,35 +35,50 @@ export const produceDeepCleanEmptyKeys = (opts: ICleanerOptions = {}) =>
     deepCleanEmptyKeys(draft, opts);
   });
 
+/** plain deep snapshot of a value that may be an immer draft */
+const snapshot = <T>(v: T): T => (isDraft(v) ? (current(v as object) as T) : v);
+
+const isEmptyObject = (v: unknown): v is object =>
+  !!v && typeof v === 'object' && Object.keys(v).length === 0;
+
 /**
- * Preserves plugin entries with empty config ({}) after deep cleaning.
- * APISIX plugins like key-auth have no required fields and are valid with {}.
- * deepCleanEmptyKeys would strip them, so we restore them from the original.
+ * Deep-clean the draft while preserving values the cleaner must not own
+ * (#3417):
+ *
+ * - plugin configs are user-authored JSON, detached before the clean and
+ *   reattached VERBATIM: the gateway is the only judge of empty members
+ *   ({} / [] / "" / null) — loose-schema plugins accept and store them,
+ *   strict ones reject with a descriptive 400 (both verified against a
+ *   live Admin API). The old whole-entry-only restore silently removed
+ *   empties inside partially-surviving configs (#3269/#3277 siblings).
+ * - discovery_args: {} is meaningful and accepted by the gateway;
+ *   preserved at the root (upstreams page, #3376) and on an inline
+ *   upstream (routes/services — the #3376 fix missed the nested case).
+ *
+ * Everything happens inside ONE draft with plain snapshots — a restore
+ * stage that closed over the pipeline's original value crashed under
+ * nested pipeProduce composition (the routes detail page composes
+ * produceRoute, itself a pipeProduce, as a stage of another pipeProduce,
+ * so inner stages receive the outer draft, not a plain value).
  */
-export const produceRestoreEmptyPlugins = (original: object) =>
+export const produceCleanPreservingUserValues = (opts: ICleanerOptions = {}) =>
   produce((draft: Record<string, unknown>) => {
-    const orig = original as Record<string, unknown>;
-    if (orig.plugins && typeof orig.plugins === 'object') {
-      const origPlugins = orig.plugins as Record<string, unknown>;
-      const draftPlugins = (draft.plugins ?? {}) as Record<string, unknown>;
-      Object.keys(origPlugins).forEach((name) => {
-        if (!(name in draftPlugins)) {
-          draftPlugins[name] = origPlugins[name];
-        }
-      });
-      if (Object.keys(draftPlugins).length > 0) {
-        draft.plugins = draftPlugins;
-      }
+    const plugins = snapshot(draft.plugins);
+    const rootDiscoveryArgs = snapshot(draft.discovery_args);
+    const upstreamDiscoveryArgs = snapshot(
+      (draft.upstream as Record<string, unknown> | undefined)?.discovery_args
+    );
+    delete draft.plugins;
+    deepCleanEmptyKeys(draft, opts);
+    if (plugins && typeof plugins === 'object') {
+      draft.plugins = plugins;
     }
-    // Restore discovery_args: {} if it was present in the original.
-    // APISIX accepts empty discovery_args and deepCleanEmptyKeys would strip it.
-    if (
-      'discovery_args' in orig &&
-      orig.discovery_args !== null &&
-      typeof orig.discovery_args === 'object' &&
-      Object.keys(orig.discovery_args as object).length === 0
-    ) {
-      (draft as Record<string, unknown>).discovery_args = {};
+    if (isEmptyObject(rootDiscoveryArgs)) {
+      draft.discovery_args = {};
+    }
+    const upstream = draft.upstream as Record<string, unknown> | undefined;
+    if (upstream && isEmptyObject(upstreamDiscoveryArgs)) {
+      upstream.discovery_args = {};
     }
   });
 
@@ -102,8 +117,7 @@ export const pipeProduce = (...funcs: ((a: any) => unknown)[]) => {
         ...fs,
         produceRmDoubleUnderscoreKeys,
         produceTime,
-        produceDeepCleanEmptyKeys(),
-        produceRestoreEmptyPlugins(val as object)
+        produceCleanPreservingUserValues()
       )(draft) as never;
     }) as T;
 };

--- a/src/utils/producer.ts
+++ b/src/utils/producer.ts
@@ -60,6 +60,11 @@ const isEmptyObject = (v: unknown): v is object =>
  * nested pipeProduce composition (the routes detail page composes
  * produceRoute, itself a pipeProduce, as a stage of another pipeProduce,
  * so inner stages receive the outer draft, not a plain value).
+ *
+ * The `__`-prefixed UI-flag removal (form-only fields like __checksEnabled)
+ * also runs here, AFTER the plugins subtree is detached — otherwise a
+ * plugin config field that legitimately begins with `__` would be
+ * stripped, breaking the verbatim contract (#3438 review).
  */
 export const produceCleanPreservingUserValues = (opts: ICleanerOptions = {}) =>
   produce((draft: Record<string, unknown>) => {
@@ -69,6 +74,7 @@ export const produceCleanPreservingUserValues = (opts: ICleanerOptions = {}) =>
       (draft.upstream as Record<string, unknown> | undefined)?.discovery_args
     );
     delete draft.plugins;
+    rmDoubleUnderscoreKeys(draft);
     deepCleanEmptyKeys(draft, opts);
     if (plugins && typeof plugins === 'object') {
       draft.plugins = plugins;
@@ -99,10 +105,6 @@ export const rmDoubleUnderscoreKeys = (obj: object) => {
   return obj;
 };
 
-export const produceRmDoubleUnderscoreKeys = produce((draft) => {
-  rmDoubleUnderscoreKeys(draft);
-});
-
 /**
  * FIXME: type error
  */
@@ -115,8 +117,9 @@ export const pipeProduce = (...funcs: ((a: any) => unknown)[]) => {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-expect-error
         ...fs,
-        produceRmDoubleUnderscoreKeys,
         produceTime,
+        // __-flag removal happens inside this stage, after the plugins
+        // subtree is detached (see #3438 review)
         produceCleanPreservingUserValues()
       )(draft) as never;
     }) as T;


### PR DESCRIPTION
**Why submit this pull request?**

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

Part of #3417 (Data-integrity section, last remaining item): "Empty-value stripping inside surviving plugin configs: `produceRestoreEmptyPlugins` only restores whole-plugin entries; nested meaningful empties (`{"headers": {}}`, `[]`, `""`) are still silently removed. Inline route/service `upstream.discovery_args: {}` also still dropped (the #3376 merge-back fix covered the upstreams page only)."

The submit pipeline deep-cleans every empty value (`{}` / `[]` / `""` / `null`) and then restored only WHOLE plugin entries that had vanished. Consequences, both verified against a live gateway:

- empty members **inside** a partially-surviving plugin config were silently removed on any edit-save — the Admin API accepts and stores these shapes for loose-schema plugins (`{"key-auth": {"empty_obj": {}, "empty_arr": [], "empty_str": ""}}` → 201, stored verbatim);
- `discovery_args: {}` on an **inline** upstream (routes/services) was dropped — the #3376 fix only restored the root-level field on the upstreams page.

**Fix.** The clean-then-restore pair is replaced by a single stage, `produceCleanPreservingUserValues`: snapshot the `plugins` subtree, detach it, deep-clean the rest, reattach verbatim, and re-add root/inline `discovery_args: {}` when present. The principle: plugin configs are user-authored JSON and the gateway is the only judge of their empties — loose schemas accept them, strict ones reject with a descriptive 400 (`proxy-rewrite` `headers: {}` → "value should match only one schema, but matches none", verified live).

**Behavior change, disclosed:** typing an empty member that a strict plugin schema rejects now surfaces the gateway's 400 (toast via the existing error path) instead of being silently stripped into a "successful" save that stored something other than what the user wrote.

**Why a single-draft stage — two crashier designs died in testing, disclosed for reviewers:** a restore stage that closes over the pipeline's input value breaks under *nested* `pipeProduce` composition (the routes detail page composes `produceRoute` — itself a `pipeProduce` — as a stage of another `pipeProduce`), because inner stages receive the outer **live immer draft** instead of a plain value: assigning the base reference back trips immer's set trap, and `structuredClone` rejects proxies. Both variants passed unit tests with plain inputs and were caught by the full e2e suite (`routes.crud-all-fields`, `routes.empty-plugin-config` went red). The final design does everything inside one draft with `current()` snapshots and references nothing outside it; a dedicated unit test pins the nested composition.

**Tests** (red on the unfixed build at the intended assertions, green after):

- Unit `producer.test.ts` additions: plugin configs pass through verbatim (array-form nodes included), inline + root `discovery_args` restored, nested-`pipeProduce` composition survives.
- E2E regression `form.plugin-config-nested-empties.spec.ts`: a no-op edit-save keeps `{}` / `[]` / `""` members inside a plugin config, and keeps `discovery_args: {}` on an inline upstream.

Blast radius: full local e2e suite — **177 passed** (the run that caught the two intermediate designs' regressions is what forced the final shape); remaining failures are documented environment items unrelated to this change (one Monaco read-back race non-deterministic on the same build and reproducing on pristine master, one bulk-page load flake green on isolated rerun, and `stream_routes.show-disabled-error`, which cannot run outside the repo's own compose project). Unit tests 37/37, lint and build clean.

**Related issues**

Part of #3417 (please do not auto-close the tracking issue)

**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [x] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document? (no user-facing document covers the submit pipeline)
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first