### PR TITLE
fix: wire the form TOC refresh intentionally

### DIFF
--- a/e2e/tests/regression/form.toc-refresh-on-dynamic-sections.spec.ts
+++ b/e2e/tests/regression/form.toc-refresh-on-dynamic-sections.spec.ts
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Regression for a UX item of apache/apisix-dashboard#3417: the form
+// table of contents never refreshed when sections appeared or
+// disappeared dynamically — `refreshTOC` built a debounced function on
+// every call and discarded it without invoking, so Mantine's
+// TableOfContents reinitialize hook was never actually called. Enabling
+// the health-check switch rendered the new sections in the form while
+// the TOC kept showing the stale initial list.
+
+import { upstreamsPom } from '@e2e/pom/upstreams';
+import { test } from '@e2e/utils/test';
+import { expect } from '@playwright/test';
+
+test('TOC gains and loses entries as sections toggle', async ({ page }) => {
+  await upstreamsPom.toAdd(page);
+  await upstreamsPom.isAddPage(page);
+
+  const toc = page.locator('.mantine-TableOfContents-root');
+  await expect(toc).toBeVisible();
+  // the always-present Nodes section proves the TOC scanned the form
+  await expect(toc.getByText('Nodes', { exact: true })).toBeVisible();
+  await expect(toc.getByText('Active', { exact: true })).toBeHidden();
+
+  const checksTrack = page
+    .getByTestId('checksEnabled')
+    .locator('..')
+    .locator('.mantine-Switch-track');
+
+  // enabling health checks mounts the Active section in the form…
+  await checksTrack.click();
+  await expect(
+    page.getByRole('group', { name: 'Active', exact: true })
+  ).toBeVisible();
+  // …and the TOC must pick it up (debounced refresh, auto-retried here)
+  await expect(toc.getByText('Active', { exact: true })).toBeVisible();
+
+  // and drop it again when the section unmounts
+  await checksTrack.click();
+  await expect(
+    page.getByRole('group', { name: 'Active', exact: true })
+  ).toBeHidden();
+  await expect(toc.getByText('Active', { exact: true })).toBeHidden();
+});

--- a/src/components/form-slice/FormSection/index.tsx
+++ b/src/components/form-slice/FormSection/index.tsx
@@ -28,7 +28,6 @@ import {
   createContext,
   type PropsWithChildren,
   type ReactNode,
-  useCallback,
   useContext,
   useMemo,
   useRef,
@@ -88,8 +87,12 @@ export const FormSection = (props: FormSectionProps) => {
     [legend, depth]
   );
 
-  // refresh TOC when children changes
-  useShallowEffect(refreshTOC, [children]);
+  // refresh TOC when children change, and again on unmount — a section
+  // that disappears must also drop out of the TOC
+  useShallowEffect(() => {
+    refreshTOC();
+    return refreshTOC;
+  }, [children]);
 
   return (
     <SectionDepthProvider value={depth}>
@@ -146,10 +149,15 @@ export type FormTOCBoxProps = PropsWithChildren;
 export const FormTOCBox = (props: FormTOCBoxProps) => {
   const { children } = props;
   const reinitializeRef = useRef(() => {});
-  const refreshTOC = useCallback(
-    () => debounce(reinitializeRef.current, 200),
-    []
-  );
+  // one stable debounced function, invoked through the ref so it always
+  // reaches Mantine's latest reinitialize. The previous version built a
+  // debounced wrapper on every call and discarded it — the TOC only kept
+  // refreshing because React treated that discarded return value as an
+  // effect CLEANUP and invoked it on the next change (see #3417).
+  const refreshTOC = useMemo(() => {
+    const run = debounce(() => reinitializeRef.current(), 200);
+    return () => run(undefined);
+  }, []);
 
   return (
     <Group


### PR DESCRIPTION
**Why submit this pull request?**

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

**What changes will this PR take into?**

Part of #3417 (UX section): "Form TOC never refreshes when sections appear dynamically: `refreshTOC` builds a debounced function and discards it without calling (`FormSection/index.tsx:149-152`)."

**Runtime finding first, because it corrects the issue:** the user-visible claim is *refuted*. On current master, toggling the health-check switch does add Active/Healthy/Unhealthy/Passive to the TOC, and disabling removes them (verified by driving the real page and dumping the TOC before/after). The code reading in the issue is nevertheless accurate — `refreshTOC` really does build a debounced wrapper on every call and discard it. The refresh works **by accident**: the discarded function is the return value of the `useShallowEffect` callback, so React stores it as the effect **cleanup** and invokes it on the next children change or unmount — one change behind the intent, masked in practice by the burst of section mounts/unmounts a toggle causes.

That accident is a landmine: any future cleanup of the "pointless" return value silently kills the TOC refresh, and the wiring misleads every reader (including the #3417 reviewer, whose careful reading still predicted the wrong runtime behavior). This PR makes the accident a contract:

- `FormTOCBox` creates **one** stable debounced function (`useMemo`), calling through the ref so it always reaches Mantine's latest `reinitialize` (the old code would also have captured the initial no-op ref value had it ever been invoked directly);
- the `FormSection` effect now invokes `refreshTOC()` on children changes and **deliberately** returns it as the cleanup, so sections that unmount also drop out of the TOC — same observable behavior as today's accident, stated in code;
- a comment records the history so the shape is not "simplified" back into a bug.

Small honest note: rambdax's `debounce` types its result as `(input) => void`, which is not assignable to the context's `() => void` — hence the zero-arg wrapper inside the `useMemo`.

**Tests.** The new spec `form.toc-refresh-on-dynamic-sections.spec.ts` is a **characterization test, not a red/green regression**: it passes both before and after this change (the behavior already worked, accidentally). It pins both directions — enabling health checks must add the section entries to the TOC, disabling must remove them — so any refactor that breaks the refresh path fails loudly instead of silently.

Blast radius (`FormSection` is shared by every form page): full local e2e suite — **177 passed**; the 2 failures are documented environment items unrelated to this change (a bulk-page pagination load flake, green on isolated rerun, and `stream_routes.show-disabled-error`, which cannot run outside the repo's own compose project). Lint and build clean.

**Related issues**

Part of #3417 (please do not auto-close the tracking issue)

**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [x] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document? (no user-facing document covers the form TOC)
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first