### PR TITLE
fix: give each page a distinct localized document title

### DIFF
--- a/e2e/tests/regression/router.document-title.spec.ts
+++ b/e2e/tests/regression/router.document-title.spec.ts
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Regression for a UX/IA item of apache/apisix-dashboard#3417: every page
+// shipped the same static document.title. Titles are now derived per
+// route (section name + Add/Detail qualifier) from the nav route table.
+
+import { routesPom } from '@e2e/pom/routes';
+import { test } from '@e2e/utils/test';
+import { uiGoto } from '@e2e/utils/ui';
+import { expect } from '@playwright/test';
+
+test('each page has a distinct, section-specific document title', async ({
+  page,
+}) => {
+  await routesPom.toIndex(page);
+  await routesPom.isIndexPage(page);
+  await expect(page).toHaveTitle(/^Routes - /);
+
+  await uiGoto(page, '/upstreams');
+  await expect(page).toHaveTitle(/^Upstreams - /);
+
+  // longest-prefix match: /consumer_groups must not resolve as /consumers
+  await uiGoto(page, '/consumer_groups');
+  await expect(page).toHaveTitle(/^Consumer Groups - /);
+
+  await uiGoto(page, '/consumers');
+  await expect(page).toHaveTitle(/^Consumers - /);
+
+  // add and detail qualifiers
+  await routesPom.toIndex(page);
+  await routesPom.getAddRouteBtn(page).click();
+  await routesPom.isAddPage(page);
+  await expect(page).toHaveTitle(/Add .* - /);
+});

--- a/e2e/tests/regression/router.document-title.spec.ts
+++ b/e2e/tests/regression/router.document-title.spec.ts
@@ -27,6 +27,7 @@ import { uiGoto } from '@e2e/utils/ui';
 import { expect } from '@playwright/test';
 
 import { deleteAllConsumers } from '@/apis/consumers';
+import { API_SECRETS } from '@/config/constant';
 
 test('each page has a distinct, section-specific document title', async ({
   page,
@@ -70,4 +71,24 @@ test('nested resource pages get their own title, not the parent detail', async (
   await expect(page).toHaveTitle(/^Add Credentials - /);
 
   await deleteAllConsumers(e2eReq);
+});
+
+// #3441 review: /secrets/detail/$manager/$id ends with TWO params; a
+// classifier that only inspected the second-to-last segment fell through
+// to the list branch and produced the generic application title.
+test('a detail route with two trailing params still gets its title', async ({
+  page,
+}) => {
+  const id = randomId('title-secret');
+  const manager = 'vault';
+  await e2eReq.put(`${API_SECRETS}/${manager}/${id}`, {
+    uri: 'http://vault.example.com:8200',
+    prefix: 'apisix',
+    token: 'title-token',
+  });
+
+  await uiGoto(page, '/secrets/detail/$manager/$id', { manager, id });
+  await expect(page).toHaveTitle(/^Secrets Detail - /);
+
+  await e2eReq.delete(`${API_SECRETS}/${manager}/${id}`).catch(() => {});
 });

--- a/e2e/tests/regression/router.document-title.spec.ts
+++ b/e2e/tests/regression/router.document-title.spec.ts
@@ -20,9 +20,13 @@
 // route (section name + Add/Detail qualifier) from the nav route table.
 
 import { routesPom } from '@e2e/pom/routes';
+import { randomId } from '@e2e/utils/common';
+import { e2eReq } from '@e2e/utils/req';
 import { test } from '@e2e/utils/test';
 import { uiGoto } from '@e2e/utils/ui';
 import { expect } from '@playwright/test';
+
+import { deleteAllConsumers } from '@/apis/consumers';
 
 test('each page has a distinct, section-specific document title', async ({
   page,
@@ -46,4 +50,24 @@ test('each page has a distinct, section-specific document title', async ({
   await routesPom.getAddRouteBtn(page).click();
   await routesPom.isAddPage(page);
   await expect(page).toHaveTitle(/Add .* - /);
+});
+
+// #3441 review: a nested resource page must be classified by the deepest
+// matched route, not by the parent `detail/$id` in the middle of the path.
+test('nested resource pages get their own title, not the parent detail', async ({
+  page,
+}) => {
+  const username = randomId('title_c');
+  await e2eReq.put(`/consumers/${username}`, { username });
+
+  await uiGoto(page, '/consumers/detail/$username', { username });
+  await expect(page).toHaveTitle(/^Consumers Detail - /);
+
+  await uiGoto(page, '/consumers/detail/$username/credentials/add', {
+    username,
+  });
+  // must be the credential add page, NOT "Consumers Detail"
+  await expect(page).toHaveTitle(/^Add Credentials - /);
+
+  await deleteAllConsumers(e2eReq);
 });

--- a/src/hooks/useDocumentTitle.test.ts
+++ b/src/hooks/useDocumentTitle.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { classifyRouteId } from './useDocumentTitle';
+
+// Every route pattern the generated tree actually produces, so a new
+// route shape cannot silently fall back to the generic app title.
+describe('classifyRouteId', () => {
+  it('classifies top-level list / add / detail routes', () => {
+    expect(classifyRouteId('/routes/')).toEqual({
+      label: 'routes',
+      action: 'list',
+    });
+    expect(classifyRouteId('/routes/add')).toEqual({
+      label: 'routes',
+      action: 'add',
+    });
+    expect(classifyRouteId('/routes/detail/$id')).toEqual({
+      label: 'routes',
+      action: 'detail',
+    });
+    expect(classifyRouteId('/consumer_groups/detail/$id')).toEqual({
+      label: 'consumerGroups',
+      action: 'detail',
+    });
+    expect(classifyRouteId('/stream_routes/add')).toEqual({
+      label: 'streamRoutes',
+      action: 'add',
+    });
+  });
+
+  // #3441 review: /secrets/detail/$manager/$id ends with TWO params, so a
+  // check that only looked at the second-to-last segment fell through to
+  // the list branch, picked $manager as the resource and returned null —
+  // the page got the generic application title.
+  it('classifies a detail route with multiple trailing params', () => {
+    expect(classifyRouteId('/secrets/detail/$manager/$id')).toEqual({
+      label: 'secrets',
+      action: 'detail',
+    });
+  });
+
+  it('classifies nested resources by their own leaf, not the parent', () => {
+    expect(classifyRouteId('/services/detail/$id/routes/')).toEqual({
+      label: 'routes',
+      action: 'list',
+    });
+    expect(classifyRouteId('/services/detail/$id/routes/add')).toEqual({
+      label: 'routes',
+      action: 'add',
+    });
+    expect(
+      classifyRouteId('/services/detail/$id/routes/detail/$routeId')
+    ).toEqual({ label: 'routes', action: 'detail' });
+    expect(
+      classifyRouteId('/services/detail/$id/stream_routes/detail/$routeId')
+    ).toEqual({ label: 'streamRoutes', action: 'detail' });
+    expect(classifyRouteId('/consumers/detail/$username/credentials/add')).toEqual(
+      { label: 'credentials', action: 'add' }
+    );
+    expect(
+      classifyRouteId('/consumers/detail/$username/credentials/detail/$id')
+    ).toEqual({ label: 'credentials', action: 'detail' });
+  });
+
+  it('still classifies the parent detail page itself', () => {
+    expect(classifyRouteId('/services/detail/$id/')).toEqual({
+      label: 'services',
+      action: 'detail',
+    });
+    expect(classifyRouteId('/consumers/detail/$username/')).toEqual({
+      label: 'consumers',
+      action: 'detail',
+    });
+  });
+
+  it('returns null for routes outside the resource sections', () => {
+    expect(classifyRouteId('/')).toBeNull();
+    expect(classifyRouteId('/__root__')).toBeNull();
+  });
+});

--- a/src/hooks/useDocumentTitle.ts
+++ b/src/hooks/useDocumentTitle.ts
@@ -18,41 +18,81 @@ import { useRouterState } from '@tanstack/react-router';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import type { Resources } from '@/config/i18n';
 import { navRoutes } from '@/config/navRoutes';
 
 // matches the static <title> in index.html (the default before any route
 // resolves and the suffix on every page)
 const APP_NAME = 'Apache APISIX Dashboard';
 
-// Longest `to` first so '/consumer_groups' wins over '/consumers'.
-const sectionsByPathLength = [...navRoutes].sort(
-  (a, b) => b.to.length - a.to.length
-);
+type SourceLabel = keyof Resources['en']['common']['sources'];
+
+// path segment -> sources i18n label. Built from the nav table (the single
+// source of truth), plus `credentials`, which is only ever a nested
+// resource (never a top-level nav entry).
+const segmentToLabel: Record<string, SourceLabel> = {
+  ...Object.fromEntries(
+    navRoutes.map((r) => [r.to.replace(/^\//, ''), r.label])
+  ),
+  credentials: 'credentials',
+};
+
+const isParam = (seg: string) => seg.startsWith('$');
+
+/**
+ * Classify the DEEPEST matched route by its pattern (e.g.
+ * `/services/detail/$id/routes/add`). The action is read from the TAIL of
+ * the pattern so a `detail/$id` in the middle (navigation context) does
+ * not misclassify a nested add/detail page as the parent's detail (#3441
+ * review): a nested `…/routes/add` is "Add Route", not "Service Detail".
+ */
+const classify = (
+  routeId: string
+): { label: SourceLabel; action: 'add' | 'detail' | 'list' } | null => {
+  const segs = routeId.split('/').filter(Boolean);
+  if (segs.length === 0) return null;
+
+  const last = segs[segs.length - 1];
+  let action: 'add' | 'detail' | 'list';
+  let resourceIdx: number;
+
+  if (last === 'add') {
+    action = 'add';
+    resourceIdx = segs.length - 2;
+  } else if (isParam(last) && segs[segs.length - 2] === 'detail') {
+    action = 'detail';
+    resourceIdx = segs.length - 3;
+  } else {
+    // list page: the leaf segment is the resource (skip a trailing param)
+    action = 'list';
+    resourceIdx = isParam(last) ? segs.length - 2 : segs.length - 1;
+  }
+
+  const resource = segs[resourceIdx];
+  const label = resource && segmentToLabel[resource];
+  return label ? { label, action } : null;
+};
 
 /**
  * Give every page a distinct, localized document.title instead of the one
  * static title the app shipped with (#3417). Derived centrally from the
- * current path + the nav route table (single source of truth), reactive
- * to both navigation and language change — no per-route boilerplate.
+ * deepest matched route + the nav route table, reactive to both
+ * navigation and language change — no per-route boilerplate.
  */
 export const useDocumentTitle = () => {
   const { t, i18n } = useTranslation();
-  const pathname = useRouterState({
-    select: (s) => s.location.pathname,
+  const routeId = useRouterState({
+    select: (s) => s.matches[s.matches.length - 1]?.routeId as string,
   });
 
   useEffect(() => {
-    const section = sectionsByPathLength.find(
-      (r) => pathname === r.to || pathname.startsWith(`${r.to}/`)
-    );
-
+    const matched = routeId ? classify(routeId) : null;
     let title = APP_NAME;
-    if (section) {
-      const name = t(`sources.${section.label}`);
-      const rest = pathname.slice(section.to.length);
-      if (rest.startsWith('/add')) {
+    if (matched) {
+      const name = t(`sources.${matched.label}`);
+      if (matched.action === 'add') {
         title = `${t('info.add.title', { name })} - ${APP_NAME}`;
-      } else if (rest.startsWith('/detail')) {
+      } else if (matched.action === 'detail') {
         title = `${t('info.detail.title', { name })} - ${APP_NAME}`;
       } else {
         title = `${name} - ${APP_NAME}`;
@@ -60,5 +100,5 @@ export const useDocumentTitle = () => {
     }
     document.title = title;
     // i18n.language in deps so the title re-localizes on a language switch
-  }, [pathname, t, i18n.language]);
+  }, [routeId, t, i18n.language]);
 };

--- a/src/hooks/useDocumentTitle.ts
+++ b/src/hooks/useDocumentTitle.ts
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useRouterState } from '@tanstack/react-router';
+import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { navRoutes } from '@/config/navRoutes';
+
+// matches the static <title> in index.html (the default before any route
+// resolves and the suffix on every page)
+const APP_NAME = 'Apache APISIX Dashboard';
+
+// Longest `to` first so '/consumer_groups' wins over '/consumers'.
+const sectionsByPathLength = [...navRoutes].sort(
+  (a, b) => b.to.length - a.to.length
+);
+
+/**
+ * Give every page a distinct, localized document.title instead of the one
+ * static title the app shipped with (#3417). Derived centrally from the
+ * current path + the nav route table (single source of truth), reactive
+ * to both navigation and language change — no per-route boilerplate.
+ */
+export const useDocumentTitle = () => {
+  const { t, i18n } = useTranslation();
+  const pathname = useRouterState({
+    select: (s) => s.location.pathname,
+  });
+
+  useEffect(() => {
+    const section = sectionsByPathLength.find(
+      (r) => pathname === r.to || pathname.startsWith(`${r.to}/`)
+    );
+
+    let title = APP_NAME;
+    if (section) {
+      const name = t(`sources.${section.label}`);
+      const rest = pathname.slice(section.to.length);
+      if (rest.startsWith('/add')) {
+        title = `${t('info.add.title', { name })} - ${APP_NAME}`;
+      } else if (rest.startsWith('/detail')) {
+        title = `${t('info.detail.title', { name })} - ${APP_NAME}`;
+      } else {
+        title = `${name} - ${APP_NAME}`;
+      }
+    }
+    document.title = title;
+    // i18n.language in deps so the title re-localizes on a language switch
+  }, [pathname, t, i18n.language]);
+};

--- a/src/hooks/useDocumentTitle.ts
+++ b/src/hooks/useDocumentTitle.ts
@@ -39,37 +39,34 @@ const segmentToLabel: Record<string, SourceLabel> = {
 
 const isParam = (seg: string) => seg.startsWith('$');
 
+export type RouteTitleParts = {
+  label: SourceLabel;
+  action: 'add' | 'detail' | 'list';
+};
+
 /**
  * Classify the DEEPEST matched route by its pattern (e.g.
- * `/services/detail/$id/routes/add`). The action is read from the TAIL of
- * the pattern so a `detail/$id` in the middle (navigation context) does
- * not misclassify a nested add/detail page as the parent's detail (#3441
- * review): a nested `…/routes/add` is "Add Route", not "Service Detail".
+ * `/services/detail/$id/routes/add`).
+ *
+ * All TRAILING params are stripped first, so routes with more than one
+ * (`/secrets/detail/$manager/$id`) are recognised as detail pages too
+ * (#3441 review). The action then comes from the tail of what remains, so
+ * a `detail/$id` in the MIDDLE (navigation context) never wins: a nested
+ * `…/routes/add` is "Add Route", not "Service Detail".
  */
-const classify = (
-  routeId: string
-): { label: SourceLabel; action: 'add' | 'detail' | 'list' } | null => {
+export const classifyRouteId = (routeId: string): RouteTitleParts | null => {
   const segs = routeId.split('/').filter(Boolean);
+  while (segs.length > 0 && isParam(segs[segs.length - 1])) segs.pop();
   if (segs.length === 0) return null;
 
   const last = segs[segs.length - 1];
-  let action: 'add' | 'detail' | 'list';
-  let resourceIdx: number;
+  const action: RouteTitleParts['action'] =
+    last === 'add' ? 'add' : last === 'detail' ? 'detail' : 'list';
+  // for add/detail the resource is the segment before the action keyword;
+  // for a list page the leaf segment IS the resource
+  const resource = action === 'list' ? last : segs[segs.length - 2];
 
-  if (last === 'add') {
-    action = 'add';
-    resourceIdx = segs.length - 2;
-  } else if (isParam(last) && segs[segs.length - 2] === 'detail') {
-    action = 'detail';
-    resourceIdx = segs.length - 3;
-  } else {
-    // list page: the leaf segment is the resource (skip a trailing param)
-    action = 'list';
-    resourceIdx = isParam(last) ? segs.length - 2 : segs.length - 1;
-  }
-
-  const resource = segs[resourceIdx];
-  const label = resource && segmentToLabel[resource];
+  const label = resource ? segmentToLabel[resource] : undefined;
   return label ? { label, action } : null;
 };
 
@@ -86,7 +83,7 @@ export const useDocumentTitle = () => {
   });
 
   useEffect(() => {
-    const matched = routeId ? classify(routeId) : null;
+    const matched = routeId ? classifyRouteId(routeId) : null;
     let title = APP_NAME;
     if (matched) {
       const name = t(`sources.${matched.label}`);

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -37,11 +37,13 @@ import {
   APPSHELL_NAVBAR_WIDTH,
 } from '@/config/constant';
 import i18n from '@/config/i18n';
+import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 
-const Root = () => {
+const RootShell = () => {
   const [opened, { toggle }] = useDisclosure(false);
+  useDocumentTitle();
   return (
-    <I18nextProvider i18n={i18n}>
+    <>
       <HeadContent />
       <AppShell
         header={{ height: APPSHELL_HEADER_HEIGHT }}
@@ -67,6 +69,14 @@ const Root = () => {
         </>
       )}
       <SettingsModal />
+    </>
+  );
+};
+
+const Root = () => {
+  return (
+    <I18nextProvider i18n={i18n}>
+      <RootShell />
     </I18nextProvider>
   );
 };


### PR DESCRIPTION
**Why submit this pull request?**

- [x] Bugfix

**What changes will this PR take into?**

Part of #3417 (UX/IA section): "one static `document.title` for every page (router `HeadContent` is already mounted — one `head` option per route away)."

Every page shipped the same static `<title>` (Apache APISIX Dashboard), so tabs, history and bookmarks were indistinguishable. Titles are now derived centrally by a `useDocumentTitle` hook from the current path and the nav route table (the single source of truth already used by the sidebar): section name, plus an Add/Detail qualifier, plus the app name — e.g. `Routes - Apache APISIX Dashboard`, `Add Route - …`, `Route Detail - …`.

**Why central derivation rather than a `head` option on each of the 35 route files:** no per-route boilerplate, and it stays reactive to both navigation and language change — the title re-localizes on a language switch, which per-route `head` evaluation would not. Longest-prefix matching so `/consumer_groups` is not mis-resolved as `/consumers`. `Root` is split into `Root` (provides the i18n context) and `RootShell` (runs the hook inside it).

**Tests.** e2e `router.document-title.spec.ts` asserts distinct section titles, the longest-prefix disambiguation, and the Add qualifier.

Blast radius: full local e2e suite — 178 passed; the only failure is `stream_routes.show-disabled-error`, a documented environment item that cannot run outside the repo's own compose project. Unit tests, lint and build clean.

**Related issues**

Part of #3417 (please do not auto-close the tracking issue)

**Checklist:**

- [x] Did you explain what problem does this PR solve?
- [x] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document? (no user-facing document covers page titles)
- [x] Is this PR backward compatible?
