### PR TITLE
fix: accessible names for header icon buttons, Monaco contrast, drawer Escape

### DIFF
--- a/e2e/tests/regression/a11y.icon-buttons-and-escape.spec.ts
+++ b/e2e/tests/regression/a11y.icon-buttons-and-escape.spec.ts
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Regression for a11y items of apache/apisix-dashboard#3417: the header's
+// icon-only buttons (settings, language) had no accessible name, and the
+// Select Plugins drawer disabled Escape-to-close despite having no unsaved
+// state to protect.
+
+import { routesPom } from '@e2e/pom/routes';
+import { test } from '@e2e/utils/test';
+import { expect } from '@playwright/test';
+
+test('header icon buttons expose accessible names', async ({ page }) => {
+  await routesPom.toIndex(page);
+  await routesPom.isIndexPage(page);
+
+  await expect(
+    page.getByRole('button', { name: 'Open settings' })
+  ).toBeVisible();
+  await expect(
+    page.getByRole('button', { name: 'Select language' })
+  ).toBeVisible();
+});
+
+test('the Select Plugins drawer closes on Escape', async ({ page }) => {
+  await routesPom.toIndex(page);
+  await routesPom.isIndexPage(page);
+  await routesPom.getAddRouteBtn(page).click();
+  await routesPom.isAddPage(page);
+
+  await page.getByRole('button', { name: 'Select Plugins' }).click();
+  const drawer = page.getByRole('dialog', { name: 'Select Plugins' });
+  await expect(drawer).toBeVisible();
+
+  await page.keyboard.press('Escape');
+  await expect(drawer).toBeHidden();
+});

--- a/src/components/Header/LanguageMenu.tsx
+++ b/src/components/Header/LanguageMenu.tsx
@@ -50,7 +50,11 @@ export const LanguageMenu = () => {
   return (
     <Menu shadow="md" width={200}>
       <Menu.Target>
-        <ActionIcon variant="light" size="sm">
+        <ActionIcon
+          variant="light"
+          size="sm"
+          aria-label={t('a11y.selectLanguage')}
+        >
           <IconLanguage />
         </ActionIcon>
       </Menu.Target>

--- a/src/components/Header/SettingModalBtn.tsx
+++ b/src/components/Header/SettingModalBtn.tsx
@@ -16,18 +16,21 @@
  */
 import { ActionIcon } from '@mantine/core';
 import { useSetAtom } from 'jotai';
+import { useTranslation } from 'react-i18next';
 
 import { isSettingsOpenAtom } from '@/stores/global';
 import IconSettings from '~icons/material-symbols/settings';
 
 export const SettingModalBtn = () => {
   const setIsSettingsOpen = useSetAtom(isSettingsOpenAtom);
+  const { t } = useTranslation();
 
   return (
     <ActionIcon
       onClick={() => setIsSettingsOpen(true)}
       variant="light"
       size="sm"
+      aria-label={t('a11y.openSettings')}
     >
       <IconSettings />
     </ActionIcon>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -41,7 +41,13 @@ export const Header: FC<HeaderProps> = (props) => {
     <AppShell.Header>
       <Group h="100%" px="md" justify="space-between">
         <Group h="100%" gap="sm">
-          <Burger opened={opened} onClick={toggle} hiddenFrom="sm" size="sm" />
+          <Burger
+            opened={opened}
+            onClick={toggle}
+            hiddenFrom="sm"
+            size="sm"
+            aria-label={t('a11y.toggleNavigation')}
+          />
           <Logo />
           <div>{t('apisix.dashboard')}</div>
         </Group>

--- a/src/components/form-slice/FormItemPlugins/SelectPluginsDrawer.tsx
+++ b/src/components/form-slice/FormItemPlugins/SelectPluginsDrawer.tsx
@@ -47,7 +47,8 @@ export const SelectPluginsDrawer = (props: SelectPluginsDrawerProps) => {
         radius="md"
         position="right"
         size="xl"
-        closeOnEscape={false}
+        // this drawer only picks a plugin to add — no unsaved edits to
+        // protect, so Escape should close it like any other dialog (#3417)
         opened={opened}
         onClose={() => setOpened(false)}
         title={t('form.plugins.selectPlugins.title')}

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -374,5 +374,10 @@
   "error": {
     "title": "Something went wrong",
     "retry": "Retry"
+  },
+  "a11y": {
+    "openSettings": "Open settings",
+    "selectLanguage": "Select language",
+    "toggleNavigation": "Toggle navigation"
   }
 }

--- a/src/locales/zh/common.json
+++ b/src/locales/zh/common.json
@@ -374,5 +374,10 @@
   "error": {
     "title": "出错了",
     "retry": "重试"
+  },
+  "a11y": {
+    "openSettings": "打开设置",
+    "selectLanguage": "选择语言",
+    "toggleNavigation": "切换导航"
   }
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -52,8 +52,10 @@
     pointer-events: auto !important;
   }
 
+  /* gray-7 on the gray-0 background clears WCAG AA (~7:1); gray-5 was
+     ~2:1 and unreadable on the primary read path (#3417) */
   .monaco-editor .view-lines,
   .monaco-editor .view-line * {
-    color: var(--mantine-color-gray-5) !important;
+    color: var(--mantine-color-gray-7) !important;
   }
 }


### PR DESCRIPTION
**Why submit this pull request?**

- [x] Bugfix

**What changes will this PR take into?**

Part of #3417 (a11y section). Accessibility quick wins — the app had exactly one `aria-label` in all of `src/`:

- the header's icon-only buttons — settings, language, and the mobile navigation burger — had no accessible name; screen readers announced them as a bare "button". Each gets an `aria-label` from new `a11y.*` i18n keys.
- view-mode Monaco text was gray-5 on the gray-0 editor background, about 2:1 — unreadable on a primary read path. Bumped to gray-7 (~7:1, clears WCAG AA).
- the Select Plugins drawer set `closeOnEscape={false}` despite holding no unsaved state; Escape now closes it like any other dialog.

**Scope, disclosed honestly:** the plugin-card action buttons the issue also lists carry visible text (Add/View/Edit/Delete), so they already have an accessible name — adding an `aria-label` would double-label them. The deeper combobox/`role` semantics rework and the e2e a11y assertion suite the issue mentions are a separate, larger change left for follow-up.

**Tests.** e2e `a11y.icon-buttons-and-escape.spec.ts` covers the accessible names and the drawer's Escape-to-close.

Blast radius: full local e2e suite — 179 passed; the only failure is `stream_routes.show-disabled-error`, a documented environment item that cannot run outside the repo's own compose project. Unit tests, lint and build clean.

**Related issues**

Part of #3417 (please do not auto-close the tracking issue)

**Checklist:**

- [x] Did you explain what problem does this PR solve?
- [x] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document? (no user-facing document covers these controls)
- [x] Is this PR backward compatible?
