### PR TITLE
ci: run unit tests in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,3 +45,6 @@ jobs:
 
       - name: Run Type Check
         run: pnpm exec tsc -b
+
+      - name: Run unit tests
+        run: pnpm test


### PR DESCRIPTION
Please answer these questions before submitting a pull request, **or your PR will get closed**.

**Why submit this pull request?**

- [x] Bugfix

**What changes will this PR take into?**

This addresses the "the repo's only unit test never runs in CI" item of the frontend review in #3417.

A `test` script (`vitest run src`) already exists in `package.json`, and the suite has grown from the single `upstreams.test.ts` the review noted to several files (`producer`, `zod`, `upstreams`, `labels-conversion`, `nodes-conversion`) guarding real fixes. But no workflow ever invoked it, so all of that coverage was unenforced — a change could break a unit test and still merge green.

This adds one step to the existing `lint` workflow (which already sets up pnpm/Node and installs dependencies) to run `pnpm test` after the type check. Placing it in the existing job reuses the setup rather than duplicating it in a new workflow.

**Related issues**

Part of #3417

**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [x] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first

This is a CI-configuration change only; no application code is touched, so there is nothing for the e2e suite to exercise. Verified locally that `pnpm test` passes (`vitest run src` — 5 files, 38 tests) and that the modified `lint.yml` is valid YAML.
