### PR TITLE
refactor: stop the apis layer importing types from components

### DIFF
--- a/src/apis/plugins.ts
+++ b/src/apis/plugins.ts
@@ -17,7 +17,6 @@
 import { queryOptions, skipToken } from '@tanstack/react-query';
 import type { AxiosRequestConfig } from 'axios';
 
-import type { PluginConfig } from '@/components/form-slice/FormItemPlugins/PluginEditorDrawer';
 import {
   API_PLUGIN_METADATA,
   API_PLUGINS,
@@ -25,6 +24,9 @@ import {
 } from '@/config/constant';
 import { req } from '@/config/req';
 import type { APISIXType } from '@/types/schema/apisix';
+
+/** A plugin's name paired with its config object (the plugin-editor shape). */
+export type PluginConfig = { name: string; config: object };
 
 
 export type NeedPluginSchema = {

--- a/src/apis/ssls.ts
+++ b/src/apis/ssls.ts
@@ -16,9 +16,9 @@
  */
 import type { AxiosInstance } from 'axios';
 
-import type { SSLPostType } from '@/components/form-slice/FormPartSSL/schema';
 import { API_SSLS } from '@/config/constant';
 import type { APISIXType } from '@/types/schema/apisix';
+import type { SSLPostBody } from '@/types/schema/apisix/ssls';
 import type { PageSearchType } from '@/types/schema/pageSearch';
 
 export const getSSLListReq = (req: AxiosInstance, params: PageSearchType) =>
@@ -41,7 +41,7 @@ export const putSSLReq = (req: AxiosInstance, data: APISIXType['SSL']) => {
   );
 };
 
-export const postSSLReq = (req: AxiosInstance, data: SSLPostType) =>
+export const postSSLReq = (req: AxiosInstance, data: SSLPostBody) =>
   req.post<APISIXType['SSL'], APISIXType['RespSSLDetail']>(API_SSLS, data);
 
 export const deleteAllSSLs = async (req: AxiosInstance) => {

--- a/src/apis/stream_routes.ts
+++ b/src/apis/stream_routes.ts
@@ -17,13 +17,13 @@
 
 import type { AxiosInstance } from 'axios';
 
-import type { StreamRoutePostType } from '@/components/form-slice/FormPartStreamRoute/schema';
 import {
   API_STREAM_ROUTES,
   PAGE_SIZE_MAX,
   PAGE_SIZE_MIN,
 } from '@/config/constant';
 import type { APISIXType } from '@/types/schema/apisix';
+import type { StreamRoutePostType } from '@/types/schema/apisix/stream_routes';
 
 import type { WithServiceIdFilter } from './routes';
 

--- a/src/components/form-slice/FormItemPlugins/PluginEditorDrawer.tsx
+++ b/src/components/form-slice/FormItemPlugins/PluginEditorDrawer.tsx
@@ -22,12 +22,15 @@ import { useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
+import type { PluginConfig } from '@/apis/plugins';
 import { FormSubmitBtn } from '@/components/form/Btn';
 import { FormItemEditor } from '@/components/form/Editor';
 
 import type { PluginCardListProps } from './PluginCardList';
 
-export type PluginConfig = { name: string; config: object };
+// PluginConfig is defined in the API layer (apis/plugins) and re-exported
+// here so existing importers keep their path.
+export type { PluginConfig };
 export type PluginEditorDrawerProps = Pick<PluginCardListProps, 'mode'> & {
   opened: boolean;
   onClose: () => void;

--- a/src/components/form-slice/FormPartStreamRoute/schema.ts
+++ b/src/components/form-slice/FormPartStreamRoute/schema.ts
@@ -14,15 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { TypeOf } from 'zod';
-
-import { APISIXCommon } from '@/types/schema/apisix/common';
-import { APISIXStreamRoutes } from '@/types/schema/apisix/stream_routes';
-
-export const StreamRoutePostSchema = APISIXStreamRoutes.StreamRoute.omit({
-  create_time: true,
-  update_time: true,
-  id: true,
-}).merge(APISIXCommon.Basic);
-
-export type StreamRoutePostType = TypeOf<typeof StreamRoutePostSchema>;
+// The stream-route create-form schema lives in the schema layer so the API
+// layer can type its request body without importing from components/.
+export {
+  StreamRoutePostSchema,
+  type StreamRoutePostType,
+} from '@/types/schema/apisix/stream_routes';

--- a/src/routes/upstreams/detail.$id.tsx
+++ b/src/routes/upstreams/detail.$id.tsx
@@ -17,11 +17,7 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Button, Group, Skeleton } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
-import {
-  queryOptions,
-  useMutation,
-  useSuspenseQuery,
-} from '@tanstack/react-query';
+import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import {
   createFileRoute,
   useNavigate,
@@ -33,7 +29,8 @@ import { useTranslation } from 'react-i18next';
 import { useBoolean } from 'react-use';
 import type { z } from 'zod';
 
-import { getUpstreamReq, putUpstreamReq } from '@/apis/upstreams';
+import { getUpstreamQueryOptions } from '@/apis/hooks';
+import { putUpstreamReq } from '@/apis/upstreams';
 import { FormSubmitBtn } from '@/components/form/Btn';
 import { FormPartUpstream } from '@/components/form-slice/FormPartUpstream';
 import {
@@ -58,12 +55,6 @@ type Props = {
   readOnly: boolean;
   setReadOnly: (v: boolean) => void;
 };
-
-const getUpstreamQueryOptions = (id: string) =>
-  queryOptions({
-    queryKey: ['upstream', id],
-    queryFn: () => getUpstreamReq(req, id),
-  });
 
 const UpstreamDetailForm = (
   props: Props & Pick<APISIXType['Upstream'], 'id'>

--- a/src/types/schema/apisix/ssls.ts
+++ b/src/types/schema/apisix/ssls.ts
@@ -49,6 +49,18 @@ const SSL = z
   .merge(APISIXCommon.Basic)
   .merge(APISIXCommon.Info);
 
+// The request body of an SSL create: the stored resource minus the
+// server-managed id/timestamps. The form's own post type (which also carries
+// the UI-only `__clientEnabled` helper) is assignable to this, so the API
+// layer can type its payload without importing from components/.
+export const SSLPostBodySchema = SSL.omit({
+  id: true,
+  create_time: true,
+  update_time: true,
+});
+
+export type SSLPostBody = z.infer<typeof SSLPostBodySchema>;
+
 export const APISIXSSLs = {
   SSL,
   SSLStatus: APISIXCommon.Status,

--- a/src/types/schema/apisix/stream_routes.ts
+++ b/src/types/schema/apisix/stream_routes.ts
@@ -48,6 +48,16 @@ const StreamRoute = z
   .merge(APISIXCommon.Basic.omit({ name: true, status: true }))
   .merge(APISIXCommon.Info);
 
+// The shape the create form submits: the stored resource minus the
+// server-managed id/timestamps, plus the editable Basic fields.
+export const StreamRoutePostSchema = StreamRoute.omit({
+  create_time: true,
+  update_time: true,
+  id: true,
+}).merge(APISIXCommon.Basic);
+
+export type StreamRoutePostType = z.infer<typeof StreamRoutePostSchema>;
+
 export const APISIXStreamRoutes = {
   StreamRoute,
 };


### PR DESCRIPTION
Please answer these questions before submitting a pull request, **or your PR will get closed**.

**Why submit this pull request?**

- [x] Bugfix

**What changes will this PR take into?**

This addresses the "`apis/` imports types from `components/` (inverted layering); one detail page re-declares an exported query-options helper" item of the frontend review in #3417.

The data-access layer (`apis/`) should not depend on the UI layer (`components/`). Three `apis/` modules imported a type from `components/form-slice/…`:

- `apis/ssls.ts` imported `SSLPostType` from `FormPartSSL/schema`.
- `apis/stream_routes.ts` imported `StreamRoutePostType` from `FormPartStreamRoute/schema`.
- `apis/plugins.ts` imported `PluginConfig` from `FormItemPlugins/PluginEditorDrawer`.

Each is fixed by putting the type where the layer boundary allows the API module to reach it, with no behaviour change:

- **`SSLPostBody`** — a new request-body type (`SSL.omit({ id, create_time, update_time })`) added to `types/schema/apisix/ssls.ts`. `apis/ssls.ts` now types `postSSLReq`'s payload with it. The form keeps its own `SSLPostType` (which additionally carries the UI-only `__clientEnabled` helper the SSL client-cert switch binds to); that form type is assignable to `SSLPostBody`, so the caller is unaffected. This keeps the UI flag out of the API-schema layer rather than relocating it there.
- **`StreamRoutePostSchema` / `StreamRoutePostType`** — moved into `types/schema/apisix/stream_routes.ts` (they are purely API-derived, no form-only fields) and re-exported from `FormPartStreamRoute/schema.ts`, so component importers are unchanged. `apis/stream_routes.ts` imports from the schema layer.
- **`PluginConfig`** (`{ name: string; config: object }`) — moved to `apis/plugins.ts` (it is the shape `putPluginMetadataReq` consumes) and re-exported from `PluginEditorDrawer.tsx`, so its component importers are unchanged and the dependency now points component → api.

Separately, `routes/upstreams/detail.$id.tsx` re-declared a local `getUpstreamQueryOptions` identical to the one already exported from `apis/hooks.ts`; it now imports the shared helper (same query key `['upstream', id]`), and the now-unused `queryOptions` / `getUpstreamReq` imports are dropped.

**Related issues**

Part of #3417

**Checklist:**

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [x] Have you modified the corresponding document?
- [x] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first

These are type-relocation and de-duplication changes with no runtime behaviour change (the one runtime touch — the upstream detail page using the shared query-options helper — keeps the identical query key), so no new tests were added. Verified with `tsc`, ESLint, the unit suite, and the full e2e suite.
